### PR TITLE
chore: Introspect peer IP address for directpath tests

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -338,6 +338,44 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>bigtable-directpath-ipv4-it</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>directpath-it</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <skip>false</skip>
+
+                  <systemPropertyVariables>
+                    <bigtable.env>cloud</bigtable.env>
+                    <bigtable.data-endpoint>${bigtable.directpath-data-endpoint}</bigtable.data-endpoint>
+                    <bigtable.admin-endpoint>${bigtable.directpath-admin-endpoint}</bigtable.admin-endpoint>
+                    <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-it</bigtable.grpc-log-dir>
+                    <bigtable.attempt-directpath>true</bigtable.attempt-directpath>
+                    <bigtable.directpath-ipv4>true</bigtable.directpath-ipv4>
+                  </systemPropertyVariables>
+                  <includes>
+                    <!-- TODO(igorbernstein): Once the control plane is accessible via directpath, add admin tests -->
+                    <include>com.google.cloud.bigtable.data.v2.it.*IT</include>
+                  </includes>
+                  <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-directpath-it.xml</summaryFile>
+                  <reportsDirectory>${project.build.directory}/failsafe-reports/directpath-ipv4-it</reportsDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -359,7 +359,7 @@
                     <bigtable.env>cloud</bigtable.env>
                     <bigtable.data-endpoint>${bigtable.directpath-data-endpoint}</bigtable.data-endpoint>
                     <bigtable.admin-endpoint>${bigtable.directpath-admin-endpoint}</bigtable.admin-endpoint>
-                    <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-it</bigtable.grpc-log-dir>
+                    <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-ipv4-it</bigtable.grpc-log-dir>
                     <bigtable.attempt-directpath>true</bigtable.attempt-directpath>
                     <bigtable.directpath-ipv4>true</bigtable.directpath-ipv4>
                   </systemPropertyVariables>
@@ -367,7 +367,7 @@
                     <!-- TODO(igorbernstein): Once the control plane is accessible via directpath, add admin tests -->
                     <include>com.google.cloud.bigtable.data.v2.it.*IT</include>
                   </includes>
-                  <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-directpath-it.xml</summaryFile>
+                  <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-directpath-ipv4-it.xml</summaryFile>
                   <reportsDirectory>${project.build.directory}/failsafe-reports/directpath-ipv4-it</reportsDirectory>
                 </configuration>
               </execution>

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
@@ -78,6 +78,10 @@ public abstract class AbstractTestEnv {
     return Boolean.getBoolean("bigtable.attempt-directpath");
   }
 
+  public boolean isDirectPathIpv4() {
+    return Boolean.getBoolean("bigtable.directpath-ipv4");
+  }
+
   public String getPrimaryZone() {
     return "us-central1-b";
   }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
@@ -222,7 +222,7 @@ class CloudEnv extends AbstractTestEnv {
                                   + " to the test environment's requirement for DirectPath."
                                   + " Expected test to access DirectPath via %s,"
                                   + " but RPC was destined for %s",
-                              remoteAddr.toString(), isDirectPathIpv4() ? "ipv4" : "ipv6"));
+                              isDirectPathIpv4() ? "ipv4" : "ipv6", remoteAddr.toString()));
                     }
                     super.onHeaders(headers);
                   }


### PR DESCRIPTION
As we are rolling out DirectPath IPv4 support, we want to test both ipv4 and ipv6 cases (i.e. run test client on both ipv4-only VM and ipv6-enabled VM). And to make sure DirectPath is working as expected on both ipv4/ipv6 connection, we would want to introspect the peer IP address after connection is successfully established.

Changes in this PR:
* Added client interceptor in `CloudEnv.java`, which is only enabled for directpath tests. Please advise if there's a better place for adding this interceptor.
* Throws a `RuntimeException` when remote IP address is not as expected.
* Added `bigtable-directpath-ipv4-it` test profile to be run on a ipv4-only VM. The original `bigtable-directpath-it` will still be run on a ipv6-enabled VM.