### PR TITLE
deps: dependency order matters

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -51,8 +51,7 @@
   </dependencyManagement>
 
   <dependencies>
-    <!-- NOTE: Dependencies are organized into two groups, production and test.
-         Within a group, dependencies are sorted by (groupId, artifactId) -->
+    <!-- NOTE: Dependencies are organized into two groups, production and test. -->
 
     <!-- Production dependencies -->
     <dependency>


### PR DESCRIPTION
@kolea2 not going to reorder these right now, but in maven dependency order is significant, and we've been taking advantage of that to fix some dependency issues. We should not promise to sort them alphabetically.
