### PR TITLE
Fixup root pom.xml

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -23,7 +23,7 @@
 
     <!-- Production dependencies -->
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core-grpc</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-bigtable-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.5.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
     <name>Google Cloud Bigtable Parent</name>
     <url>https://github.com/googleapis/java-bigtable</url>
     <description>
@@ -151,23 +151,57 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
         <site.installationModule>google-cloud-bigtable-parent</site.installationModule>
-        <google.core.version>1.91.2</google.core.version>
+        <project.javadoc.protobufBaseURL>https://googleapis.dev/java/google-api-grpc/latest</project.javadoc.protobufBaseURL>
+
+        <auto-value.version>1.6.6</auto-value.version>
+        <gax.version>1.49.0</gax.version>
         <google.api-common.version>1.8.1</google.api-common.version>
         <google.common-protos.version>1.16.0</google.common-protos.version>
-        <gax.version>1.49.0</gax.version>
+        <google.core.version>1.91.2</google.core.version>
         <grpc.version>1.23.0</grpc.version>
+        <opencensus.version>0.24.0</opencensus.version>
         <protobuf.version>3.10.0</protobuf.version>
-        <junit.version>4.12</junit.version>
         <threeten.version>1.3.3</threeten.version>
-        <javax.annotations.version>1.3.2</javax.annotations.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- BOMs, in alphabetical order -->
+            <dependency>
+                <groupId>com.google.api</groupId>
+                <artifactId>gax-bom</artifactId>
+                <version>${gax.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava-bom</artifactId>
+                <version>28.1-android</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- Child Modules, in alphabetical order -->
+            <dependency>
+                <!-- TODO: Make this a child module -->
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-bigtable-emulator</artifactId>
+                <version>0.111.0-alpha</version>
+            </dependency>
             <dependency>
                 <groupId>com.google.api.grpc</groupId>
-                <artifactId>proto-google-cloud-bigtable-v2</artifactId>
-                <version>0.81.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-bigtable-v2:current} -->
+                <artifactId>grpc-google-cloud-bigtable-admin-v2</artifactId>
+                <version>0.81.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-bigtable-admin-v2:current} -->
             </dependency>
             <dependency>
                 <groupId>com.google.api.grpc</groupId>
@@ -176,72 +210,55 @@
             </dependency>
             <dependency>
                 <groupId>com.google.api.grpc</groupId>
-                <artifactId>grpc-google-cloud-bigtable-admin-v2</artifactId>
-                <version>0.81.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-bigtable-v2:current} -->
+                <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
+                <version>0.81.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-bigtable-admin-v2:current} -->
             </dependency>
             <dependency>
                 <groupId>com.google.api.grpc</groupId>
-                <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
-                <version>0.81.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-bigtable-v2:current} -->
+                <artifactId>proto-google-cloud-bigtable-v2</artifactId>
+                <version>0.81.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-bigtable-v2:current} -->
+            </dependency>
+
+            <!-- Production dependency version definitions in alphabetical order -->
+            <dependency>
+                <groupId>com.google.api</groupId>
+                <artifactId>api-common</artifactId>
+                <version>${google.api-common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.api.grpc</groupId>
+                <artifactId>proto-google-common-protos</artifactId>
+                <version>${google.common-protos.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.api.grpc</groupId>
+                <artifactId>proto-google-iam-v1</artifactId>
+                <version>0.13.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.auto.value</groupId>
                 <artifactId>auto-value</artifactId>
-                <version>1.6.6</version>
+                <version>${auto-value.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.auto.value</groupId>
                 <artifactId>auto-value-annotations</artifactId>
-                <version>1.6.6</version>
+                <version>${auto-value.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-core</artifactId>
-                <version>1.91.2</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>3.0.2</version>
-            </dependency>
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-bom</artifactId>
-                <version>${grpc.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.google.api</groupId>
-                <artifactId>gax-bom</artifactId>
-                <version>${gax.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.google.truth</groupId>
-                <artifactId>truth</artifactId>
-                <version>1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-bigtable-emulator</artifactId>
-                <version>0.111.0-alpha</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>1.10.19</version>
-            </dependency>
-            <dependency>
-                <groupId>io.opencensus</groupId>
-                <artifactId>opencensus-api</artifactId>
-                <version>0.24.0</version>
+                <version>${google.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-core-grpc</artifactId>
                 <version>${google.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
             </dependency>
             <dependency>
                 <groupId>com.google.errorprone</groupId>
@@ -259,49 +276,43 @@
                 <version>${protobuf.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.api</groupId>
-                <artifactId>api-common</artifactId>
-                <version>${google.api-common.version}</version>
+                <groupId>io.opencensus</groupId>
+                <artifactId>opencensus-api</artifactId>
+                <version>${opencensus.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.api.grpc</groupId>
-                <artifactId>proto-google-common-protos</artifactId>
-                <version>${google.common-protos.version}</version>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
             </dependency>
             <dependency>
                 <groupId>org.threeten</groupId>
                 <artifactId>threetenbp</artifactId>
                 <version>${threeten.version}</version>
             </dependency>
-            <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>${javax.annotations.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.api.grpc</groupId>
-                <artifactId>proto-google-iam-v1</artifactId>
-                <version>0.13.0</version>
-            </dependency>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
+
+
+            <!-- Test Deps in alphabetical order -->
             <dependency>
                 <groupId>com.google.api</groupId>
                 <artifactId>gax-grpc</artifactId>
                 <version>${gax.version}</version>
                 <classifier>testlib</classifier>
-                <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava-bom</artifactId>
-                <version>28.1-android</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <groupId>com.google.truth</groupId>
+                <artifactId>truth</artifactId>
+                <version>1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>1.10.19</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -312,9 +323,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <configuration>
-                        <ignoredUnusedDeclaredDependencies>org.objenesis:objenesis</ignoredUnusedDeclaredDependencies>
-                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Main
* Update parent pom version along with the client

Properties:
* Add vertical space to properties to separate version from other variables
* alphabetize version props to make it easier to track
* only include primary dep version as a property
* add missing project.javadoc.protobufBaseURL property

Dependency Management:
* Make ordering consistent: Setions for BOMs, child modules, prod deps, tests. Each section is alphabetical
* move boms to top
* Child modules next
* Fix x-version-update markers
* Remove scopes from dependency management. It should only manage versions

Misc
* remove <ignoredUnusedDeclaredDependencies>objenesis, it's not used and causing warnings