### PR TITLE
fix: use proper scope for DirectPath transitive dependencies

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -83,6 +83,16 @@
       <artifactId>grpc-alts</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <!--
+      grpc-stub is needed directly by our tests and transitively by grpc-alts at runtime.
+      So it has to be declared as a direct dependency and to avoid overriding grpc-alts'
+      runtime requirement it has to be promoted to the runtime scope.
+    -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
@@ -160,11 +170,6 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-stub</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
grpc-alts has a transitive dep on grpc-stub, but our tests have a direct dependency on it. This would cause the transitive dependency to be downgraded to the test scope