### PR TITLE
feat: add experimental channel refreshing

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
@@ -184,6 +184,12 @@ public final class BigtableDataSettings {
     return stubSettings.getAppProfileId();
   }
 
+  /** Gets if channels will gracefully refresh connections to Cloud Bigtable service */
+  @BetaApi("This API depends on experimental gRPC APIs")
+  public boolean isRefreshingChannel() {
+    return stubSettings.isRefreshingChannel();
+  }
+
   /** Returns the underlying RPC settings. */
   public EnhancedBigtableStubSettings getStubSettings() {
     return stubSettings;
@@ -273,6 +279,26 @@ public final class BigtableDataSettings {
     /** Gets the CredentialsProvider to use for getting the credentials to make calls with. */
     public CredentialsProvider getCredentialsProvider() {
       return stubSettings.getCredentialsProvider();
+    }
+
+    /**
+     * Configure periodic gRPC channel refreshes.
+     *
+     * <p>This feature will gracefully refresh connections to the Cloud Bigtable service. This is an
+     * experimental feature to address tail latency caused by the service dropping long lived gRPC
+     * connections, which causes the client to renegotiate the gRPC connection in the request path,
+     * which causes periodic spikes in latency
+     */
+    @BetaApi("This API depends on experimental gRPC APIs")
+    public Builder setRefreshingChannel(boolean isRefreshingChannel) {
+      stubSettings.setRefreshingChannel(isRefreshingChannel);
+      return this;
+    }
+
+    /** Gets if channels will gracefully refresh connections to Cloud Bigtable service */
+    @BetaApi("This API depends on experimental gRPC APIs")
+    public boolean isRefreshingChannel() {
+      return stubSettings.isRefreshingChannel();
     }
 
     /**

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/RefreshChannel.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/RefreshChannel.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.data.v2.internal;
+
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.grpc.ChannelPrimer;
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannel;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Establish a connection to the Cloud Bigtable service on managedChannel
+ *
+ * <p>This class is considered an internal implementation detail and not meant to be used by
+ * applications.
+ */
+@BetaApi("This API depends on gRPC experimental API")
+@InternalApi
+public final class RefreshChannel implements ChannelPrimer {
+
+  /**
+   * primeChannel establishes a connection to Cloud Bigtable service. This typically take less than
+   * 1s. In case of service failure, an upper limit of 10s prevents primeChannel from looping
+   * forever.
+   */
+  @Override
+  public void primeChannel(ManagedChannel managedChannel) {
+    for (int i = 0; i < 10; i++) {
+      ConnectivityState connectivityState = managedChannel.getState(true);
+      if (connectivityState == ConnectivityState.READY) {
+        break;
+      }
+      try {
+        TimeUnit.SECONDS.sleep(1);
+      } catch (InterruptedException e) {
+        break;
+      }
+    }
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/RefreshChannelTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/RefreshChannelTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.data.v2.internal;
+
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannel;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class RefreshChannelTest {
+  // RefreshChannel should establish connection to the server through managedChannel.getState(true)
+  @Test
+  public void testGetStateIsCalled() {
+    RefreshChannel refreshChannel = new RefreshChannel();
+    ManagedChannel managedChannel = Mockito.mock(ManagedChannel.class);
+
+    Mockito.doReturn(ConnectivityState.READY).when(managedChannel).getState(true);
+
+    refreshChannel.primeChannel(managedChannel);
+    Mockito.verify(managedChannel, Mockito.atLeastOnce()).getState(true);
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettingsTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettingsTest.java
@@ -61,6 +61,7 @@ public class EnhancedBigtableStubSettingsTest {
     String projectId = "my-project";
     String instanceId = "my-instance";
     String appProfileId = "my-app-profile-id";
+    boolean isRefreshingChannel = true;
     String endpoint = "some.other.host:123";
     CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
     WatchdogProvider watchdogProvider = Mockito.mock(WatchdogProvider.class);
@@ -71,6 +72,7 @@ public class EnhancedBigtableStubSettingsTest {
             .setProjectId(projectId)
             .setInstanceId(instanceId)
             .setAppProfileId(appProfileId)
+            .setRefreshingChannel(isRefreshingChannel)
             .setEndpoint(endpoint)
             .setCredentialsProvider(credentialsProvider)
             .setStreamWatchdogProvider(watchdogProvider)
@@ -81,6 +83,7 @@ public class EnhancedBigtableStubSettingsTest {
         projectId,
         instanceId,
         appProfileId,
+        isRefreshingChannel,
         endpoint,
         credentialsProvider,
         watchdogProvider,
@@ -90,6 +93,7 @@ public class EnhancedBigtableStubSettingsTest {
         projectId,
         instanceId,
         appProfileId,
+        isRefreshingChannel,
         endpoint,
         credentialsProvider,
         watchdogProvider,
@@ -99,6 +103,7 @@ public class EnhancedBigtableStubSettingsTest {
         projectId,
         instanceId,
         appProfileId,
+        isRefreshingChannel,
         endpoint,
         credentialsProvider,
         watchdogProvider,
@@ -110,6 +115,7 @@ public class EnhancedBigtableStubSettingsTest {
       String projectId,
       String instanceId,
       String appProfileId,
+      boolean isRefreshingChannel,
       String endpoint,
       CredentialsProvider credentialsProvider,
       WatchdogProvider watchdogProvider,
@@ -117,6 +123,7 @@ public class EnhancedBigtableStubSettingsTest {
     assertThat(builder.getProjectId()).isEqualTo(projectId);
     assertThat(builder.getInstanceId()).isEqualTo(instanceId);
     assertThat(builder.getAppProfileId()).isEqualTo(appProfileId);
+    assertThat(builder.isRefreshingChannel()).isEqualTo(isRefreshingChannel);
     assertThat(builder.getEndpoint()).isEqualTo(endpoint);
     assertThat(builder.getCredentialsProvider()).isEqualTo(credentialsProvider);
     assertThat(builder.getStreamWatchdogProvider()).isSameInstanceAs(watchdogProvider);
@@ -128,6 +135,7 @@ public class EnhancedBigtableStubSettingsTest {
       String projectId,
       String instanceId,
       String appProfileId,
+      boolean isRefreshingChannel,
       String endpoint,
       CredentialsProvider credentialsProvider,
       WatchdogProvider watchdogProvider,
@@ -135,6 +143,7 @@ public class EnhancedBigtableStubSettingsTest {
     assertThat(settings.getProjectId()).isEqualTo(projectId);
     assertThat(settings.getInstanceId()).isEqualTo(instanceId);
     assertThat(settings.getAppProfileId()).isEqualTo(appProfileId);
+    assertThat(settings.isRefreshingChannel()).isEqualTo(isRefreshingChannel);
     assertThat(settings.getEndpoint()).isEqualTo(endpoint);
     assertThat(settings.getCredentialsProvider()).isEqualTo(credentialsProvider);
     assertThat(settings.getStreamWatchdogProvider()).isSameInstanceAs(watchdogProvider);
@@ -520,5 +529,32 @@ public class EnhancedBigtableStubSettingsTest {
     assertThat(retrySettings.getInitialRpcTimeout()).isGreaterThan(Duration.ZERO);
     assertThat(retrySettings.getRpcTimeoutMultiplier()).isAtLeast(1.0);
     assertThat(retrySettings.getMaxRpcTimeout()).isGreaterThan(Duration.ZERO);
+  }
+
+  @Test
+  public void isRefreshingChannelDefaultValueTest() {
+    String dummyProjectId = "my-project";
+    String dummyInstanceId = "my-instance";
+    EnhancedBigtableStubSettings.Builder builder =
+        EnhancedBigtableStubSettings.newBuilder()
+            .setProjectId(dummyProjectId)
+            .setInstanceId(dummyInstanceId);
+    assertThat(builder.isRefreshingChannel()).isFalse();
+    assertThat(builder.build().isRefreshingChannel()).isFalse();
+    assertThat(builder.build().toBuilder().isRefreshingChannel()).isFalse();
+  }
+
+  @Test
+  public void isRefreshingChannelFalseValueTest() {
+    String dummyProjectId = "my-project";
+    String dummyInstanceId = "my-instance";
+    EnhancedBigtableStubSettings.Builder builder =
+        EnhancedBigtableStubSettings.newBuilder()
+            .setProjectId(dummyProjectId)
+            .setInstanceId(dummyInstanceId)
+            .setRefreshingChannel(false);
+    assertThat(builder.isRefreshingChannel()).isFalse();
+    assertThat(builder.build().isRefreshingChannel()).isFalse();
+    assertThat(builder.build().toBuilder().isRefreshingChannel()).isFalse();
   }
 }


### PR DESCRIPTION
Implement ChannelPrimer to establish connection to the GFE so bigtable client will reconnect to the Cloud Bigtable service periodically before the connection gets terminated.