### PR TITLE
feat: introduce google-cloud-bigtable-deps-bom

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Add the following to your project's pom.xml.
         <dependency>
           <groupId>io.grpc</groupId>
           <artifactId>grpc-bom</artifactId>
-          <version>1.24.1</version>
+          <version>1.26.0</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>

--- a/google-cloud-bigtable-deps-bom/README.md
+++ b/google-cloud-bigtable-deps-bom/README.md
@@ -32,8 +32,8 @@ Example usage:
 </dependencyManagement>
 
 <dependencies>
-  <!-- Declare dependency on google-cloud-client, combined with the above this will ensure a
-    consistent set of dependencies --> 
+  <!-- Declare dependency on google-cloud-client, combined with the above this will
+    ensure a consistent set of dependencies --> 
   <dependency>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-bigtable</artifactId>

--- a/google-cloud-bigtable-deps-bom/README.md
+++ b/google-cloud-bigtable-deps-bom/README.md
@@ -5,3 +5,40 @@ this BOM is complementary to google-cloud-bigtable-bom. This BOM only contains t
 while google-cloud-bigtable-bom contains versions for direct google-cloud-bigtable artifacts.
 
 This BOM is primarily intended to be used by java-bigtable-hbase to keep the dependencies in sync.
+
+Example usage:
+
+[//]: # ({x-version-update-start:google-cloud-bigtable:released})
+```xml
+<dependencyManagement>
+  <dependencies>
+    <!-- Lock google-cloud-bigtable direct dependency versions -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable-bom</artifactId>
+      <version>1.8.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+    <!-- Lock google-cloud-bigtable transitive dependency versions -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+      <version>1.8.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <!-- Declare dependency on google-cloud-client, combined with the above this will ensure a
+    consistent set of dependencies --> 
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-bigtable</artifactId>
+  </dependency>
+</dependencies>
+
+```
+[//]: # ({x-version-update-end})

--- a/google-cloud-bigtable-deps-bom/README.md
+++ b/google-cloud-bigtable-deps-bom/README.md
@@ -1,0 +1,7 @@
+# Dependency BOM for Google Cloud Bigtable Client
+
+This module contains a BOM that lists all of Cloud Bigtable's dependency versions. Please note that
+this BOM is complementary to google-cloud-bigtable-bom. This BOM only contains transitive dependencies,
+while google-cloud-bigtable-bom contains versions for direct google-cloud-bigtable artifacts.
+
+This BOM is primarily intended to be used by java-bigtable-hbase to keep the dependencies in sync.

--- a/google-cloud-bigtable-deps-bom/pom.xml
+++ b/google-cloud-bigtable-deps-bom/pom.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-shared-config</artifactId>
+    <version>0.3.0</version>
+  </parent>
+
+  <groupId>com.google.cloud</groupId>
+  <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+  <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+
+  <packaging>pom</packaging>
+  <description>
+    A BOM that describes all of the dependencies used by google-cloud-bigtable. It's
+    mainly intended to be used by java-bigtable-hbase to align dependencies
+  </description>
+
+  <organization>
+    <name>Google LLC</name>
+  </organization>
+
+  <developers>
+    <developer>
+      <id>igorberstein</id>
+      <name>Igor Bernstein</name>
+      <email>igorbernstein@google.com</email>
+      <organization>Google LLC</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>kolea2</id>
+      <name>Kristen O'Leary</name>
+      <email>kaoleary@google.com</email>
+      <organization>Google LLC</organization>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/googleapis/java-bigtable.git</connection>
+    <developerConnection>scm:git:git@github.com:googleapis/java-bigtable.git</developerConnection>
+    <url>https://github.com/googleapis/java-bigtable</url>
+  </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <properties>
+    <autovalue.version>1.7</autovalue.version>
+    <!-- when updating, make sure to align the versions of transitive deps below -->
+    <gax.version>1.52.0</gax.version>
+    <google.api-common.version>1.8.1</google.api-common.version>
+    <google.common-protos.version>1.17.0</google.common-protos.version>
+    <google.core.version>1.92.0</google.core.version>
+    <google.auth.version>0.19.0</google.auth.version>
+    <!-- make sure to update the grpc version in README -->
+    <grpc.version>1.26.0</grpc.version>
+    <guava.version>28.2-android</guava.version>
+    <opencensus.version>0.24.0</opencensus.version>
+    <protobuf.version>3.11.1</protobuf.version>
+    <threeten.version>1.4.0</threeten.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- BOMs, in alphabetical order -->
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-bom</artifactId>
+        <version>${gax.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-bom</artifactId>
+        <version>${google.auth.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-bom</artifactId>
+        <version>${guava.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${grpc.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Production dependency version definitions in alphabetical order -->
+      <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>api-common</artifactId>
+        <version>${google.api-common.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-common-protos</artifactId>
+        <version>${google.common-protos.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-iam-v1</artifactId>
+        <version>0.13.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auto.value</groupId>
+        <artifactId>auto-value</artifactId>
+        <version>${autovalue.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auto.value</groupId>
+        <artifactId>auto-value-annotations</artifactId>
+        <version>${autovalue.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-core</artifactId>
+        <version>${google.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-core-grpc</artifactId>
+        <version>${google.core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>2.3.4</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java-util</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opencensus</groupId>
+        <artifactId>opencensus-api</artifactId>
+        <version>${opencensus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-annotations</artifactId>
+        <version>1.18</version>
+      </dependency>
+      <dependency>
+        <groupId>org.threeten</groupId>
+        <artifactId>threetenbp</artifactId>
+        <version>${threeten.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <!-- Using maven site plugin only as a hook for javadoc:aggregate, don't need the reports -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+
+        <configuration>
+          <generateReports>false</generateReports>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/google-cloud-bigtable-emulator/pom.xml
+++ b/google-cloud-bigtable-emulator/pom.xml
@@ -75,6 +75,25 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- Compile deps in alphabetical order -->
     <dependency>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -29,6 +29,26 @@
     <bigtable.directpath-data-endpoint/>
     <bigtable.directpath-admin-endpoint/>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- NOTE: Dependencies are organized into two groups, production and test.
          Within a group, dependencies are sorted by (groupId, artifactId) -->

--- a/grpc-google-cloud-bigtable-admin-v2/pom.xml
+++ b/grpc-google-cloud-bigtable-admin-v2/pom.xml
@@ -12,6 +12,26 @@
     <artifactId>google-cloud-bigtable-parent</artifactId>
     <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
   </parent>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/grpc-google-cloud-bigtable-v2/pom.xml
+++ b/grpc-google-cloud-bigtable-v2/pom.xml
@@ -12,6 +12,26 @@
     <artifactId>google-cloud-bigtable-parent</artifactId>
     <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
   </parent>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,156 +152,11 @@
         <github.global.server>github</github.global.server>
         <site.installationModule>google-cloud-bigtable-parent</site.installationModule>
         <project.javadoc.protobufBaseURL>https://googleapis.dev/java/google-api-grpc/latest</project.javadoc.protobufBaseURL>
-
-        <autovalue.version>1.7</autovalue.version>
-        <gax.version>1.52.0</gax.version>
-        <google.api-common.version>1.8.1</google.api-common.version>
-        <google.common-protos.version>1.17.0</google.common-protos.version>
-        <google.core.version>1.92.0</google.core.version>
-         <!-- make sure to update the grpc version in README -->
-        <grpc.version>1.26.0</grpc.version>
-        <guava.version>28.2-android</guava.version>
-        <opencensus.version>0.24.0</opencensus.version>
-        <protobuf.version>3.11.1</protobuf.version>
-        <threeten.version>1.4.0</threeten.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!-- BOMs, in alphabetical order -->
-            <dependency>
-              <groupId>com.google.api</groupId>
-              <artifactId>gax-bom</artifactId>
-              <version>${gax.version}</version>
-              <type>pom</type>
-              <scope>import</scope>
-            </dependency>
-            <dependency>
-              <groupId>com.google.guava</groupId>
-              <artifactId>guava-bom</artifactId>
-              <version>${guava.version}</version>
-              <type>pom</type>
-              <scope>import</scope>
-            </dependency>
-            <dependency>
-              <groupId>io.grpc</groupId>
-              <artifactId>grpc-bom</artifactId>
-              <version>${grpc.version}</version>
-              <type>pom</type>
-              <scope>import</scope>
-            </dependency>
-
-            <!-- Child Modules, in alphabetical order -->
-            <dependency>
-              <groupId>com.google.cloud</groupId>
-              <artifactId>google-cloud-bigtable-emulator</artifactId>
-              <version>0.117.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable-emulator:current} -->
-            </dependency>
-            <dependency>
-              <groupId>com.google.api.grpc</groupId>
-              <artifactId>grpc-google-cloud-bigtable-admin-v2</artifactId>
-              <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-bigtable-admin-v2:current} -->
-            </dependency>
-            <dependency>
-              <groupId>com.google.api.grpc</groupId>
-              <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
-              <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-bigtable-v2:current} -->
-            </dependency>
-            <dependency>
-              <groupId>com.google.api.grpc</groupId>
-              <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
-              <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-bigtable-admin-v2:current} -->
-            </dependency>
-            <dependency>
-              <groupId>com.google.api.grpc</groupId>
-              <artifactId>proto-google-cloud-bigtable-v2</artifactId>
-              <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-bigtable-v2:current} -->
-            </dependency>
-
-            <!-- Production dependency version definitions in alphabetical order -->
-            <dependency>
-              <groupId>com.google.api</groupId>
-              <artifactId>api-common</artifactId>
-              <version>${google.api-common.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>com.google.api.grpc</groupId>
-              <artifactId>proto-google-common-protos</artifactId>
-              <version>${google.common-protos.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>com.google.api.grpc</groupId>
-              <artifactId>proto-google-iam-v1</artifactId>
-              <version>0.13.0</version>
-            </dependency>
-          <dependency>
-            <groupId>com.google.auto.value</groupId>
-            <artifactId>auto-value</artifactId>
-            <version>${autovalue.version}</version>
-          </dependency>
-            <dependency>
-              <groupId>com.google.auto.value</groupId>
-              <artifactId>auto-value-annotations</artifactId>
-              <version>${autovalue.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-core</artifactId>
-              <version>${google.core.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>com.google.cloud</groupId>
-              <artifactId>google-cloud-core-grpc</artifactId>
-              <version>${google.core.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_annotations</artifactId>
-              <version>2.3.4</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>3.0.2</version>
-            </dependency>
-            <dependency>
-              <groupId>com.google.protobuf</groupId>
-              <artifactId>protobuf-java</artifactId>
-              <version>${protobuf.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>com.google.protobuf</groupId>
-              <artifactId>protobuf-java-util</artifactId>
-              <version>${protobuf.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>io.opencensus</groupId>
-              <artifactId>opencensus-api</artifactId>
-              <version>${opencensus.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>javax.annotation</groupId>
-              <artifactId>javax.annotation-api</artifactId>
-              <version>1.3.2</version>
-            </dependency>
-            <dependency>
-              <groupId>org.codehaus.mojo</groupId>
-              <artifactId>animal-sniffer-annotations</artifactId>
-              <version>1.18</version>
-            </dependency>
-            <dependency>
-              <groupId>org.threeten</groupId>
-              <artifactId>threetenbp</artifactId>
-              <version>${threeten.version}</version>
-            </dependency>
-
             <!-- Test Deps in alphabetical order -->
-            <dependency>
-              <groupId>com.google.api</groupId>
-              <artifactId>gax-grpc</artifactId>
-              <version>${gax.version}</version>
-              <classifier>testlib</classifier>
-            </dependency>
             <dependency>
               <groupId>com.google.cloud</groupId>
               <artifactId>google-cloud-conformance-tests</artifactId>
@@ -462,5 +317,6 @@
         <module>google-cloud-bigtable</module>
         <module>google-cloud-bigtable-emulator</module>
         <module>google-cloud-bigtable-bom</module>
+        <module>google-cloud-bigtable-deps-bom</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,8 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Production Deps have been moved to google-cloud-bigtable-deps-bom -->
+
             <!-- Test Deps in alphabetical order -->
             <dependency>
               <groupId>com.google.cloud</groupId>

--- a/proto-google-cloud-bigtable-admin-v2/pom.xml
+++ b/proto-google-cloud-bigtable-admin-v2/pom.xml
@@ -12,6 +12,26 @@
     <artifactId>google-cloud-bigtable-parent</artifactId>
     <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
   </parent>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.google.api</groupId>

--- a/proto-google-cloud-bigtable-v2/pom.xml
+++ b/proto-google-cloud-bigtable-v2/pom.xml
@@ -12,6 +12,26 @@
     <artifactId>google-cloud-bigtable-parent</artifactId>
     <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
   </parent>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-bom</artifactId>
+        <version>1.8.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.google.api</groupId>


### PR DESCRIPTION
Move all of the dependency version management out of the root pom and into a separate BOM.
This will allow java-bigtable-hbase to sync on dependency versions with java-bigtable.

In addition to moving the dependencyManagement section to a BOM, I imported `google-auth-library-bom` and fixed the README to point to the correct version of gRPC