### PR TITLE
chore: improve tests

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -340,42 +340,26 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M3</version>
         <configuration>
           <parallel>classes</parallel>
-          <perCoreThreadCount>true</perCoreThreadCount>
-          <threadCount>2</threadCount>
+          <forkCount>2C</forkCount>
+          <reuseForks>true</reuseForks>
+
           <trimStackTrace>false</trimStackTrace>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>surefire-junit47</artifactId>
-            <version>3.0.0-M3</version>
-          </dependency>
-        </dependencies>
       </plugin>
 
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M3</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>surefire-junit47</artifactId>
-            <version>3.0.0-M3</version>
-          </dependency>
-        </dependencies>
 
         <configuration>
+          <parallel>classes</parallel>
+          <forkCount>2C</forkCount>
+          <reuseForks>true</reuseForks>
+
           <!-- enable the ability to skip unit tests, while running integration tests -->
           <skipTests>${skipUnitTests}</skipTests>
-          <!--
-            TODO(igorbernstein): enable parallel tests once the generate client tests use unique
-            names for the mock server
-          -->
           <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -222,6 +222,7 @@
                 <configuration>
                   <systemPropertyVariables>
                     <bigtable.env>emulator</bigtable.env>
+                    <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/emulator-it</bigtable.grpc-log-dir>
                   </systemPropertyVariables>
                   <includes>
                     <include>com.google.cloud.bigtable.**.it.*IT</include>
@@ -254,6 +255,7 @@
                     <bigtable.env>cloud</bigtable.env>
                     <bigtable.data-endpoint>${bigtable.cfe-data-endpoint}</bigtable.data-endpoint>
                     <bigtable.admin-endpoint>${bigtable.cfe-admin-endpoint}</bigtable.admin-endpoint>
+                    <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/prod-it</bigtable.grpc-log-dir>
                   </systemPropertyVariables>
                   <includes>
                     <include>com.google.cloud.bigtable.**.it.*IT</include>
@@ -286,6 +288,7 @@
                     <bigtable.env>cloud</bigtable.env>
                     <bigtable.data-endpoint>${bigtable.directpath-data-endpoint}</bigtable.data-endpoint>
                     <bigtable.admin-endpoint>${bigtable.directpath-admin-endpoint}</bigtable.admin-endpoint>
+                    <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-it</bigtable.grpc-log-dir>
                   </systemPropertyVariables>
                   <!-- Enable directpath for bigtable -->
                   <environmentVariables>

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/TestEnvRule.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/TestEnvRule.java
@@ -17,12 +17,25 @@ package com.google.cloud.bigtable.test_helpers.env;
 
 import static com.google.common.truth.TruthJUnit.assume;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.logging.FileHandler;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.junit.rules.ExternalResource;
+import java.util.logging.SimpleFormatter;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 /**
- * Simple JUnit rule to start and stop the target test environment.
+ * JUnit rule to start and stop the target test environment.
  *
  * <p>The environment can be specified via the system property {@code bigtable.env}. The choices
  * are:
@@ -37,24 +50,48 @@ import org.junit.rules.ExternalResource;
  * </ul>
  *
  * <p>By default, {@code emulator} will be used
+ *
+ * <p>Also, when the system property {@code bigtable.grpc-log-dir} is set, it will enable fine
+ * grained gRPC logging to the configured path.
  */
-public class TestEnvRule extends ExternalResource {
+public class TestEnvRule implements TestRule {
 
   private static final Logger LOGGER = Logger.getLogger(TestEnvRule.class.getName());
+  private static final String BIGTABLE_GRPC_LOG_DIR = System.getProperty("bigtable.grpc-log-dir");
   private static final String BIGTABLE_EMULATOR_HOST_ENV_VAR = "BIGTABLE_EMULATOR_HOST";
   private static final String ENV_PROPERTY = "bigtable.env";
   private static final String env = System.getProperty(ENV_PROPERTY, "emulator");
 
   private AbstractTestEnv testEnv;
 
+  private Handler grpcLogHandler;
+  private static final Set<String> GRPC_LOGGER_NAMES =
+      ImmutableSet.of("io.grpc", "io.grpc.netty.shaded");
+
   @Override
-  protected void before() throws Throwable {
+  public Statement apply(final Statement base, final Description description) {
+    return new Statement() {
+      public void evaluate() throws Throwable {
+        TestEnvRule.this.before(description);
+
+        try {
+          base.evaluate();
+        } finally {
+          TestEnvRule.this.after();
+        }
+      }
+    };
+  }
+
+  protected void before(Description description) throws Throwable {
     assume()
         .withMessage(
             "Integration tests can't run with the BIGTABLE_EMULATOR_HOST environment variable set"
                 + ". Please use the emulator-it maven profile instead")
         .that(System.getenv())
         .doesNotContainKey(BIGTABLE_EMULATOR_HOST_ENV_VAR);
+
+    configureLogging(description);
 
     switch (env) {
       case "emulator":
@@ -72,8 +109,29 @@ public class TestEnvRule extends ExternalResource {
     testEnv.start();
   }
 
-  @Override
-  protected void after() {
+  private void configureLogging(Description description) throws IOException {
+    if (Strings.isNullOrEmpty(BIGTABLE_GRPC_LOG_DIR)) {
+      return;
+    }
+
+    Files.createDirectories(Paths.get(BIGTABLE_GRPC_LOG_DIR));
+
+    String basename =
+        Joiner.on("-").useForNull("").join(description.getClassName(), description.getMethodName());
+    Path logPath = Paths.get(BIGTABLE_GRPC_LOG_DIR, basename + ".log");
+
+    grpcLogHandler = new FileHandler(logPath.toString());
+    grpcLogHandler.setFormatter(new SimpleFormatter());
+    grpcLogHandler.setLevel(Level.ALL);
+
+    for (String grpcLoggerName : GRPC_LOGGER_NAMES) {
+      Logger logger = Logger.getLogger(grpcLoggerName);
+      logger.setLevel(Level.ALL);
+      logger.addHandler(grpcLogHandler);
+    }
+  }
+
+  private void after() {
     try {
       env().cleanUpStale();
     } catch (Exception e) {
@@ -86,6 +144,19 @@ public class TestEnvRule extends ExternalResource {
       LOGGER.log(Level.WARNING, "Failed to stop the environment", e);
     }
     testEnv = null;
+    teardownLogging();
+  }
+
+  private void teardownLogging() {
+    if (grpcLogHandler == null) {
+      return;
+    }
+
+    for (String grpcLoggerName : GRPC_LOGGER_NAMES) {
+      Logger.getLogger(grpcLoggerName).removeHandler(grpcLogHandler);
+    }
+    grpcLogHandler.flush();
+    grpcLogHandler = null;
   }
 
   public AbstractTestEnv env() {


### PR DESCRIPTION
* Add fine grained grpc logging for integration tests. These will create a grpc log file per test rule invocation, which is effectively per test class
* To avoid interleaving in the logs, parallelize the tests by class
* Parallelize the unit tests as well
