### PR TITLE
feat: add toString to Bigtable*Settings to display defaults

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettings.java
@@ -19,6 +19,7 @@ import static com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings.BIGT
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.bigtable.admin.v2.stub.BigtableInstanceAdminStubSettings;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import java.io.IOException;
@@ -77,6 +78,14 @@ public final class BigtableInstanceAdminSettings {
   /** Returns a builder containing all the values of this settings class. */
   public Builder toBuilder() {
     return new Builder(this);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("projectId", projectId)
+        .add("stubSettings", stubSettings)
+        .toString();
   }
 
   /** Returns a new builder for this class. */

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettings.java
@@ -20,6 +20,7 @@ import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStubSettings;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.base.Verify;
@@ -88,6 +89,15 @@ public final class BigtableTableAdminSettings {
   /** Returns a builder containing all the values of this settings class. */
   public Builder toBuilder() {
     return new Builder(this);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("projectId", projectId)
+        .add("instanceId", instanceId)
+        .add("stubSettings", stubSettings)
+        .toString();
   }
 
   /**

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
@@ -24,6 +24,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import io.grpc.ManagedChannelBuilder;
 import java.util.logging.Logger;
@@ -203,6 +204,16 @@ public final class BigtableDataSettings {
   /** Returns a builder containing all the values of this settings class. */
   public Builder toBuilder() {
     return new Builder(this);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("projectId", getProjectId())
+        .add("instanceId", getInstanceId())
+        .add("appProfileId", getAppProfileId())
+        .add("stubSettings", stubSettings)
+        .toString();
   }
 
   /** Builder for BigtableDataSettings. */


### PR DESCRIPTION
Fixes #233

This PR adds toString() to all three BigtableDataSettings,BigtableTableAdminSettings, BigtableInstanceAdminSettings. This is to help user log the current settings.

This would display the default in the following manner:

`
BigtableDataSettings{projectId=fake-project, instanceId=fake-instance, appProfileId=fake-app-profile, stubSettings=EnhancedBigtableStubSettings{executorProvider=InstantiatingExecutorProvider{executorThreadCount=8, threadFactory=com.google.api.gax.core.InstantiatingExecutorProvider$1@533dcfeb}, transportChannelProvider=com.google.api.gax.grpc.InstantiatingGrpcChannelProvider@8062dcc, credentialsProvider=GoogleCredentialsProvider{scopesToApply=[https://www.googleapis.com/auth/bigtable.data, https://www.googleapis.com/auth/bigtable.data.readonly, https://www.googleapis.com/auth/cloud-bigtable.data, https://www.googleapis.com/auth/cloud-bigtable.data.readonly, https://www.googleapis.com/auth/cloud-platform, https://www.googleapis.com/auth/cloud-platform.read-only], jwtEnabledScopes=[https://www.googleapis.com/auth/bigtable.data, https://www.googleapis.com/auth/cloud-bigtable.data, https://www.googleapis.com/auth/cloud-platform], OAuth2Credentials=null}, headerProvider=com.google.api.gax.rpc.NoHeaderProvider@bab4db70, internalHeaderProvider=com.google.api.gax.rpc.NoHeaderProvider@6d584b5d, clock=com.google.api.core.NanoClock@f33616bc, endpoint=bigtable.googleapis.com:443, streamWatchdogProvider=com.google.api.gax.rpc.InstantiatingWatchdogProvider@885d9266, streamWatchdogCheckInterval=PT10S, tracerFactory=com.google.api.gax.tracing.OpencensusTracerFactory@121cd451}}
`