### PR TITLE
deps: move auto-value to annotation processor path

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -64,11 +64,6 @@
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
     </dependency>
     <dependency>
@@ -374,6 +369,24 @@
           <!-- enable the ability to skip unit tests, while running integration tests -->
           <skipTests>${skipUnitTests}</skipTests>
           <trimStackTrace>false</trimStackTrace>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+          <encoding>UTF-8</encoding>
+          <compilerArgument>-Xlint:unchecked</compilerArgument>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>${autovalue.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
     </plugins>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -344,7 +344,7 @@
             grpc-grpclb is used at runtime using reflection
             grpc-auth is not directly used transitively, but is pulled to align with other grpc parts
             -->
-          <usedDependencies>io.grpc:grpc-auth,io.grpc:grpc-grpclb,com.google.auto.value:auto-value</usedDependencies>
+          <usedDependencies>io.grpc:grpc-auth,io.grpc:grpc-grpclb</usedDependencies>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -234,11 +234,6 @@
               <artifactId>proto-google-iam-v1</artifactId>
               <version>0.13.0</version>
             </dependency>
-          <dependency>
-            <groupId>com.google.auto.value</groupId>
-            <artifactId>auto-value</artifactId>
-            <version>${autovalue.version}</version>
-          </dependency>
             <dependency>
               <groupId>com.google.auto.value</groupId>
               <artifactId>auto-value-annotations</artifactId>


### PR DESCRIPTION
This removes `auto-value` from the dependencies - `auto-value` is only needed at compile time. `auto-value-annotations` remains as a dependency.