### PR TITLE
chore: Ignore gapic settings for all streaming RPCs

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -117,7 +117,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
           .setJittered(true)
           .setInitialRpcTimeout(Duration.ofMinutes(5))
           .setRpcTimeoutMultiplier(2.0)
-          .setInitialRpcTimeout(Duration.ofMinutes(5))
+          .setMaxRpcTimeout(Duration.ofMinutes(5))
           .setTotalTimeout(Duration.ofHours(12))
           .build();
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -102,6 +102,25 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
           .setTotalTimeout(Duration.ofMinutes(10))
           .build();
 
+  // Allow retrying ABORTED statuses. These will be returned by the server when the client is
+  // too slow to read the rows. This makes sense for the java client because retries happen
+  // after the row merging logic. Which means that the retry will not be invoked until the
+  // current buffered chunks are consumed.
+  private static final Set<Code> READ_ROWS_RETRY_CODES =
+      ImmutableSet.<Code>builder().addAll(IDEMPOTENT_RETRY_CODES).add(Code.ABORTED).build();
+
+  private static final RetrySettings READ_ROWS_RETRY_SETTINGS =
+      RetrySettings.newBuilder()
+          .setInitialRetryDelay(Duration.ofMillis(10))
+          .setRetryDelayMultiplier(2.0)
+          .setMaxRetryDelay(Duration.ofMinutes(1))
+          .setJittered(true)
+          .setInitialRpcTimeout(Duration.ofMinutes(5))
+          .setRpcTimeoutMultiplier(2.0)
+          .setInitialRpcTimeout(Duration.ofMinutes(5))
+          .setTotalTimeout(Duration.ofHours(12))
+          .build();
+
   private static final RetrySettings MUTATE_ROWS_RETRY_SETTINGS =
       RetrySettings.newBuilder()
           .setInitialRetryDelay(Duration.ofMillis(10))
@@ -441,17 +460,9 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
       // Per-method settings using baseSettings for defaults.
       readRowsSettings = ServerStreamingCallSettings.newBuilder();
 
-      // Allow retrying ABORTED statuses. These will be returned by the server when the client is
-      // too slow to read the rows. This makes sense for the java client because retries happen
-      // after the row merging logic. Which means that the retry will not be invoked until the
-      // current buffered chunks are consumed.
       readRowsSettings
-          .setRetryableCodes(
-              ImmutableSet.<Code>builder()
-                  .addAll(baseDefaults.readRowsSettings().getRetryableCodes())
-                  .add(Code.ABORTED)
-                  .build())
-          .setRetrySettings(baseDefaults.readRowsSettings().getRetrySettings())
+          .setRetryableCodes(READ_ROWS_RETRY_CODES)
+          .setRetrySettings(READ_ROWS_RETRY_SETTINGS)
           .setIdleTimeout(Duration.ofMinutes(5));
 
       // Point reads should use same defaults as streaming reads, but with a shorter timeout
@@ -468,8 +479,8 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
 
       sampleRowKeysSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
       sampleRowKeysSettings
-          .setRetryableCodes(baseDefaults.sampleRowKeysSettings().getRetryableCodes())
-          .setRetrySettings(baseDefaults.sampleRowKeysSettings().getRetrySettings());
+          .setRetryableCodes(IDEMPOTENT_RETRY_CODES)
+          .setRetrySettings(IDEMPOTENT_RETRY_SETTINGS);
 
       mutateRowSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
       copyRetrySettings(baseDefaults.mutateRowSettings(), mutateRowSettings);

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/readrows/ReadRowsRetryTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/readrows/ReadRowsRetryTest.java
@@ -83,8 +83,10 @@ public class ReadRowsRetryTest {
   }
 
   @After
-  public void tearDown() throws Exception {
-    client.close();
+  public void tearDown() {
+    if (client != null) {
+      client.close();
+    }
   }
 
   @Test


### PR DESCRIPTION
This is to prepare for upcoming changes that will move simple retries to gRPC.
When this happens we want to retain retry settings at the client level, so they are copied into the manual settings wrapper.

See cl/277568516 for more details
