### PR TITLE
chore: update Error message for bad bigtable.env variable

### DIFF
--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/TestEnvRule.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/TestEnvRule.java
@@ -103,7 +103,7 @@ public class TestEnvRule implements TestRule {
       default:
         throw new IllegalArgumentException(
             String.format(
-                "Unknown env: %s. Please set the system property %s to either 'emulator' or 'prod'.",
+                "Unknown env: %s. Please set the system property %s to either 'emulator' or 'cloud'.",
                 env, ENV_PROPERTY));
     }
     testEnv.start();


### PR DESCRIPTION
At some point, the allowed settings were changed from "prod" and "emulator" to "cloud" and "emulator".
This change updates the error message associated to the illegal argument exception.
