### PR TITLE
chore: fix samples snippets, bump synth.metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "google-cloud-bigtable",
+  "name": "bigtable",
   "name_pretty": "Cloud Bigtable",
   "product_documentation": "https://cloud.google.com/bigtable",
   "client_documentation": "https://googleapis.dev/java/java-bigtable/latest/index.html",

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -25,13 +25,13 @@
 
 
   <dependencies>
-    <!-- [START google-cloud-bigtable_install_without_bom] -->
+    <!-- [START bigtable_install_without_bom] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable</artifactId>
       <version>1.11.0</version>
     </dependency>
-    <!-- [END google-cloud-bigtable_install_without_bom] -->
+    <!-- [END bigtable_install_without_bom] -->
 
     <dependency>
       <groupId>junit</groupId>

--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -23,7 +23,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <!-- {x-version-update-start::current} -->
+  <!-- {x-version-update-start:google-cloud-bigtable:current} -->
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -24,7 +24,7 @@
   </properties>
 
 
-  <!-- [START google-cloud-bigtable_install_with_bom] -->
+  <!-- [START bigtable_install_with_bom] -->
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -42,7 +42,7 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable</artifactId>
     </dependency>
-    <!-- [END google-cloud-bigtable_install_with_bom] -->
+    <!-- [END bigtable_install_with_bom] -->
 
     <dependency>
       <groupId>junit</groupId>

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,11 +1,10 @@
 {
-  "updateTime": "2020-03-18T22:06:08.780723Z",
   "sources": [
     {
-      "generator": {
-        "name": "artman",
-        "version": "1.1.1",
-        "dockerImage": "googleapis/artman@sha256:5ef340c8d9334719bc5c6981d95f4a5d2737b0a6a24f2b9a0d430e96fff85c5b"
+      "git": {
+        "name": ".",
+        "remote": "git@github.com:googleapis/java-bigtable.git",
+        "sha": "5b8e2571e98f3b1824deae206911b60d64ad9f38"
       }
     },
     {
@@ -21,7 +20,7 @@
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "1326d00fa9e856aa6b244b6811404cf45b109119"
+        "sha": "19465d3ec5e5acdb01521d8f3bddd311bcbee28d"
       }
     }
   ],
@@ -32,8 +31,7 @@
         "apiName": "bigtable",
         "apiVersion": "v2",
         "language": "java",
-        "generator": "gapic",
-        "config": "google/bigtable/artman_bigtable.yaml"
+        "generator": "bazel"
       }
     },
     {
@@ -42,8 +40,7 @@
         "apiName": "bigtable-admin",
         "apiVersion": "v2",
         "language": "java",
-        "generator": "gapic",
-        "config": "google/bigtable/admin/artman_bigtableadmin.yaml"
+        "generator": "bazel"
       }
     }
   ]


### PR DESCRIPTION
This should fix the snippet tags in samples and bump the synth.metadata file so that autosynth can send coherent pull requests again.

* Re-ran synthtool
* Reverted proto/java changes to isolate templates
* Reverted version changes for googleapis in synth.metadata.
