### PR TITLE
chore(fix): directpath ipv4 connection should not fail for an ipv6-enabled test client

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -340,7 +340,7 @@
     </profile>
 
     <profile>
-      <id>bigtable-directpath-ipv4-it</id>
+      <id>bigtable-directpath-ipv4only-it</id>
       <build>
         <plugins>
           <plugin>
@@ -359,7 +359,7 @@
                     <bigtable.env>cloud</bigtable.env>
                     <bigtable.data-endpoint>${bigtable.directpath-data-endpoint}</bigtable.data-endpoint>
                     <bigtable.admin-endpoint>${bigtable.directpath-admin-endpoint}</bigtable.admin-endpoint>
-                    <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-ipv4-it</bigtable.grpc-log-dir>
+                    <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-ipv4only-it</bigtable.grpc-log-dir>
                     <bigtable.attempt-directpath>true</bigtable.attempt-directpath>
                     <bigtable.directpath-ipv4>true</bigtable.directpath-ipv4>
                   </systemPropertyVariables>
@@ -367,8 +367,8 @@
                     <!-- TODO(igorbernstein): Once the control plane is accessible via directpath, add admin tests -->
                     <include>com.google.cloud.bigtable.data.v2.it.*IT</include>
                   </includes>
-                  <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-directpath-ipv4-it.xml</summaryFile>
-                  <reportsDirectory>${project.build.directory}/failsafe-reports/directpath-ipv4-it</reportsDirectory>
+                  <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-directpath-ipv4only-it.xml</summaryFile>
+                  <reportsDirectory>${project.build.directory}/failsafe-reports/directpath-ipv4only-it</reportsDirectory>
                 </configuration>
               </execution>
             </executions>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -361,7 +361,7 @@
                     <bigtable.admin-endpoint>${bigtable.directpath-admin-endpoint}</bigtable.admin-endpoint>
                     <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-ipv4only-it</bigtable.grpc-log-dir>
                     <bigtable.attempt-directpath>true</bigtable.attempt-directpath>
-                    <bigtable.directpath-ipv4>true</bigtable.directpath-ipv4>
+                    <bigtable.directpath-ipv4only>true</bigtable.directpath-ipv4only>
                   </systemPropertyVariables>
                   <includes>
                     <!-- TODO(igorbernstein): Once the control plane is accessible via directpath, add admin tests -->

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
@@ -78,8 +78,8 @@ public abstract class AbstractTestEnv {
     return Boolean.getBoolean("bigtable.attempt-directpath");
   }
 
-  public boolean isDirectPathIpv4() {
-    return Boolean.getBoolean("bigtable.directpath-ipv4");
+  public boolean isDirectPathIpv4Only() {
+    return Boolean.getBoolean("bigtable.directpath-ipv4only");
   }
 
   public String getPrimaryZone() {

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
@@ -222,7 +222,7 @@ class CloudEnv extends AbstractTestEnv {
                                   + " to the test environment's requirement for DirectPath."
                                   + " Expected test to access DirectPath via %s,"
                                   + " but RPC was destined for %s",
-                              isDirectPathIpv4() ? "ipv4" : "ipv6", remoteAddr.toString()));
+                              isDirectPathIpv4Only() ? "ipv4" : "ipv6", remoteAddr.toString()));
                     }
                     super.onHeaders(headers);
                   }
@@ -238,7 +238,7 @@ class CloudEnv extends AbstractTestEnv {
     if (remoteAddr instanceof InetSocketAddress) {
       InetAddress inetAddress = ((InetSocketAddress) remoteAddr).getAddress();
       String addr = inetAddress.getHostAddress();
-      if (isDirectPathIpv4()) {
+      if (isDirectPathIpv4Only()) {
         return addr.startsWith(DP_IPV4_PREFIX);
       } else {
         // For an ipv6-enabled VM, client could connect to either ipv4 or ipv6 balancer addresses.

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
@@ -241,7 +241,8 @@ class CloudEnv extends AbstractTestEnv {
       if (isDirectPathIpv4()) {
         return addr.startsWith(DP_IPV4_PREFIX);
       } else {
-        return addr.startsWith(DP_IPV6_PREFIX);
+        // For an ipv6-enabled VM, client could connect to either ipv4 or ipv6 balancer addresses.
+        return addr.startsWith(DP_IPV6_PREFIX) || addr.startsWith(DP_IPV4_PREFIX);
       }
     }
     return true;

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
@@ -222,7 +222,8 @@ class CloudEnv extends AbstractTestEnv {
                                   + " to the test environment's requirement for DirectPath."
                                   + " Expected test to access DirectPath via %s,"
                                   + " but RPC was destined for %s",
-                              isDirectPathIpv4Only() ? "ipv4" : "ipv6", remoteAddr.toString()));
+                              isDirectPathIpv4Only() ? "ipv4 only" : "ipv4 or ipv6",
+                              remoteAddr.toString()));
                     }
                     super.onHeaders(headers);
                   }


### PR DESCRIPTION
With the new DNS support, a client running on ipv6-enabled VM could receive both ipv4 and ipv6 balancer addresses. And client could either pick the ipv4 address or the ipv6 address, and different languages of grpc have different behaviors. For Java, it will pick ipv4 address by default, so we should allow that connection when running directpath-ipv6 tests.
