### PR TITLE
chore: use java helper for templates

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -49,9 +49,7 @@ def main():
 
   java.format_code(f'./google-cloud-bigtable/src')
 
-  common_templates = gcp.CommonTemplates()
-  templates = common_templates.java_library()
-  s.copy(templates, excludes=[
+  java.common_templates(excludes=[
     '.gitignore',
     'README.md',
     '.kokoro/presubmit/integration.cfg',


### PR DESCRIPTION
We are cleaning up usage of common templates in synthtool. This allows us the cleanup usage in a centralized place rather than in 60+ repos