### PR TITLE
fix: Prevent integration tests from different profiles from clobbering each other

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -220,6 +220,7 @@
                     <include>com.google.cloud.bigtable.**.it.*IT</include>
                   </includes>
                   <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-emulator-it.xml</summaryFile>
+                  <reportsDirectory>${project.build.directory}/failsafe-reports/emulator-it</reportsDirectory>
                 </configuration>
               </execution>
             </executions>
@@ -249,6 +250,7 @@
                     <include>com.google.cloud.bigtable.**.it.*IT</include>
                   </includes>
                   <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-prod-it.xml</summaryFile>
+                  <reportsDirectory>${project.build.directory}/failsafe-reports/prod-it</reportsDirectory>
                 </configuration>
               </execution>
             </executions>
@@ -290,6 +292,7 @@
                     <include>com.google.cloud.bigtable.data.v2.it.*IT</include>
                   </includes>
                   <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-directpath-it.xml</summaryFile>
+                  <reportsDirectory>${project.build.directory}/failsafe-reports/directpath-it</reportsDirectory>
                 </configuration>
               </execution>
             </executions>
@@ -330,31 +333,6 @@
             -->
           <usedDependencies>io.grpc:grpc-auth,io.grpc:grpc-grpclb</usedDependencies>
         </configuration>
-      </plugin>
-
-      <!-- Workaround maven failing to delete old test reports. For some reason, when using the
-        failsafe plugin in profiles, maven retains the counts from previous executions. Causing a
-        stale failure to fail the current test run. -->
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <version>2.5</version>
-        <executions>
-          <execution>
-            <id>clean-old-reports</id>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-            <phase>pre-integration-test</phase>
-            <configuration>
-              <excludeDefaultDirectories>true</excludeDefaultDirectories>
-              <filesets>
-                <fileset>
-                  <directory>${project.build.directory}/failsafe-reports</directory>
-                </fileset>
-              </filesets>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>

--- a/scripts/setup-test-table.sh
+++ b/scripts/setup-test-table.sh
@@ -36,13 +36,7 @@ for ADMIN_HOST in "${ADMIN_HOSTS[@]}"; do
   fi
 
   # Ensure that the table exists
-  if ! call_cbt -instance ${INSTANCE_ID} ls | grep -q "^${TABLE_ID}\$"; then
-    call_cbt createtable ${TABLE_ID}
-  fi
-
-  # Ensure that the family exists
-  if ! call_cbt ls "${TABLE_ID}" | grep -q "^$FAMILY\b"; then
-    call_cbt createfamily "${TABLE_ID}" "${FAMILY}"
-    call_cbt setgcpolicy "${TABLE_ID}" "${FAMILY}" maxversions=1 maxage=1h
+  if ! call_cbt -instance "$INSTANCE_ID" ls | grep -q "^${TABLE_ID}\$"; then
+    call_cbt createtable "$TABLE_ID" "families=$FAMILY:maxversions=1||maxage=1h"
   fi
 done


### PR DESCRIPTION
The integration tests in this project can target multiple environments: emulator, cloud, etc. This is implemented using profiles. To avoid conflicts, the summary reports were suffixed by the profile name. Unfortunately the individual test reports were not and each profile would overwrite the previous reports. This PR gives each profile its own directory.

Also, it fixes up the setup script