### PR TITLE
chore: use prod endpoint for directpath tests

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -24,10 +24,10 @@
 
     <!-- Use client defined default endpoints -->
     <!-- Can be overriden on the commandline via `-Dbigtable.cfe-data-endpoint=bigtableadmin.googleapis.com:443` -->
-    <bigtable.cfe-data-endpoint></bigtable.cfe-data-endpoint>
-    <bigtable.cfe-admin-endpoint></bigtable.cfe-admin-endpoint>
-    <bigtable.directpath-data-endpoint></bigtable.directpath-data-endpoint>
-    <bigtable.directpath-admin-endpoint></bigtable.directpath-admin-endpoint>
+    <bigtable.cfe-data-endpoint/>
+    <bigtable.cfe-admin-endpoint/>
+    <bigtable.directpath-data-endpoint/>
+    <bigtable.directpath-admin-endpoint/>
   </properties>
   <dependencies>
     <!-- NOTE: Dependencies are organized into two groups, production and test.

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -22,11 +22,12 @@
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
 
-    <bigtable.cfe-data-endpoint>bigtable.googleapis.com:443</bigtable.cfe-data-endpoint>
-    <bigtable.cfe-admin-endpoint>bigtableadmin.googleapis.com:443</bigtable.cfe-admin-endpoint>
-
-    <bigtable.directpath-data-endpoint>directpath-bigtable.googleapis.com:443</bigtable.directpath-data-endpoint>
-    <bigtable.directpath-admin-endpoint>bigtableadmin.googleapis.com:443</bigtable.directpath-admin-endpoint>
+    <!-- Use client defined default endpoints -->
+    <!-- Can be overriden on the commandline via `-Dbigtable.cfe-data-endpoint=bigtableadmin.googleapis.com:443` -->
+    <bigtable.cfe-data-endpoint></bigtable.cfe-data-endpoint>
+    <bigtable.cfe-admin-endpoint></bigtable.cfe-admin-endpoint>
+    <bigtable.directpath-data-endpoint></bigtable.directpath-data-endpoint>
+    <bigtable.directpath-admin-endpoint></bigtable.directpath-admin-endpoint>
   </properties>
   <dependencies>
     <!-- NOTE: Dependencies are organized into two groups, production and test.

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -25,9 +25,8 @@
     <bigtable.cfe-data-endpoint>bigtable.googleapis.com:443</bigtable.cfe-data-endpoint>
     <bigtable.cfe-admin-endpoint>bigtableadmin.googleapis.com:443</bigtable.cfe-admin-endpoint>
 
-    <!-- Use test DP env until prod endpoint is available -->
-    <bigtable.directpath-data-endpoint>testdirectpath-bigtable.sandbox.googleapis.com:443</bigtable.directpath-data-endpoint>
-    <bigtable.directpath-admin-endpoint>test-bigtableadmin.sandbox.googleapis.com:443</bigtable.directpath-admin-endpoint>
+    <bigtable.directpath-data-endpoint>directpath-bigtable.googleapis.com:443</bigtable.directpath-data-endpoint>
+    <bigtable.directpath-admin-endpoint>bigtableadmin.googleapis.com:443</bigtable.directpath-admin-endpoint>
   </properties>
   <dependencies>
     <!-- NOTE: Dependencies are organized into two groups, production and test.

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/SimpleGceRawRead.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/SimpleGceRawRead.java
@@ -66,17 +66,13 @@ public class SimpleGceRawRead {
         ComputeEngineChannelBuilder.forAddress(endpoint, 443)
             .disableServiceConfigLookUp()
             .defaultServiceConfig(newServiceConfig())
-            .maxInboundMessageSize(256 * 1024 * 1024)
             .build();
     try {
       BigtableGrpc.BigtableBlockingStub stub = BigtableGrpc.newBlockingStub(channel);
 
       Iterator<ReadRowsResponse> iter =
           stub.readRows(
-              ReadRowsRequest.newBuilder()
-                  .setTableName(tableName)
-                  .setRowsLimit(1).build()
-          );
+              ReadRowsRequest.newBuilder().setTableName(tableName).setRowsLimit(1).build());
       System.out.printf("%n%n>>>>>>>>> Success Rows Read: %d%n%n", Lists.newArrayList(iter).size());
     } finally {
       channel.shutdown();

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/SimpleGceRawRead.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/SimpleGceRawRead.java
@@ -66,13 +66,17 @@ public class SimpleGceRawRead {
         ComputeEngineChannelBuilder.forAddress(endpoint, 443)
             .disableServiceConfigLookUp()
             .defaultServiceConfig(newServiceConfig())
+            .maxInboundMessageSize(256 * 1024 * 1024)
             .build();
     try {
       BigtableGrpc.BigtableBlockingStub stub = BigtableGrpc.newBlockingStub(channel);
 
       Iterator<ReadRowsResponse> iter =
           stub.readRows(
-              ReadRowsRequest.newBuilder().setTableName(tableName).setRowsLimit(1).build());
+              ReadRowsRequest.newBuilder()
+                  .setTableName(tableName)
+                  .setRowsLimit(1).build()
+          );
       System.out.printf("%n%n>>>>>>>>> Success Rows Read: %d%n%n", Lists.newArrayList(iter).size());
     } finally {
       channel.shutdown();

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
@@ -22,6 +22,7 @@ import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Strings;
 import java.io.IOException;
 import javax.annotation.Nullable;
 
@@ -57,8 +58,8 @@ class CloudEnv extends AbstractTestEnv {
 
   static CloudEnv fromSystemProperties() {
     return new CloudEnv(
-        getOptionalProperty(DATA_ENDPOINT_PROPERTY_NAME, "bigtable.googleapis.com:443"),
-        getOptionalProperty(ADMIN_ENDPOINT_PROPERTY_NAME, "bigtableadmin.googleapis.com:443"),
+        getOptionalProperty(DATA_ENDPOINT_PROPERTY_NAME, ""),
+        getOptionalProperty(ADMIN_ENDPOINT_PROPERTY_NAME, ""),
         getRequiredProperty(PROJECT_PROPERTY_NAME),
         getRequiredProperty(INSTANCE_PROPERTY_NAME),
         getRequiredProperty(TABLE_PROPERTY_NAME));
@@ -76,18 +77,18 @@ class CloudEnv extends AbstractTestEnv {
 
     this.dataSettings =
         BigtableDataSettings.newBuilder().setProjectId(projectId).setInstanceId(instanceId);
-    if (dataEndpoint != null) {
+    if (!Strings.isNullOrEmpty(dataEndpoint)) {
       dataSettings.stubSettings().setEndpoint(dataEndpoint);
     }
 
     this.tableAdminSettings =
         BigtableTableAdminSettings.newBuilder().setProjectId(projectId).setInstanceId(instanceId);
-    if (adminEndpoint != null) {
+    if (!Strings.isNullOrEmpty(adminEndpoint)) {
       this.tableAdminSettings.stubSettings().setEndpoint(adminEndpoint);
     }
 
     this.instanceAdminSettings = BigtableInstanceAdminSettings.newBuilder().setProjectId(projectId);
-    if (adminEndpoint != null) {
+    if (!Strings.isNullOrEmpty(adminEndpoint)) {
       this.instanceAdminSettings.stubSettings().setEndpoint(adminEndpoint);
     }
   }


### PR DESCRIPTION
directpath-bigtable.googleapis.com is now available