### PR TITLE
chore: add filter size check on read row request

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Query.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Query.java
@@ -167,9 +167,11 @@ public final class Query implements Serializable {
    */
   public Query filter(Filters.Filter filter) {
     Preconditions.checkNotNull(filter, "filter can't be null");
+
     RowFilter rowFilter = filter.toProto();
     Preconditions.checkArgument(
         rowFilter.getSerializedSize() < MAX_FILTER_SIZE, "filter size can't be more than 20MB");
+
     builder.setFilter(rowFilter);
     return this;
   }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/QueryTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/QueryTest.java
@@ -113,7 +113,7 @@ public class QueryTest {
   }
 
   @Test
-  public void filterTestWithNull() {
+  public void filterTestWithExceptions() {
     Exception actualException = null;
     try {
       Query.create(TABLE_ID).filter(null);
@@ -121,6 +121,17 @@ public class QueryTest {
       actualException = ex;
     }
     assertThat(actualException).isInstanceOf(NullPointerException.class);
+
+    actualException = null;
+    int maxFilterSize = 20 * 1024 * 1024;
+    ByteString largeValue = ByteString.copyFrom(new byte[maxFilterSize + 1]);
+
+    try {
+      Query.create(TABLE_ID).filter(FILTERS.value().exactMatch(largeValue));
+    } catch (Exception ex) {
+      actualException = ex;
+    }
+    assertThat(actualException).hasMessageThat().contains("filter size can't be more than 20MB");
   }
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/QueryTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/QueryTest.java
@@ -113,6 +113,17 @@ public class QueryTest {
   }
 
   @Test
+  public void filterTestWithNull() {
+    Exception actualException = null;
+    try {
+      Query.create(TABLE_ID).filter(null);
+    } catch (Exception ex) {
+      actualException = ex;
+    }
+    assertThat(actualException).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
   public void filterTest() {
     Query query = Query.create(TABLE_ID).filter(FILTERS.key().regex(".*"));
 


### PR DESCRIPTION
Currently, bigtable could only serve read row requests with the filter size of 20MB. Adding this check to prevent failure.