### PR TITLE
chore: force compute engine creds for directpath test

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -83,6 +83,10 @@
       <artifactId>proto-google-iam-v1</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
       <scope>provided</scope>

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
@@ -19,7 +19,9 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.TruthJUnit.assume;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
@@ -52,6 +54,9 @@ import org.junit.runners.JUnit4;
 /**
  * Test DirectPath fallback behavior by injecting a ChannelHandler into the netty stack that will
  * disrupt IPv6 communications.
+ *
+ * <p>WARNING: this test can only be run on a GCE VM and will explicitly ignore
+ * GOOGLE_APPLICATION_CREDENTIALS and use the service account associated with the VM.
  */
 @RunWith(JUnit4.class)
 public class DirectPathFallbackIT {
@@ -111,7 +116,9 @@ public class DirectPathFallbackIT {
 
     settingsBuilder
         .stubSettings()
-        .setTransportChannelProvider(instrumentedTransportChannelProvider);
+        .setTransportChannelProvider(instrumentedTransportChannelProvider)
+        // Forcefully ignore GOOGLE_APPLICATION_CREDENTIALS
+        .setCredentialsProvider(FixedCredentialsProvider.create(ComputeEngineCredentials.create()));
 
     instrumentedClient = BigtableDataClient.create(settingsBuilder.build());
   }


### PR DESCRIPTION
DirectPath requires compute channel credentials. If any other credentials are set, then it will silently fallback to cloud path.  The DirectPathFallbackIT requires the connection to use DirectPath, however kokoro currently configures GOOGLE_APPLICATION_CREDENTIALS for all tests. So this PR forcefully sets the credentials provider to be ComputeEngineCredentials