### PR TITLE
chore: fix tests

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -362,10 +362,6 @@
         <artifactId>maven-surefire-plugin</artifactId>
 
         <configuration>
-          <parallel>classes</parallel>
-          <forkCount>2C</forkCount>
-          <reuseForks>true</reuseForks>
-
           <!-- enable the ability to skip unit tests, while running integration tests -->
           <skipTests>${skipUnitTests}</skipTests>
           <trimStackTrace>false</trimStackTrace>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -64,6 +64,11 @@
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
     </dependency>
     <dependency>
@@ -338,7 +343,7 @@
             grpc-grpclb is used at runtime using reflection
             grpc-auth is not directly used transitively, but is pulled to align with other grpc parts
             -->
-          <usedDependencies>io.grpc:grpc-auth,io.grpc:grpc-grpclb</usedDependencies>
+          <usedDependencies>io.grpc:grpc-auth,io.grpc:grpc-grpclb,com.google.auto.value:auto-value</usedDependencies>
         </configuration>
       </plugin>
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableInstanceAdminClientIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableInstanceAdminClientIT.java
@@ -42,7 +42,8 @@ import org.threeten.bp.Instant;
 
 public class BigtableInstanceAdminClientIT {
 
-  @ClassRule public static TestEnvRule testEnvRule = new TestEnvRule();
+  @ClassRule
+  public static TestEnvRule testEnvRule = new TestEnvRule();
 
   private String instanceId = testEnvRule.env().getInstanceId();
   private BigtableInstanceAdminClient client;
@@ -203,7 +204,8 @@ public class BigtableInstanceAdminClientIT {
       Cluster resizeCluster = client.resizeCluster(instanceId, clusterId, freshNumOfNodes);
       assertThat(resizeCluster.getServeNodes()).isEqualTo(freshNumOfNodes);
 
-      assertThat(client.resizeCluster(instanceId, clusterId, existingClusterNodeSize))
+      assertThat(
+          client.resizeCluster(instanceId, clusterId, existingClusterNodeSize).getServeNodes())
           .isEqualTo(existingClusterNodeSize);
     }
   }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableInstanceAdminClientIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableInstanceAdminClientIT.java
@@ -27,6 +27,7 @@ import com.google.cloud.bigtable.admin.v2.models.CreateAppProfileRequest;
 import com.google.cloud.bigtable.admin.v2.models.CreateClusterRequest;
 import com.google.cloud.bigtable.admin.v2.models.CreateInstanceRequest;
 import com.google.cloud.bigtable.admin.v2.models.Instance;
+import com.google.cloud.bigtable.admin.v2.models.Instance.Type;
 import com.google.cloud.bigtable.admin.v2.models.StorageType;
 import com.google.cloud.bigtable.admin.v2.models.UpdateAppProfileRequest;
 import com.google.cloud.bigtable.admin.v2.models.UpdateInstanceRequest;
@@ -42,8 +43,7 @@ import org.threeten.bp.Instant;
 
 public class BigtableInstanceAdminClientIT {
 
-  @ClassRule
-  public static TestEnvRule testEnvRule = new TestEnvRule();
+  @ClassRule public static TestEnvRule testEnvRule = new TestEnvRule();
 
   private String instanceId = testEnvRule.env().getInstanceId();
   private BigtableInstanceAdminClient client;
@@ -111,18 +111,18 @@ public class BigtableInstanceAdminClientIT {
     assertThat(permissions).hasSize(2);
   }
 
+  /** To optimize test run time, instance & cluster creation is tested at the same time */
   @Test
-  public void instanceCreationDeletionTest() {
+  public void instanceAndClusterCreationDeletionTest() {
     String newInstanceId = AbstractTestEnv.TEST_INSTANCE_PREFIX + Instant.now().getEpochSecond();
     String newClusterId = newInstanceId + "-c1";
 
     client.createInstance(
         CreateInstanceRequest.of(newInstanceId)
-            .addDevelopmentCluster(
-                newClusterId, testEnvRule.env().getPrimaryZone(), StorageType.SSD)
+            .addCluster(newClusterId, testEnvRule.env().getPrimaryZone(), 3, StorageType.SSD)
             .setDisplayName("Fresh-Instance-Name")
             .addLabel("state", "readytodelete")
-            .setType(Instance.Type.DEVELOPMENT));
+            .setType(Type.PRODUCTION));
 
     try {
       assertThat(client.exists(newInstanceId)).isTrue();
@@ -135,6 +135,8 @@ public class BigtableInstanceAdminClientIT {
 
       assertThat(client.listInstances()).contains(instance);
 
+      clusterCreationDeletionTestHelper(newInstanceId);
+
       client.deleteInstance(newInstanceId);
       assertThat(client.exists(newInstanceId)).isFalse();
     } finally {
@@ -144,29 +146,25 @@ public class BigtableInstanceAdminClientIT {
     }
   }
 
-  @Test
-  public void clusterCreationDeletionTest() {
-    Instance currentInstance = client.getInstance(instanceId);
-    assume()
-        .withMessage("cluster replication test can only run on PRODUCTION instance")
-        .that(currentInstance.getType())
-        .isEqualTo(Instance.Type.PRODUCTION);
-
+  // To improve test runtime, piggyback off the instance creation/deletion test's fresh instance.
+  // This will avoid the need to copy any existing tables and will also reduce flakiness in case a
+  // previous run failed to clean up a cluster in the secondary zone.
+  public void clusterCreationDeletionTestHelper(String newInstanceId) {
     String newClusterId = AbstractTestEnv.TEST_CLUSTER_PREFIX + Instant.now().getEpochSecond();
     boolean isClusterDeleted = false;
     client.createCluster(
-        CreateClusterRequest.of(instanceId, newClusterId)
+        CreateClusterRequest.of(newInstanceId, newClusterId)
             .setZone(testEnvRule.env().getSecondaryZone())
             .setStorageType(StorageType.SSD)
             .setServeNodes(3));
     try {
-      assertThat(client.getCluster(instanceId, newClusterId)).isNotNull();
+      assertThat(client.getCluster(newInstanceId, newClusterId)).isNotNull();
 
-      client.deleteCluster(instanceId, newClusterId);
+      client.deleteCluster(newInstanceId, newClusterId);
       isClusterDeleted = true;
     } finally {
       if (!isClusterDeleted) {
-        client.deleteCluster(instanceId, newClusterId);
+        client.deleteCluster(newInstanceId, newClusterId);
       }
     }
   }
@@ -205,7 +203,7 @@ public class BigtableInstanceAdminClientIT {
       assertThat(resizeCluster.getServeNodes()).isEqualTo(freshNumOfNodes);
 
       assertThat(
-          client.resizeCluster(instanceId, clusterId, existingClusterNodeSize).getServeNodes())
+              client.resizeCluster(instanceId, clusterId, existingClusterNodeSize).getServeNodes())
           .isEqualTo(existingClusterNodeSize);
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,11 @@
               <artifactId>proto-google-iam-v1</artifactId>
               <version>0.13.0</version>
             </dependency>
+          <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>${autovalue.version}</version>
+          </dependency>
             <dependency>
               <groupId>com.google.auto.value</groupId>
               <artifactId>auto-value-annotations</artifactId>
@@ -345,13 +350,6 @@
                     <target>1.7</target>
                     <encoding>UTF-8</encoding>
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
-                    <annotationProcessorPaths>
-                      <path>
-                        <groupId>com.google.auto.value</groupId>
-                        <artifactId>auto-value</artifactId>
-                        <version>${autovalue.version}</version>
-                      </path>
-                    </annotationProcessorPaths>
                   </configuration>
                 </plugin>
 


### PR DESCRIPTION
* Fix bug in the instance admin IT. This was unnoticed because our presubmits target a development instance (I just changed that)
* Move auto-value back as a provided dep in the main dependency list. This caused issues in intellij when annotation processing was disabled
* Disable concurrent unit tests, it makes the autogen tests flaky