### PR TITLE
chore(deps): update google-cloud-shared-config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,9 @@
                         <!-- Explicitly set the source directory to avoid running checkstyle on generated sources. -->
                         <sourceDirectory>src/main/java</sourceDirectory>
                       </sourceDirectories>
+                      <testSourceDirectories>
+                        <testSourceDirectory>src/test/java</testSourceDirectory>
+                      </testSourceDirectories>
                     </configuration>
                   </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-config</artifactId>
-        <version>0.1.1</version>
+        <version>0.2.1</version>
     </parent>
 
     <developers>
@@ -354,6 +354,19 @@
                     </annotationProcessorPaths>
                   </configuration>
                 </plugin>
+
+                  <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <configuration>
+                      <sourceDirectories>
+                        <!-- TODO: pull this into google-cloud-shared-config -->
+                        <!-- Explicitly set the source directory to avoid running checkstyle on generated sources. -->
+                        <sourceDirectory>src/main/java</sourceDirectory>
+                      </sourceDirectories>
+                    </configuration>
+                  </plugin>
+
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This should supercedes #15. 

The new shared config force checkstyle checks, unfortunately this doesn't play well with annotations and generated sources as maven will add the generated sources path to `$project.compileSourceRoots`, which checkstyle uses as the default value for `<sourceDirectories>`, this PR changes the value to src/main/java