### PR TITLE
WIP: enable grpc stats when enabling Bigtable stats

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -40,12 +40,11 @@
       <artifactId>opencensus-api</artifactId>
     </dependency>
 
-    <!-- // TODO(igorbernstein): Enable grpc views once we upgrade to grpc-java 1.24.0 -->
-<!--    <dependency>-->
-<!--      <groupId>io.opencensus</groupId>-->
-<!--      <artifactId>opencensus-contrib-grpc-metrics</artifactId>-->
-<!--      <version>${opencensus.version}</version>-->
-<!--    </dependency>-->
+    <dependency>
+      <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-contrib-grpc-metrics</artifactId>
+      <version>${opencensus.version}</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
@@ -162,9 +162,7 @@ public final class BigtableDataSettings {
   @BetaApi("OpenCensus stats integration is currently unstable and may change in the future")
   public static void enableOpenCensusStats() {
     com.google.cloud.bigtable.data.v2.stub.metrics.RpcViews.registerBigtableClientViews();
-    // TODO(igorbernstein): Enable grpc views once we upgrade to grpc-java 1.24.0
-    // Required change: https://github.com/grpc/grpc-java/pull/5996
-    // io.opencensus.contrib.grpc.metrics.RpcViews.registerClientGrpcBasicViews();
+    io.opencensus.contrib.grpc.metrics.RpcViews.registerClientGrpcBasicViews();
   }
 
   /** Returns the target project id. */


### PR DESCRIPTION
To get a full picture of metrics for the bigtable client, the customer would need to look at both operation metrics and grpc rpc metrics. This was previously disabled because grpc metrics had a bug that prevented the method and status tags from being populated. This was fixed in https://github.com/grpc/grpc-java/pull/5996 which was released in version 1.24