### PR TITLE
deps: upgrade gax to 1.52.0, google-cloud-core to 1.92.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,10 +154,10 @@
         <project.javadoc.protobufBaseURL>https://googleapis.dev/java/google-api-grpc/latest</project.javadoc.protobufBaseURL>
 
         <autovalue.version>1.7</autovalue.version>
-        <gax.version>1.51.0</gax.version>
+        <gax.version>1.52.0</gax.version>
         <google.api-common.version>1.8.1</google.api-common.version>
         <google.common-protos.version>1.17.0</google.common-protos.version>
-        <google.core.version>1.91.3</google.core.version>
+        <google.core.version>1.92.0</google.core.version>
          <!-- make sure to update the grpc version in README -->
         <grpc.version>1.25.0</grpc.version>
         <guava.version>28.1-android</guava.version>


### PR DESCRIPTION
Combining #116 and #117 