### PR TITLE
chore: specify primary CODEOWNERS team in repo-metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,11 @@
 # Code owners file.
 # This file controls who is tagged for review for any given pull request.
-#
+
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
+# The @googleapis/bigtable-dpe is the default owner for changes in this repo
+**/*.java               @googleapis/bigtable-dpe
 
-# The bigtable-dpe team is the default owner for anything not
-# explicitly taken by someone else.
-*                               @googleapis/bigtable-dpe
+# The java-samples-reviewers team is the default owner for samples changes
+samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,5 +9,6 @@
   "repo": "googleapis/java-bigtable",
   "repo_short": "java-bigtable",
   "distribution_name": "com.google.cloud:google-cloud-bigtable",
+  "codeowner_team": "@googleapis/bigtable-dpe",
   "api_id": "bigtable.googleapis.com"
 }

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,23 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/java-bigtable.git",
-        "sha": "ce3bbba103568c49a1edb1d432b497e4fec13d5d"
+        "remote": "git@github.com:googleapis/java-bigtable.git",
+        "sha": "b9e5e832791b728d5931e1fe4546d01ffb4903d1"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "c4e37010d74071851ff24121f522e802231ac86e",
-        "internalRef": "313460921"
+        "sha": "f72c3a53fe6705cd705b4fc4e464bed4dbd1f18f",
+        "internalRef": "314606371"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "98c50772ec23295c64cf0d2ddf199ea52961fd4c"
+        "sha": "8b65daa222d193b689279162781baf0aa1f0ffd2"
       }
     }
   ],


### PR DESCRIPTION
The CODEOWNERS file is now templated so that java-samples-reviewers group can manage samples. Restoring the config for the rest of the code.
