### PR TITLE
chore: Adding .gitignore to skip generated meta files & folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# Packages
+dist
+bin
+var
+sdist
+target
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+
+.metadata
+.project
+.pydevproject
+*.iml
+.idea
+.settings
+.DS_Store
+.classpath
+
+# Built documentation
+docs/
+
+
+# Wheel directory used in Travis builds.
+gcloud-java-wheels/
+src/test/resources/gcd-head.zip
+src/test/resources/gcd-v1beta2-rev1-2.1.1.zip
+
+# API key file containing value of GOOGLE_API_KEY for integration tests
+api_key
+
+# Python utilities
+*.pyc
+artman-genfiles


### PR DESCRIPTION
Copied `.gitignore` content from the source(google-cloud-java) repository.