### PR TITLE
Added note about timestamp granularity in MutationApi interface.

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/MutationApi.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/MutationApi.java
@@ -36,9 +36,9 @@ public interface MutationApi<T extends MutationApi<T>> {
    *
    * <p>This is a convenience override that converts Strings to ByteStrings.
    *
-   * <p>Note: The timestamp value could be -1 to use Bigtable server time. Otherwise, the user must
-   * provide this value in the multiples of 1000 (millisecond granularity). For example:
-   * `1571902339435000`.
+   * <p>Note: The timestamp values are in microseconds but must match the granularity of the
+   * table(defaults to `MILLIS`). Therefore, the given value must be a multiple of 1000 (millisecond
+   * granularity). For example: `1571902339435000`.
    */
   T setCell(
       @Nonnull String familyName, @Nonnull String qualifier, long timestamp, @Nonnull String value);
@@ -53,9 +53,9 @@ public interface MutationApi<T extends MutationApi<T>> {
   /**
    * Adds a mutation which sets the value of the specified cell.
    *
-   * <p>Note: The timestamp value could be -1 to use Bigtable server time. Otherwise, the user must
-   * provide this value in the multiples of 1000 (millisecond granularity). For example:
-   * `1571902339435000`.
+   * <p>Note: The timestamp values are in microseconds but must match the granularity of the
+   * table(defaults to `MILLIS`). Therefore, the given value must be a multiple of 1000 (millisecond
+   * granularity). For example: `1571902339435000`.
    */
   T setCell(
       @Nonnull String familyName,
@@ -76,9 +76,9 @@ public interface MutationApi<T extends MutationApi<T>> {
    *
    * <p>This is a convenience override that converts Strings to ByteStrings.
    *
-   * <p>Note: The timestamp value could be -1 to use Bigtable server time. Otherwise, the user must
-   * provide this value in the multiples of 1000 (millisecond granularity). For example:
-   * `1571902339435000`.
+   * <p>Note: The timestamp values are in microseconds but must match the granularity of the
+   * table(defaults to `MILLIS`). Therefore, the given value must be a multiple of 1000 (millisecond
+   * granularity). For example: `1571902339435000`.
    */
   T setCell(@Nonnull String familyName, @Nonnull String qualifier, long timestamp, long value);
 
@@ -92,9 +92,9 @@ public interface MutationApi<T extends MutationApi<T>> {
   /**
    * Adds a mutation which sets the value of the specified cell.
    *
-   * <p>Note: The timestamp value could be -1 to use Bigtable server time. Otherwise, the user must
-   * provide this value in the multiples of 1000 (millisecond granularity). For example:
-   * `1571902339435000`.
+   * <p>Note: The timestamp values are in microseconds but must match the granularity of the
+   * table(defaults to `MILLIS`). Therefore, the given value must be a multiple of 1000 (millisecond
+   * granularity). For example: `1571902339435000`.
    */
   T setCell(@Nonnull String familyName, @Nonnull ByteString qualifier, long timestamp, long value);
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/MutationApi.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/MutationApi.java
@@ -35,6 +35,10 @@ public interface MutationApi<T extends MutationApi<T>> {
    * Adds a mutation which sets the value of the specified cell.
    *
    * <p>This is a convenience override that converts Strings to ByteStrings.
+   *
+   * <p>Note: The timestamp value could be -1 to use Bigtable server time. Otherwise, the user must
+   * provide this value in the multiples of 1000 (millisecond granularity). For example:
+   * `1571902339435000`.
    */
   T setCell(
       @Nonnull String familyName, @Nonnull String qualifier, long timestamp, @Nonnull String value);
@@ -46,7 +50,13 @@ public interface MutationApi<T extends MutationApi<T>> {
    */
   T setCell(@Nonnull String familyName, @Nonnull ByteString qualifier, @Nonnull ByteString value);
 
-  /** Adds a mutation which sets the value of the specified cell. */
+  /**
+   * Adds a mutation which sets the value of the specified cell.
+   *
+   * <p>Note: The timestamp value could be -1 to use Bigtable server time. Otherwise, the user must
+   * provide this value in the multiples of 1000 (millisecond granularity). For example:
+   * `1571902339435000`.
+   */
   T setCell(
       @Nonnull String familyName,
       @Nonnull ByteString qualifier,
@@ -65,6 +75,10 @@ public interface MutationApi<T extends MutationApi<T>> {
    * Adds a mutation which sets the value of the specified cell.
    *
    * <p>This is a convenience override that converts Strings to ByteStrings.
+   *
+   * <p>Note: The timestamp value could be -1 to use Bigtable server time. Otherwise, the user must
+   * provide this value in the multiples of 1000 (millisecond granularity). For example:
+   * `1571902339435000`.
    */
   T setCell(@Nonnull String familyName, @Nonnull String qualifier, long timestamp, long value);
 
@@ -75,7 +89,13 @@ public interface MutationApi<T extends MutationApi<T>> {
    */
   T setCell(@Nonnull String familyName, @Nonnull ByteString qualifier, long value);
 
-  /** Adds a mutation which sets the value of the specified cell. */
+  /**
+   * Adds a mutation which sets the value of the specified cell.
+   *
+   * <p>Note: The timestamp value could be -1 to use Bigtable server time. Otherwise, the user must
+   * provide this value in the multiples of 1000 (millisecond granularity). For example:
+   * `1571902339435000`.
+   */
   T setCell(@Nonnull String familyName, @Nonnull ByteString qualifier, long timestamp, long value);
 
   /** Adds a mutation which deletes cells from the specified column. */


### PR DESCRIPTION
For documentation about the timestamp format for Mutation#setCell APIs.