### PR TITLE
feat: expose new API with ReadRowsRequest in EnhancedBigtableStub

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.data.v2.stub;
 
+import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.batching.Batcher;
 import com.google.api.gax.batching.BatcherImpl;
@@ -149,6 +150,27 @@ public class EnhancedBigtableStub implements AutoCloseable {
   // <editor-fold desc="Callable creators">
 
   /**
+   * Creates a callable chain to handle ReadRows RPCs. The chain will:
+   *
+   * <ul>
+   *   <li>Dispatch the RPC with {@link ReadRowsRequest}.
+   *   <li>Upon receiving the response stream, it will merge the {@link
+   *       com.google.bigtable.v2.ReadRowsResponse.CellChunk}s in logical rows. The actual row
+   *       implementation can be configured by the {@code rowAdapter} parameter.
+   *   <li>Retry/resume on failure.
+   *   <li>Filter out marker rows.
+   * </ul>
+   *
+   * <p>NOTE: the caller is responsible for adding tracing & metrics.
+   */
+  @BetaApi("This surface is stable yet it might be removed in the future.")
+  public <RowT> ServerStreamingCallable<ReadRowsRequest, RowT> createReadRowsRawCallable(
+      RowAdapter<RowT> rowAdapter) {
+    return createReadRowsBaseCallable(settings.readRowsSettings(), rowAdapter)
+        .withDefaultCallContext(clientContext.getDefaultCallContext());
+  }
+
+  /**
    * Creates a callable chain to handle streaming ReadRows RPCs. The chain will:
    *
    * <ul>
@@ -164,12 +186,15 @@ public class EnhancedBigtableStub implements AutoCloseable {
    */
   public <RowT> ServerStreamingCallable<Query, RowT> createReadRowsCallable(
       RowAdapter<RowT> rowAdapter) {
-    ServerStreamingCallable<Query, RowT> readRowsCallable =
+    ServerStreamingCallable<ReadRowsRequest, RowT> readRowsCallable =
         createReadRowsBaseCallable(settings.readRowsSettings(), rowAdapter);
+
+    ServerStreamingCallable<Query, RowT> readRowsUserCallable =
+        new ReadRowsUserCallable<>(readRowsCallable, requestContext);
 
     ServerStreamingCallable<Query, RowT> traced =
         new TracedServerStreamingCallable<>(
-            readRowsCallable,
+            readRowsUserCallable,
             clientContext.getTracerFactory(),
             SpanName.of(TRACING_OUTER_CLIENT_NAME, "ReadRows"));
 
@@ -199,15 +224,17 @@ public class EnhancedBigtableStub implements AutoCloseable {
    * </ul>
    */
   public <RowT> UnaryCallable<Query, RowT> createReadRowCallable(RowAdapter<RowT> rowAdapter) {
-    UnaryCallable<Query, RowT> readRowCallable =
+    ServerStreamingCallable<ReadRowsRequest, RowT> readRowsCallable =
         createReadRowsBaseCallable(
-                ServerStreamingCallSettings.<Query, Row>newBuilder()
-                    .setRetryableCodes(settings.readRowSettings().getRetryableCodes())
-                    .setRetrySettings(settings.readRowSettings().getRetrySettings())
-                    .setIdleTimeout(settings.readRowSettings().getRetrySettings().getTotalTimeout())
-                    .build(),
-                rowAdapter)
-            .first();
+            ServerStreamingCallSettings.<ReadRowsRequest, Row>newBuilder()
+                .setRetryableCodes(settings.readRowSettings().getRetryableCodes())
+                .setRetrySettings(settings.readRowSettings().getRetrySettings())
+                .setIdleTimeout(settings.readRowSettings().getRetrySettings().getTotalTimeout())
+                .build(),
+            rowAdapter);
+
+    UnaryCallable<Query, RowT> readRowCallable =
+        new ReadRowsUserCallable<>(readRowsCallable, requestContext).first();
 
     return createUserFacingUnaryCallable("ReadRow", readRowCallable);
   }
@@ -216,28 +243,6 @@ public class EnhancedBigtableStub implements AutoCloseable {
    * Creates a callable chain to handle ReadRows RPCs. The chain will:
    *
    * <ul>
-   *   <li>Convert a {@link Query} into a {@link com.google.bigtable.v2.ReadRowsRequest} and
-   *       dispatch the RPC.
-   *   <li>Upon receiving the response stream, it will merge the {@link
-   *       com.google.bigtable.v2.ReadRowsResponse.CellChunk}s in logical rows. The actual row
-   *       implementation can be configured by the {@code rowAdapter} parameter.
-   *   <li>Retry/resume on failure.
-   *   <li>Filter out marker rows.
-   * </ul>
-   *
-   * <p>NOTE: the caller is responsible for adding tracing & metrics.
-   */
-  private <RowT> ServerStreamingCallable<Query, RowT> createReadRowsBaseCallable(
-      ServerStreamingCallSettings<Query, Row> readRowsSettings, RowAdapter<RowT> rowAdapter) {
-
-    return new ReadRowsUserCallable<>(
-        createReadRowsRawCallable(readRowsSettings, rowAdapter), requestContext);
-  }
-
-  /**
-   * Creates a callable chain to handle ReadRows RPCs. The chain will:
-   *
-   * <ul>
    *   <li>Dispatch the RPC with {@link ReadRowsRequest}.
    *   <li>Upon receiving the response stream, it will merge the {@link
    *       com.google.bigtable.v2.ReadRowsResponse.CellChunk}s in logical rows. The actual row
@@ -248,46 +253,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
    *
    * <p>NOTE: the caller is responsible for adding tracing & metrics.
    */
-  public <RowT> ServerStreamingCallable<ReadRowsRequest, RowT> createReadRowsRawCallable(
-      RowAdapter<RowT> adapter) {
-    return createReadRowsBaseCallable(adapter)
-        .withDefaultCallContext(clientContext.getDefaultCallContext());
-  }
-
-  /**
-   * Creates a callable chain to handle ReadRows RPCs. The chain will:
-   *
-   * <ul>
-   *   <li>Dispatch the RPC with {@link ReadRowsRequest}.
-   *   <li>Upon receiving the response stream, it will merge the {@link
-   *       com.google.bigtable.v2.ReadRowsResponse.CellChunk}s in logical rows. The actual row
-   *       implementation can be configured by the {@code rowAdapter} parameter.
-   *   <li>Retry/resume on failure.
-   *   <li>Filter out marker rows.
-   * </ul>
-   *
-   * <p>NOTE: the caller is responsible for adding tracing & metrics.
-   */
-  public <RowT> ServerStreamingCallable<ReadRowsRequest, RowT> createReadRowsBaseCallable(
-      RowAdapter<RowT> adapter) {
-    return createReadRowsRawCallable(settings.readRowsSettings(), adapter);
-  }
-
-  /**
-   * Creates a callable chain to handle ReadRows RPCs. The chain will:
-   *
-   * <ul>
-   *   <li>Dispatch the RPC with {@link ReadRowsRequest}.
-   *   <li>Upon receiving the response stream, it will merge the {@link
-   *       com.google.bigtable.v2.ReadRowsResponse.CellChunk}s in logical rows. The actual row
-   *       implementation can be configured by the {@code rowAdapter} parameter.
-   *   <li>Retry/resume on failure.
-   *   <li>Filter out marker rows.
-   * </ul>
-   *
-   * <p>NOTE: the caller is responsible for adding tracing & metrics.
-   */
-  private <ReqT, RowT> ServerStreamingCallable<ReadRowsRequest, RowT> createReadRowsRawCallable(
+  private <ReqT, RowT> ServerStreamingCallable<ReadRowsRequest, RowT> createReadRowsBaseCallable(
       ServerStreamingCallSettings<ReqT, Row> readRowsSettings, RowAdapter<RowT> rowAdapter) {
 
     ServerStreamingCallable<ReadRowsRequest, ReadRowsResponse> base =
@@ -307,8 +273,8 @@ public class EnhancedBigtableStub implements AutoCloseable {
     ServerStreamingCallable<ReadRowsRequest, RowT> merging =
         new RowMergingCallable<>(base, rowAdapter);
 
-    // Copy settings for the middle ReadRowsRequest -> RowT callable (as opposed to the outer
-    // Query -> RowT callable or the inner ReadRowsRequest -> ReadRowsResponse callable).
+    // Copy settings for the middle ReadRowsRequest -> RowT callable (as opposed to the inner
+    // ReadRowsRequest -> ReadRowsResponse callable).
     ServerStreamingCallSettings<ReadRowsRequest, RowT> innerSettings =
         ServerStreamingCallSettings.<ReadRowsRequest, RowT>newBuilder()
             .setResumptionStrategy(new ReadRowsResumptionStrategy<>(rowAdapter))

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.data.v2.stub;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.testing.InProcessServer;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.RowSet;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
+import com.google.cloud.bigtable.data.v2.models.DefaultRowAdapter;
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.common.collect.Queues;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.StringValue;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class EnhancedBigtableStubTest {
+
+  private static final String PROJECT_ID = "fake-project";
+  private static final String INSTANCE_ID = "fake-instance";
+  private static final String TABLE_NAME =
+      NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, "fake-table");
+  private static final String FAKE_HOST_NAME = "fake-stub-host:123";
+
+  private InProcessServer<?> server;
+  private FakeDataService fakeDataService;
+  private EnhancedBigtableStub enhancedBigtableStub;
+  private EnhancedBigtableStubSettings enhancedBigtableStubSettings;
+
+  @Before
+  public void setUp() throws IOException, IllegalAccessException, InstantiationException {
+    fakeDataService = new FakeDataService();
+    server = new InProcessServer<>(fakeDataService, FAKE_HOST_NAME);
+    server.start();
+
+    enhancedBigtableStubSettings =
+        EnhancedBigtableStubSettings.newBuilder()
+            .setProjectId(PROJECT_ID)
+            .setInstanceId(INSTANCE_ID)
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .setEndpoint(FAKE_HOST_NAME)
+            .setTransportChannelProvider(LocalChannelProvider.create(FAKE_HOST_NAME))
+            .build();
+
+    enhancedBigtableStub = EnhancedBigtableStub.create(enhancedBigtableStubSettings);
+  }
+
+  @After
+  public void tearDown() {
+    server.stop();
+  }
+
+  @Test
+  public void testCreateReadRowsBaseCallable() throws InterruptedException, IOException {
+    ServerStreamingCallable<ReadRowsRequest, Row> callable =
+        enhancedBigtableStub.createReadRowsBaseCallable(new DefaultRowAdapter());
+
+    ApiCallContext context =
+        ClientContext.create(enhancedBigtableStubSettings).getDefaultCallContext();
+
+    ReadRowsRequest expectedRequest =
+        ReadRowsRequest.newBuilder()
+            .setTableName(TABLE_NAME)
+            .setAppProfileId("app-profile-1")
+            .setRows(RowSet.newBuilder().addRowKeys(ByteString.copyFromUtf8("test-row-key")))
+            .build();
+    callable.call(expectedRequest, context).iterator().next();
+    assertThat(fakeDataService.popLastRequest()).isEqualTo(expectedRequest);
+
+    ReadRowsRequest expectedRequest2 =
+        ReadRowsRequest.newBuilder()
+            .setTableName(TABLE_NAME)
+            .setAppProfileId("app-profile-2")
+            .build();
+    callable.call(expectedRequest2, context).iterator().next();
+    assertThat(fakeDataService.popLastRequest()).isEqualTo(expectedRequest2);
+  }
+
+  @Test
+  public void testCreateReadRowsRawCallable() throws InterruptedException {
+    ServerStreamingCallable<ReadRowsRequest, Row> callable =
+        enhancedBigtableStub.createReadRowsRawCallable(new DefaultRowAdapter());
+
+    ReadRowsRequest expectedRequest =
+        ReadRowsRequest.newBuilder()
+            .setTableName(TABLE_NAME)
+            .setAppProfileId("app-profile-1")
+            .setRows(RowSet.newBuilder().addRowKeys(ByteString.copyFromUtf8("test-row-key")))
+            .build();
+    callable.call(expectedRequest).iterator().next();
+    assertThat(fakeDataService.popLastRequest()).isEqualTo(expectedRequest);
+
+    ReadRowsRequest expectedRequest2 =
+        ReadRowsRequest.newBuilder()
+            .setTableName(TABLE_NAME)
+            .setAppProfileId("app-profile-2")
+            .build();
+    callable.call(expectedRequest2).iterator().next();
+    assertThat(fakeDataService.popLastRequest()).isEqualTo(expectedRequest2);
+  }
+
+  private static class FakeDataService extends BigtableGrpc.BigtableImplBase {
+    final BlockingQueue<Object> requests = Queues.newLinkedBlockingDeque();
+
+    @SuppressWarnings("unchecked")
+    <T> T popLastRequest() throws InterruptedException {
+      return (T) requests.poll(1, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void readRows(
+        ReadRowsRequest request, StreamObserver<ReadRowsResponse> responseObserver) {
+      requests.add(request);
+      // Dummy row for stream
+      responseObserver.onNext(
+          ReadRowsResponse.newBuilder()
+              .addChunks(
+                  ReadRowsResponse.CellChunk.newBuilder()
+                      .setCommitRow(true)
+                      .setRowKey(ByteString.copyFromUtf8("a"))
+                      .setFamilyName(StringValue.getDefaultInstance())
+                      .setQualifier(BytesValue.getDefaultInstance())
+                      .setValueSize(0))
+              .build());
+      responseObserver.onCompleted();
+    }
+  }
+}


### PR DESCRIPTION
Fixes #275 

This commit would enable the user to target the table using an absolute resource name on each read request. Currently, we expose `ServerStreamingCallable<Query, RowT>`, which does not have an option to provide different `app-profile-id` on each request.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
