### PR TITLE
chore: copy the emulator back into this repo.

### DIFF
--- a/google-cloud-bigtable-emulator/README.md
+++ b/google-cloud-bigtable-emulator/README.md
@@ -1,0 +1,130 @@
+# Google Cloud Java Emulator for Bigtable
+
+A Java wrapper for the [Cloud Bigtable][cloud-bigtable] emulator. This
+wrapper bundles the native Bigtable emulator and exposes a simple Java
+interface to ease writing tests. Please note that this wrapper is under
+heavy development and APIs may change in the future.
+
+## Quickstart
+
+If you are using Maven, add this to your pom.xml file
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bom</artifactId>
+      <!-- Replace with the latest version -->
+      <version>0.116.0-alpha</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-bigtable</artifactId>
+  </dependency>
+
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-bigtable-emulator</artifactId>
+    <scope>test</scope>
+  </dependency>
+
+  <dependency>
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+    <version>4.12</version>
+    <scope>test</scope>
+  </dependency>
+</dependencies>
+```
+
+If you are using Gradle, add this to your dependencies
+```Groovy
+compile 'com.google.cloud:google-cloud-bigtable:0.114.0-alpha'
+testCompile 'com.google.cloud:google-cloud-bigtable-emulator:0.114.0-alpha'
+testCompile 'junit:junit:4.12'
+```
+If you are using SBT, add this to your dependencies
+```Scala
+libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "0.116.0-alpha"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigtable-emulator" % "0.116.0-alpha" % Test
+libraryDependencies += "junit" % "junit" % "4.12" % Test
+```
+[//]: # ({x-version-update-end})
+
+## Getting Started
+
+Here is a code snippet showing a simple JUnit test. Add the following imports
+at the top of your file:
+
+```java
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.emulator.v2.BigtableEmulatorRule;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+```
+
+Then, to make a query to Bigtable, use the following code:
+```java
+@RunWith(JUnit4.class)
+public class ExampleTest {
+  // Initialize the emulator Rule
+  @Rule
+  public final BigtableEmulatorRule bigtableEmulator = BigtableEmulatorRule.create();
+
+  // Clients that will be connected to the emulator
+  private BigtableTableAdminClient tableAdminClient;
+  private BigtableDataClient dataClient;
+
+  @Before
+  public void setUp() throws IOException {
+    // Initialize the clients to connect to the emulator
+    BigtableTableAdminSettings.Builder tableAdminSettings = BigtableTableAdminSettings.newBuilderForEmulator(bigtableEmulator.getPort());
+    tableAdminClient = BigtableTableAdminClient.create(tableAdminSettings.build());
+
+    BigtableDataSettings.Builder dataSettings = BigtableDataSettings.newBuilderForEmulator(bigtableEmulator.getPort());
+    dataClient = BigtableDataClient.create(dataSettings.build());
+
+    // Create a test table that can be used in tests
+    tableAdminClient.createTable(
+        CreateTableRequest.of("fake-table")
+          .addFamily("cf")
+    );
+  }
+
+  @Test
+  public void testWriteRead() throws ExecutionException, InterruptedException {
+    ApiFuture<Void> mutateFuture = dataClient.mutateRowAsync(
+        RowMutation.create("fake-table", "fake-key")
+            .setCell("cf", "col", "value")
+    );
+
+    mutateFuture.get();
+
+    ApiFuture<Row> rowFuture = dataClient.readRowAsync("fake-table", "fake-key");
+
+    Assert.assertEquals("value", rowFuture.get().getCells().get(0).getValue().toStringUtf8());
+  }
+}
+```

--- a/google-cloud-bigtable-emulator/README.md
+++ b/google-cloud-bigtable-emulator/README.md
@@ -43,19 +43,6 @@ If you are using Maven, add this to your pom.xml file
 </dependencies>
 ```
 
-If you are using Gradle, add this to your dependencies
-```Groovy
-compile 'com.google.cloud:google-cloud-bigtable:0.114.0-alpha'
-testCompile 'com.google.cloud:google-cloud-bigtable-emulator:0.114.0-alpha'
-testCompile 'junit:junit:4.12'
-```
-If you are using SBT, add this to your dependencies
-```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "0.116.0-alpha"
-libraryDependencies += "com.google.cloud" % "google-cloud-bigtable-emulator" % "0.116.0-alpha" % Test
-libraryDependencies += "junit" % "junit" % "4.12" % Test
-```
-[//]: # ({x-version-update-end})
 
 ## Getting Started
 

--- a/google-cloud-bigtable-emulator/pom.xml
+++ b/google-cloud-bigtable-emulator/pom.xml
@@ -74,16 +74,11 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-core</artifactId>
+      <artifactId>grpc-api</artifactId>
       <!-- gRPC deps are provided by the client -->
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty-shaded</artifactId>
-      <!-- gRPC deps are provided by the client -->
-      <scope>provided</scope>
-    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -102,6 +97,18 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-cloud-bigtable-admin-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-bigtable-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/google-cloud-bigtable-emulator/pom.xml
+++ b/google-cloud-bigtable-emulator/pom.xml
@@ -117,5 +117,11 @@
       <artifactId>truth</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/google-cloud-bigtable-emulator/pom.xml
+++ b/google-cloud-bigtable-emulator/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>google-cloud-bigtable-emulator</artifactId>
+  <version>0.114.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable-emulator:current} -->
+  <name>Google Cloud Java - Bigtable Emulator</name>
+  <url>https://github.com/googleapis/java-bigtable</url>
+  <description>
+    A Java wrapper for the Cloud Bigtable emulator.
+  </description>
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-bigtable-parent</artifactId>
+    <version>1.5.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+  </parent>
+  <scm>
+    <connection>scm:git:git@github.com:googleapis/java-bigtable.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/java-bigtable.git</developerConnection>
+    <url>https://github.com/googleapis/java-bigtable</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <developers>
+    <developer>
+      <id>igorberstein</id>
+      <name>Igor Bernstein</name>
+      <email>igorbernstein@google.com</email>
+      <organization>Google</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
+
+  <build>
+    <plugins>
+      <plugin>
+        <!-- https://github.com/googleapis/java-gcloud-maven-plugin -->
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-gcloud-maven-plugin</artifactId>
+        <version>0.1.0</version>
+
+        <executions>
+          <execution>
+            <id>gen-sources</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>download</goal>
+            </goals>
+            <configuration>
+              <componentNames>
+                <componentName>bigtable-darwin-x86</componentName>
+                <componentName>bigtable-darwin-x86_64</componentName>
+                <componentName>bigtable-linux-x86</componentName>
+                <componentName>bigtable-linux-x86_64</componentName>
+                <componentName>bigtable-windows-x86</componentName>
+                <componentName>bigtable-windows-x86_64</componentName>
+              </componentNames>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <!-- Compile deps in alphabetical order -->
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <!-- gRPC deps are provided by the client -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <!-- gRPC deps are provided by the client -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <!-- NOTE: this is intentionally in compile scope since it provides a JUnit Rule -->
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- Test deps, in alphabetical order -->
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-bigtable-admin-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/google-cloud-bigtable-emulator/pom.xml
+++ b/google-cloud-bigtable-emulator/pom.xml
@@ -63,6 +63,15 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <!-- grpc-netty-shaded is used at test runtime -->
+          <usedDependencies>io.grpc:grpc-netty-shaded</usedDependencies>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -109,6 +118,12 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/BigtableEmulatorRule.java
+++ b/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/BigtableEmulatorRule.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.emulator.v2;
+
+import com.google.api.core.BetaApi;
+import io.grpc.ManagedChannel;
+import org.junit.rules.ExternalResource;
+
+/**
+ * The BigtableEmulatorRule manages the lifecycle of the Bigtable {@link Emulator}. Before the start
+ * of a test, the emulator will be started on a random port and will be shutdown after the test
+ * finishes.
+ *
+ * <p>Example usage: <code>{@code
+ *   {@literal @RunWith(JUnit4.class)}
+ *   public class MyTest {
+ *     {@literal @Rule}
+ *     public final BigtableEmulatorRule bigtableEmulator = BigtableEmulatorRule.create();
+ *
+ *     {@literal @Test}
+ *     public void testUsingEmulator() {
+ *        ManagedChannel adminChannel = bigtableEmulator.getAdminChannel();
+ *        // Do something with channel
+ *     }
+ *   }
+ * }</code>
+ */
+@BetaApi("Surface for Bigtable emulator is not yet stable")
+public class BigtableEmulatorRule extends ExternalResource {
+  private Emulator emulator;
+
+  public static BigtableEmulatorRule create() {
+    return new BigtableEmulatorRule();
+  }
+
+  private BigtableEmulatorRule() {}
+
+  /** Initializes the Bigtable emulator before a test runs. */
+  @Override
+  protected void before() throws Throwable {
+    emulator = Emulator.createBundled();
+    emulator.start();
+  }
+
+  /** Stops the Bigtable emulator after a test finishes. */
+  @Override
+  protected void after() {
+    emulator.stop();
+    emulator = null;
+  }
+
+  /**
+   * Gets a {@link ManagedChannel} connected to the Emulator. The channel is configured for data
+   * operations.
+   */
+  public ManagedChannel getDataChannel() {
+    return emulator.getDataChannel();
+  }
+
+  /**
+   * Gets a {@link ManagedChannel} connected to the Emulator. This channel should be used for admin
+   * operations.
+   */
+  public ManagedChannel getAdminChannel() {
+    return emulator.getAdminChannel();
+  }
+
+  /**
+   * Gets the port of the emulator, allowing the caller to create their own {@link ManagedChannel}.
+   */
+  public int getPort() {
+    return emulator.getPort();
+  }
+}

--- a/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/Emulator.java
+++ b/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/Emulator.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.emulator.v2;
+
+import com.google.api.core.BetaApi;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Wraps the Bigtable emulator in a java api.
+ *
+ * <p>This class will use the golang binaries embedded in this jar to launch the emulator as an
+ * external process and redirect its output to a {@link Logger}.
+ */
+@BetaApi("Surface for Bigtable emulator is not yet stable")
+public class Emulator {
+
+  private static final Logger LOGGER = Logger.getLogger(Emulator.class.getName());
+
+  private final Path executable;
+  private Process process;
+  private boolean isStopped = true;
+  private Thread shutdownHook;
+
+  private int port;
+  private ManagedChannel dataChannel;
+  private ManagedChannel adminChannel;
+
+  /**
+   * Create a new instance of emulator. The emulator will use the bundled binaries in this jar.
+   * Please note that the emulator is created in a stopped state, please use {@link #start()} after
+   * creating it.
+   */
+  public static Emulator createBundled() throws IOException {
+    String resourcePath = getBundledResourcePath();
+
+    File tmpEmulator = File.createTempFile("cbtemulator", "");
+    tmpEmulator.deleteOnExit();
+
+    try (InputStream is = Emulator.class.getResourceAsStream(resourcePath);
+        FileOutputStream os = new FileOutputStream(tmpEmulator)) {
+
+      if (is == null) {
+        throw new FileNotFoundException(
+            "Failed to find the bundled emulator binary: " + resourcePath);
+      }
+
+      byte[] buff = new byte[2048];
+      int length;
+
+      while ((length = is.read(buff)) != -1) {
+        os.write(buff, 0, length);
+      }
+    }
+    tmpEmulator.setExecutable(true);
+
+    return new Emulator(tmpEmulator.toPath());
+  }
+
+  private Emulator(Path executable) {
+    this.executable = executable;
+  }
+
+  /** Starts the emulator process and waits for it to be ready. */
+  public synchronized void start() throws IOException, TimeoutException, InterruptedException {
+    if (!isStopped) {
+      throw new IllegalStateException("Emulator is already started");
+    }
+    this.port = getAvailablePort();
+
+    // Workaround https://bugs.openjdk.java.net/browse/JDK-8068370
+    for (int attemptsLeft = 3; process == null; attemptsLeft--) {
+      try {
+        process = Runtime.getRuntime().exec(String.format("%s -port %d", executable, port));
+      } catch (IOException e) {
+        if (attemptsLeft > 0) {
+          Thread.sleep(1000);
+          continue;
+        }
+        throw e;
+      }
+    }
+    pipeStreamToLog(process.getInputStream(), Level.INFO);
+    pipeStreamToLog(process.getErrorStream(), Level.WARNING);
+    isStopped = false;
+
+    shutdownHook =
+        new Thread() {
+          @Override
+          public void run() {
+            if (!isStopped) {
+              isStopped = true;
+              process.destroy();
+            }
+          }
+        };
+
+    Runtime.getRuntime().addShutdownHook(shutdownHook);
+
+    waitForPort(port);
+  }
+
+  /** Stops the emulator process. */
+  public synchronized void stop() {
+    if (isStopped) {
+      throw new IllegalStateException("Emulator already stopped");
+    }
+
+    try {
+      Runtime.getRuntime().removeShutdownHook(shutdownHook);
+      shutdownHook = null;
+
+      // Shutdown channels in parallel
+      if (dataChannel != null) {
+        dataChannel.shutdownNow();
+      }
+      if (adminChannel != null) {
+        adminChannel.shutdownNow();
+      }
+
+      // Then wait for actual shutdown
+      if (dataChannel != null) {
+        dataChannel.awaitTermination(1, TimeUnit.MINUTES);
+        dataChannel = null;
+      }
+      if (adminChannel != null) {
+        adminChannel.awaitTermination(1, TimeUnit.MINUTES);
+        adminChannel = null;
+      }
+    } catch (InterruptedException e) {
+      LOGGER.warning("Interrupted while waiting for client channels to close");
+      Thread.currentThread().interrupt();
+    } finally {
+      isStopped = true;
+      process.destroy();
+    }
+  }
+
+  public synchronized int getPort() {
+    if (isStopped) {
+      throw new IllegalStateException("Emulator is not running");
+    }
+    return port;
+  }
+
+  public synchronized ManagedChannel getDataChannel() {
+    if (isStopped) {
+      throw new IllegalStateException("Emulator is not running");
+    }
+
+    if (dataChannel == null) {
+      dataChannel = newChannelBuilder(port).maxInboundMessageSize(256 * 1024 * 1024).build();
+    }
+    return dataChannel;
+  }
+
+  public synchronized ManagedChannel getAdminChannel() {
+    if (isStopped) {
+      throw new IllegalStateException("Emulator is not running");
+    }
+
+    if (adminChannel == null) {
+      adminChannel = newChannelBuilder(port).build();
+    }
+    return adminChannel;
+  }
+
+  // <editor-fold desc="Helpers">
+
+  /** Gets the current platform, which will be used to select the appropriate emulator binary. */
+  private static String getBundledResourcePath() {
+    String unformattedOs = System.getProperty("os.name", "unknown").toLowerCase(Locale.ENGLISH);
+    String os;
+    String suffix = "";
+
+    if (unformattedOs.contains("mac") || unformattedOs.contains("darwin")) {
+      os = "darwin";
+    } else if (unformattedOs.contains("win")) {
+      os = "windows";
+      suffix = ".exe";
+    } else if (unformattedOs.contains("linux")) {
+      os = "linux";
+    } else {
+      throw new UnsupportedOperationException(
+          "Emulator is not supported on your platform: " + unformattedOs);
+    }
+
+    String unformattedArch = System.getProperty("os.arch");
+    String arch;
+
+    switch (unformattedArch) {
+      case "x86":
+        arch = "x86";
+        break;
+      case "x86_64":
+      case "amd64":
+        arch = "x86_64";
+        break;
+      default:
+        throw new UnsupportedOperationException("Unsupported architecture: " + unformattedArch);
+    }
+
+    return String.format(
+        "/gcloud/bigtable-%s-%s/platform/bigtable-emulator/cbtemulator%s", os, arch, suffix);
+  }
+
+  /** Gets a random open port number. */
+  private static int getAvailablePort() {
+    try (ServerSocket serverSocket = new ServerSocket(0)) {
+      return serverSocket.getLocalPort();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to find open port");
+    }
+  }
+
+  /** Waits for a port to open. It's used to wait for the emulator's gRPC server to be ready. */
+  private static void waitForPort(int port) throws InterruptedException, TimeoutException {
+    for (int i = 0; i < 100; i++) {
+      try (Socket ignored = new Socket("localhost", port)) {
+        return;
+      } catch (IOException e) {
+        Thread.sleep(200);
+      }
+    }
+
+    throw new TimeoutException("Timed out waiting for server to start");
+  }
+
+  /** Creates a {@link io.grpc.ManagedChannelBuilder} preconfigured for the emulator's port. */
+  private static ManagedChannelBuilder<?> newChannelBuilder(int port) {
+    // NOTE: usePlaintext is currently @ExperimentalAPI.
+    // See https://github.com/grpc/grpc-java/issues/1772 for discussion
+    return ManagedChannelBuilder.forAddress("localhost", port).usePlaintext();
+  }
+
+  /** Creates a thread that will pipe an {@link java.io.InputStream} to this class' Logger. */
+  private static void pipeStreamToLog(final InputStream stream, final Level level) {
+    final BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+
+    Thread thread =
+        new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  String line;
+                  while ((line = reader.readLine()) != null) {
+                    LOGGER.log(level, line);
+                  }
+                } catch (IOException e) {
+                  if (!"Stream closed".equals(e.getMessage())) {
+                    LOGGER.log(Level.WARNING, "Failed to read process stream", e);
+                  }
+                }
+              }
+            });
+    thread.setDaemon(true);
+    thread.start();
+  }
+  // </editor-fold>
+}

--- a/google-cloud-bigtable-emulator/src/test/java/com/google/cloud/bigtable/emulator/v2/BigtableEmulatorRuleTest.java
+++ b/google-cloud-bigtable-emulator/src/test/java/com/google/cloud/bigtable/emulator/v2/BigtableEmulatorRuleTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.emulator.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.bigtable.admin.v2.BigtableTableAdminGrpc;
+import com.google.bigtable.admin.v2.BigtableTableAdminGrpc.BigtableTableAdminBlockingStub;
+import com.google.bigtable.admin.v2.ColumnFamily;
+import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.bigtable.admin.v2.Table;
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.v2.BigtableGrpc.BigtableBlockingStub;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.Mutation;
+import com.google.bigtable.v2.Mutation.SetCell;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.protobuf.ByteString;
+import java.util.Iterator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BigtableEmulatorRuleTest {
+  @Rule public BigtableEmulatorRule bigtableRule = BigtableEmulatorRule.create();
+  private BigtableTableAdminBlockingStub tableAdminStub;
+  private BigtableBlockingStub dataStub;
+
+  @Before
+  public void setUp() {
+    tableAdminStub = BigtableTableAdminGrpc.newBlockingStub(bigtableRule.getAdminChannel());
+    dataStub = BigtableGrpc.newBlockingStub(bigtableRule.getDataChannel());
+  }
+
+  @Test
+  public void testTableAdminClient() {
+    Table table =
+        tableAdminStub.createTable(
+            CreateTableRequest.newBuilder()
+                .setParent("projects/fake-project/instances/fake-instance")
+                .setTableId("fake-table")
+                .setTable(
+                    Table.newBuilder().putColumnFamilies("cf", ColumnFamily.getDefaultInstance()))
+                .build());
+
+    assertThat(table.getName())
+        .isEqualTo("projects/fake-project/instances/fake-instance/tables/fake-table");
+  }
+
+  @Test
+  public void testDataClient() throws Exception {
+    tableAdminStub.createTable(
+        CreateTableRequest.newBuilder()
+            .setParent("projects/fake-project/instances/fake-instance")
+            .setTableId("fake-table")
+            .setTable(Table.newBuilder().putColumnFamilies("cf", ColumnFamily.getDefaultInstance()))
+            .build());
+
+    dataStub.mutateRow(
+        MutateRowRequest.newBuilder()
+            .setTableName("projects/fake-project/instances/fake-instance/tables/fake-table")
+            .setRowKey(ByteString.copyFromUtf8("fake-key"))
+            .addMutations(
+                Mutation.newBuilder()
+                    .setSetCell(
+                        SetCell.newBuilder()
+                            .setFamilyName("cf")
+                            .setColumnQualifier(ByteString.EMPTY)
+                            .setValue(ByteString.copyFromUtf8("value"))))
+            .build());
+
+    Iterator<ReadRowsResponse> results =
+        dataStub.readRows(
+            ReadRowsRequest.newBuilder()
+                .setTableName("projects/fake-project/instances/fake-instance/tables/fake-table")
+                .build());
+
+    ReadRowsResponse row = results.next();
+    assertThat(row.getChunks(0).getValue()).isEqualTo(ByteString.copyFromUtf8("value"));
+  }
+}

--- a/google-cloud-bigtable-emulator/src/test/java/com/google/cloud/bigtable/emulator/v2/EmulatorTest.java
+++ b/google-cloud-bigtable-emulator/src/test/java/com/google/cloud/bigtable/emulator/v2/EmulatorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.emulator.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.bigtable.admin.v2.BigtableTableAdminGrpc;
+import com.google.bigtable.admin.v2.BigtableTableAdminGrpc.BigtableTableAdminBlockingStub;
+import com.google.bigtable.admin.v2.ColumnFamily;
+import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.bigtable.admin.v2.Table;
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.v2.BigtableGrpc.BigtableBlockingStub;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.Mutation;
+import com.google.bigtable.v2.Mutation.SetCell;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.protobuf.ByteString;
+import java.util.Iterator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class EmulatorTest {
+
+  private Emulator emulator;
+  private BigtableTableAdminBlockingStub tableAdminStub;
+  private BigtableBlockingStub dataStub;
+
+  @Before
+  public void setUp() throws Exception {
+    emulator = Emulator.createBundled();
+    emulator.start();
+    tableAdminStub = BigtableTableAdminGrpc.newBlockingStub(emulator.getAdminChannel());
+    dataStub = BigtableGrpc.newBlockingStub(emulator.getDataChannel());
+  }
+
+  @After
+  public void tearDown() {
+    emulator.stop();
+    emulator = null;
+  }
+
+  @Test
+  public void testTableAdminClient() {
+    Table table =
+        tableAdminStub.createTable(
+            CreateTableRequest.newBuilder()
+                .setParent("projects/fake-project/instances/fake-instance")
+                .setTableId("fake-table")
+                .setTable(
+                    Table.newBuilder().putColumnFamilies("cf", ColumnFamily.getDefaultInstance()))
+                .build());
+
+    assertThat(table.getName())
+        .isEqualTo("projects/fake-project/instances/fake-instance/tables/fake-table");
+  }
+
+  @Test
+  public void testDataClient() {
+    tableAdminStub.createTable(
+        CreateTableRequest.newBuilder()
+            .setParent("projects/fake-project/instances/fake-instance")
+            .setTableId("fake-table")
+            .setTable(Table.newBuilder().putColumnFamilies("cf", ColumnFamily.getDefaultInstance()))
+            .build());
+
+    dataStub.mutateRow(
+        MutateRowRequest.newBuilder()
+            .setTableName("projects/fake-project/instances/fake-instance/tables/fake-table")
+            .setRowKey(ByteString.copyFromUtf8("fake-key"))
+            .addMutations(
+                Mutation.newBuilder()
+                    .setSetCell(
+                        SetCell.newBuilder()
+                            .setFamilyName("cf")
+                            .setColumnQualifier(ByteString.EMPTY)
+                            .setValue(ByteString.copyFromUtf8("value"))))
+            .build());
+
+    Iterator<ReadRowsResponse> results =
+        dataStub.readRows(
+            ReadRowsRequest.newBuilder()
+                .setTableName("projects/fake-project/instances/fake-instance/tables/fake-table")
+                .build());
+
+    ReadRowsResponse row = results.next();
+    assertThat(row.getChunks(0).getValue()).isEqualTo(ByteString.copyFromUtf8("value"));
+  }
+}

--- a/google-cloud-testing/google-cloud-bigtable-emulator/README.md
+++ b/google-cloud-testing/google-cloud-bigtable-emulator/README.md
@@ -1,3 +1,0 @@
-# Google Cloud Java Emulator for Bigtable
-
-This client has moved to https://github.com/googleapis/java-bigtable-emulator

--- a/pom.xml
+++ b/pom.xml
@@ -192,10 +192,9 @@
 
             <!-- Child Modules, in alphabetical order -->
             <dependency>
-              <!-- TODO: Make this a child module -->
               <groupId>com.google.cloud</groupId>
               <artifactId>google-cloud-bigtable-emulator</artifactId>
-              <version>0.111.0-alpha</version>
+              <version>0.114.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable-emulator:current} -->
             </dependency>
             <dependency>
               <groupId>com.google.api.grpc</groupId>
@@ -364,6 +363,7 @@
         <module>proto-google-cloud-bigtable-admin-v2</module>
         <module>grpc-google-cloud-bigtable-admin-v2</module>
         <module>google-cloud-bigtable</module>
+        <module>google-cloud-bigtable-emulator</module>
     </modules>
 
     <reporting>

--- a/versions.txt
+++ b/versions.txt
@@ -6,3 +6,4 @@ grpc-google-cloud-bigtable-admin-v2:0.81.0:0.81.1-SNAPSHOT
 grpc-google-cloud-bigtable-v2:0.81.0:0.81.1-SNAPSHOT
 proto-google-cloud-bigtable-admin-v2:0.81.0:0.81.1-SNAPSHOT
 proto-google-cloud-bigtable-v2:0.81.0:0.81.1-SNAPSHOT
+google-cloud-bigtable-emulator:0.114.0:0.114.1-alpha-SNAPSHOT


### PR DESCRIPTION
It was accidentally moved into its own repo https://github.com/googleapis/java-bigtable-emulator.
This PR copies it back. Git history is short enough that a subtree merge would be over kill.
