### PR TITLE
chore: update DirectPath tests

### DIFF
--- a/google-cloud-bigtable-deps-bom/pom.xml
+++ b/google-cloud-bigtable-deps-bom/pom.xml
@@ -79,7 +79,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -323,11 +323,8 @@
                     <bigtable.data-endpoint>${bigtable.directpath-data-endpoint}</bigtable.data-endpoint>
                     <bigtable.admin-endpoint>${bigtable.directpath-admin-endpoint}</bigtable.admin-endpoint>
                     <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-it</bigtable.grpc-log-dir>
+                    <bigtable.attempt-directpath>true</bigtable.attempt-directpath>
                   </systemPropertyVariables>
-                  <!-- Enable directpath for bigtable -->
-                  <environmentVariables>
-                    <GOOGLE_CLOUD_ENABLE_DIRECT_PATH>bigtable</GOOGLE_CLOUD_ENABLE_DIRECT_PATH>
-                  </environmentVariables>
                   <includes>
                     <!-- TODO(igorbernstein): Once the control plane is accessible via directpath, add admin tests -->
                     <include>com.google.cloud.bigtable.data.v2.it.*IT</include>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -229,9 +229,20 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
 
   /** Returns a builder for the default ChannelProvider for this service. */
   public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder() {
-    return BigtableStubSettings.defaultGrpcTransportProviderBuilder()
+    InstantiatingGrpcChannelProvider.Builder builder =
+        BigtableStubSettings.defaultGrpcTransportProviderBuilder()
         .setPoolSize(getDefaultChannelPoolSize())
         .setMaxInboundMessageSize(MAX_MESSAGE_SIZE);
+    // TODO(weiranf): Remove this once DirectPath goes to public beta
+    if (isDirectPathEnabled()) {
+      builder.setAttemptDirectPath(true);
+    }
+    return builder;
+  }
+
+  // TODO(weiranf): Remove this once DirectPath goes to public beta
+  private static boolean isDirectPathEnabled() {
+    return Boolean.getBoolean("bigtable.attempt-directpath");
   }
 
   static int getDefaultChannelPoolSize() {
@@ -504,7 +515,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
       // Defaults provider
       BigtableStubSettings.Builder baseDefaults = BigtableStubSettings.newBuilder();
 
-      // TODO(igorbernstein): remove this once DirectPath goes to public Beta and uses the default
+      // TODO(weiranf): remove this once DirectPath goes to public Beta and uses the default
       // endpoint.
       if (isDirectPathEnabled()) {
         setEndpoint(DIRECT_PATH_ENDPOINT);
@@ -625,22 +636,6 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
         UnaryCallSettings.Builder<?, ?> source, UnaryCallSettings.Builder<?, ?> dest) {
       dest.setRetryableCodes(source.getRetryableCodes());
       dest.setRetrySettings(source.getRetrySettings());
-    }
-
-    // TODO(igorbernstein): Remove this once DirectPath goes to public beta
-    // Extracted from InstantiatingGrpcChannelProvider#isDirectPathEnabled
-    private static boolean isDirectPathEnabled() {
-      String whiteList = System.getenv(DIRECT_PATH_ENV_VAR);
-      if (whiteList == null) {
-        return false;
-      }
-
-      for (String service : whiteList.split(",")) {
-        if (!service.isEmpty() && DIRECT_PATH_ENDPOINT.contains(service)) {
-          return true;
-        }
-      }
-      return false;
     }
     // </editor-fold>
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -83,7 +83,8 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   private static final String SERVER_DEFAULT_APP_PROFILE_ID = "";
 
   // TODO(weiranf): Remove this temporary endpoint once DirectPath goes to public beta
-  private static final String DIRECT_PATH_ENDPOINT = "directpath-bigtable.googleapis.com:443";
+  private static final String DIRECT_PATH_ENDPOINT =
+      "testdirectpath-bigtable.sandbox.googleapis.com:443";
 
   private static final Set<Code> IDEMPOTENT_RETRY_CODES =
       ImmutableSet.of(Code.DEADLINE_EXCEEDED, Code.UNAVAILABLE);

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -82,9 +82,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   private static final int MAX_MESSAGE_SIZE = 256 * 1024 * 1024;
   private static final String SERVER_DEFAULT_APP_PROFILE_ID = "";
 
-  // TODO(igorbernstein2): Remove this once DirectPath goes to public beta
-  // Temporary endpoint for the DirectPath private alpha
-  private static final String DIRECT_PATH_ENV_VAR = "GOOGLE_CLOUD_ENABLE_DIRECT_PATH";
+  // TODO(weiranf): Remove this temporary endpoint once DirectPath goes to public beta
   private static final String DIRECT_PATH_ENDPOINT = "directpath-bigtable.googleapis.com:443";
 
   private static final Set<Code> IDEMPOTENT_RETRY_CODES =
@@ -229,15 +227,11 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
 
   /** Returns a builder for the default ChannelProvider for this service. */
   public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder() {
-    InstantiatingGrpcChannelProvider.Builder builder =
-        BigtableStubSettings.defaultGrpcTransportProviderBuilder()
+    return BigtableStubSettings.defaultGrpcTransportProviderBuilder()
         .setPoolSize(getDefaultChannelPoolSize())
-        .setMaxInboundMessageSize(MAX_MESSAGE_SIZE);
-    // TODO(weiranf): Remove this once DirectPath goes to public beta
-    if (isDirectPathEnabled()) {
-      builder.setAttemptDirectPath(true);
-    }
-    return builder;
+        .setMaxInboundMessageSize(MAX_MESSAGE_SIZE)
+        // TODO(weiranf): Set this to true by default once DirectPath goes to public beta
+        .setAttemptDirectPath(isDirectPathEnabled());
   }
 
   // TODO(weiranf): Remove this once DirectPath goes to public beta

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
@@ -233,7 +233,7 @@ public class DirectPathFallbackIT {
       if (remoteAddress instanceof InetSocketAddress) {
         InetAddress inetAddress = ((InetSocketAddress) remoteAddress).getAddress();
         String addr = inetAddress.getHostAddress();
-        isDpAddr = addr.startsWith(DP_IPV6_PREFIX) ||  addr.startsWith(DP_IPV4_PREFIX);
+        isDpAddr = addr.startsWith(DP_IPV6_PREFIX) || addr.startsWith(DP_IPV4_PREFIX);
       }
 
       if (!(isDpAddr && blackholeDpAddr.get())) {

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
@@ -39,7 +39,9 @@ import io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel;
 import io.grpc.netty.shaded.io.netty.util.ReferenceCountUtil;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
@@ -66,12 +68,14 @@ public class DirectPathFallbackIT {
   // This was determined experimentally to account for both gRPC-LB RPCs and Bigtable api RPCs.
   private static final int MIN_COMPLETE_READ_CALLS = 40;
   private static final int NUM_RPCS_TO_SEND = 20;
+  private static final String DP_IPV6_PREFIX = "2001:4860:8040";
+  private static final String DP_IPV4_PREFIX = "34.126";
 
   @ClassRule public static TestEnvRule testEnvRule = new TestEnvRule();
 
-  private AtomicBoolean blackholeIPv6 = new AtomicBoolean();
+  private AtomicBoolean blackholeDpAddr = new AtomicBoolean();
   private AtomicInteger numBlocked = new AtomicInteger();
-  private AtomicInteger numIPv6Read = new AtomicInteger();
+  private AtomicInteger numDpAddrRead = new AtomicInteger();
 
   private ChannelFactory<NioSocketChannel> channelFactory;
   private EventLoopGroup eventLoopGroup;
@@ -97,6 +101,7 @@ public class DirectPathFallbackIT {
     InstantiatingGrpcChannelProvider instrumentedTransportChannelProvider =
         defaultTransportProvider
             .toBuilder()
+            .setAttemptDirectPath(true)
             .setPoolSize(1)
             .setChannelConfigurator(
                 new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
@@ -140,8 +145,8 @@ public class DirectPathFallbackIT {
     // Precondition: wait for DirectPath to connect
     assertWithMessage("Failed to observe RPCs over DirectPath").that(exerciseDirectPath()).isTrue();
 
-    // Enable the blackhole, which will prevent communication via IPv6 and thus DirectPath.
-    blackholeIPv6.set(true);
+    // Enable the blackhole, which will prevent communication with grpclb and thus DirectPath.
+    blackholeDpAddr.set(true);
 
     // Send a request, which should be routed over IPv4 and CFE.
     instrumentedClient.readRow(testEnvRule.env().getTableId(), "nonexistent-row");
@@ -154,14 +159,14 @@ public class DirectPathFallbackIT {
 
     // Make sure that the client will start reading from IPv6 again by sending new requests and
     // checking the injected IPv6 counter has been updated.
-    blackholeIPv6.set(false);
+    blackholeDpAddr.set(false);
 
     assertWithMessage("Failed to upgrade back to DirectPath").that(exerciseDirectPath()).isTrue();
   }
 
   private boolean exerciseDirectPath() throws InterruptedException, TimeoutException {
     Stopwatch stopwatch = Stopwatch.createStarted();
-    numIPv6Read.set(0);
+    numDpAddrRead.set(0);
 
     boolean seenEnough = false;
 
@@ -170,7 +175,7 @@ public class DirectPathFallbackIT {
         instrumentedClient.readRow(testEnvRule.env().getTableId(), "nonexistent-row");
       }
       Thread.sleep(100);
-      seenEnough = numIPv6Read.get() >= MIN_COMPLETE_READ_CALLS;
+      seenEnough = numDpAddrRead.get() >= MIN_COMPLETE_READ_CALLS;
     }
     return seenEnough;
   }
@@ -215,7 +220,7 @@ public class DirectPathFallbackIT {
    * make IPv6 packets disappear
    */
   private class MyChannelHandler extends ChannelDuplexHandler {
-    private boolean isIPv6;
+    private boolean isDpAddr;
 
     @Override
     public void connect(
@@ -225,23 +230,30 @@ public class DirectPathFallbackIT {
         ChannelPromise promise)
         throws Exception {
 
-      this.isIPv6 =
-          (remoteAddress instanceof InetSocketAddress)
-              && ((InetSocketAddress) remoteAddress).getAddress() instanceof Inet6Address;
+      if (remoteAddress instanceof InetSocketAddress) {
+        InetAddress inetAddress = ((InetSocketAddress) remoteAddress).getAddress();
+        String addr = inetAddress.getHostAddress();
+        if ((inetAddress instanceof Inet6Address && addr.startsWith(DP_IPV6_PREFIX))
+          || (inetAddress instanceof Inet4Address && addr.startsWith(DP_IPV4_PREFIX))) {
+          isDpAddr = true;
+        }
+      }
 
-      if (!(isIPv6 && blackholeIPv6.get())) {
+      if (!(isDpAddr && blackholeDpAddr.get())) {
         super.connect(ctx, remoteAddress, localAddress, promise);
       } else {
         // Fail the connection fast
+        System.out.println(">>>>>>>>>>>>>>>>>>>>>>>>>>> Failing connection");
         promise.setFailure(new IOException("fake error"));
       }
     }
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-      boolean dropCall = isIPv6 && blackholeIPv6.get();
+      boolean dropCall = isDpAddr && blackholeDpAddr.get();
 
       if (dropCall) {
+        System.out.println(">>>>>>>>>>>>>>>>>>>>>>> Dropping call.");
         // Don't notify the next handler and increment counter
         numBlocked.incrementAndGet();
         ReferenceCountUtil.release(msg);
@@ -252,14 +264,14 @@ public class DirectPathFallbackIT {
 
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-      boolean dropCall = isIPv6 && blackholeIPv6.get();
+      boolean dropCall = isDpAddr && blackholeDpAddr.get();
 
       if (dropCall) {
         // Don't notify the next handler and increment counter
         numBlocked.incrementAndGet();
       } else {
-        if (isIPv6) {
-          numIPv6Read.incrementAndGet();
+        if (isDpAddr) {
+          numDpAddrRead.incrementAndGet();
         }
         super.channelReadComplete(ctx);
       }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
@@ -75,7 +75,7 @@ public abstract class AbstractTestEnv {
   }
 
   public boolean isDirectPathEnabled() {
-    return "bigtable".equals(System.getenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH"));
+    return Boolean.getBoolean("bigtable.attempt-directpath");
   }
 
   public String getPrimaryZone() {


### PR DESCRIPTION
- Update DirectPath tests to use the new opt-in method instead of env var
- Change fallback tests to blackhole all ipv4 and ipv6 DP addresses

Q: This change depends on v0.8.0 google-cloud-shared-dependencies, so do I need to wait for https://github.com/googleapis/java-bigtable/pull/338 to be merged?