### PR TITLE
build(deps): manually update dependency com.google.cloud:google-cloud-shared-config to v0.3.1

### DIFF
--- a/google-cloud-bigtable-bom/pom.xml
+++ b/google-cloud-bigtable-bom/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-config</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
 
     <name>Google Cloud Bigtable BOM</name>

--- a/google-cloud-bigtable-deps-bom/pom.xml
+++ b/google-cloud-bigtable-deps-bom/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1</version>
   </parent>
 
   <groupId>com.google.cloud</groupId>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -381,6 +381,7 @@
 
           <parallel>classes</parallel>
           <forkCount>2C</forkCount>
+          <threadCount>1</threadCount>
           <reuseForks>true</reuseForks>
 
           <trimStackTrace>false</trimStackTrace>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-config</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
 
     <developers>


### PR DESCRIPTION
This is a counter PR for https://github.com/googleapis/java-bigtable/pull/133 that fixes the failsafe config

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for context and/or discussion)