### PR TITLE
chore: remove checkstyle plugin from pom after shared config update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,31 +200,15 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                  <artifactId>maven-compiler-plugin</artifactId>
-                  <version>3.5.1</version>
-                  <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                    <encoding>UTF-8</encoding>
-                    <compilerArgument>-Xlint:unchecked</compilerArgument>
-                  </configuration>
-                </plugin>
-
-                  <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.5.1</version>
                     <configuration>
-                      <sourceDirectories>
-                        <!-- TODO: pull this into google-cloud-shared-config -->
-                        <!-- Explicitly set the source directory to avoid running checkstyle on generated sources. -->
-                        <sourceDirectory>src/main/java</sourceDirectory>
-                      </sourceDirectories>
-                      <testSourceDirectories>
-                        <testSourceDirectory>src/test/java</testSourceDirectory>
-                      </testSourceDirectories>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                        <encoding>UTF-8</encoding>
+                        <compilerArgument>-Xlint:unchecked</compilerArgument>
                     </configuration>
-                  </plugin>
-
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
The checkstyle settings in our pom.xml were added to the shared config and can now be deleted here.

Also some minor whitespace reformatting