### PR TITLE
chore: ensure that transitive deps have the latest version selected

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -366,7 +366,7 @@
           </execution>
           <!-- Ensure that greatest version of each transitive dependency got selected -->
           <execution>
-            <id>enforce-dependencu-upper-bound</id>
+            <id>enforce-dependency-upper-bound</id>
             <configuration>
               <rules>
                 <requireUpperBoundDeps/>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -352,7 +352,7 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.0.0-M3</version>
         <executions>
-          <!-- Prevent users from mistypig a profile name -->
+          <!-- Prevent users from mistyping a profile name -->
           <execution>
             <id>enforce-valid-profile</id>
             <configuration>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -352,11 +352,24 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.0.0-M3</version>
         <executions>
+          <!-- Prevent users from mistypig a profile name -->
           <execution>
             <id>enforce-valid-profile</id>
             <configuration>
               <rules>
                 <requireProfileIdsExist/>
+              </rules>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+          <!-- Ensure that greatest version of each transitive dependency got selected -->
+          <execution>
+            <id>enforce-dependencu-upper-bound</id>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps/>
               </rules>
             </configuration>
             <goals>


### PR DESCRIPTION
This should mitigate diamond dependency issues.
Gradle and maven have different behaviors when resolving transitive dependency version conflicts. Gradle selects the greatest version, while maven picks the closest in the dependency hierarchy. For example:
Say http-client and google-auth-library pull in different versions of Apache commons logging at the same depth. Then which one your project gets depends on whether you depend on http-client first and google-auth-library second or vice versa.

This PR enforces that the resolution behavior remains consistent and will break the build.

Fixes issues like googleapis/google-http-java-client#981