### PR TITLE
refactor: stop using autogenerated gapic chains

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -69,6 +69,10 @@
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-bigtable-v2</artifactId>
     </dependency>
     <dependency>
@@ -187,11 +191,6 @@
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
       <classifier>testlib</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fully compose own callable chains. This will remove the need to fiddle with StubSettings
to disable default retry behavior and will also  eliminate unnecessary gapic trace spans. This also fixes a  bug where the trace annotations for ReadRows was missing the connection id. And this will pave the way for decoupling Opencensus via the ApiTracer api

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for context and/or discussion)