### PR TITLE
chore: make version embedding more robust

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -15,9 +15,6 @@
     <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
   </parent>
   <properties>
-    <!-- The version that will be embedded in the published jar via maven-resources-plugin -->
-    <java-bigtable.version>1.16.1-SNAPSHOT</java-bigtable.version><!-- {x-version-update:google-cloud-bigtable:current} -->
-
     <site.installationModule>google-cloud-bigtable</site.installationModule>
 
     <!-- Enable the ability to skip unit tests and only run integration tests,
@@ -386,36 +383,7 @@
   </profiles>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/templates</directory>
-        <includes>
-          <include>**/*.java</include>
-        </includes>
-        <filtering>true</filtering>
-        <targetPath>${project.build.directory}/generated-sources/java</targetPath>
-      </resource>
-    </resources>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.2.0</version>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated-sources/java/</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -15,6 +15,9 @@
     <version>1.16.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
   </parent>
   <properties>
+    <!-- The version that will be embedded in the published jar via maven-resources-plugin -->
+    <java-bigtable.version>1.16.1-SNAPSHOT</java-bigtable.version><!-- {x-version-update:google-cloud-bigtable:current} -->
+
     <site.installationModule>google-cloud-bigtable</site.installationModule>
 
     <!-- Enable the ability to skip unit tests and only run integration tests,
@@ -383,7 +386,36 @@
   </profiles>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/templates</directory>
+        <includes>
+          <include>**/*.java</include>
+        </includes>
+        <filtering>true</filtering>
+        <targetPath>${project.build.directory}/generated-sources/java</targetPath>
+      </resource>
+    </resources>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/java/</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/GoogleUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/GoogleUtils.java
@@ -17,8 +17,10 @@ package com.google.cloud.bigtable;
 
 import com.google.api.core.InternalApi;
 
+/** Utility to get the current version of the Bigtable client. */
 @InternalApi("For internal use only")
-public final class Version {
-  // The released version, populated by maven.
-  public static String VERSION="${java-bigtable.version}";
+// Note: this file MUST be named GoogleUtils.java so that it can be picked up by releasetool
+public class GoogleUtils {
+  public static final String BIGTABLE_CLIENT_VERSION =
+      "1.16.1-SNAPSHOT"; // {x-version-update:google-cloud-bigtable:current}
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -29,7 +29,7 @@ import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
-import com.google.cloud.bigtable.GoogleUtils;
+import com.google.cloud.bigtable.Version;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -544,7 +544,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
               .putAll(
                   BigtableStubSettings.defaultApiClientHeaderProviderBuilder().build().getHeaders())
               // GrpcHeaderInterceptor treats the `user-agent` as a magic string
-              .put("user-agent", "bigtable-java/" + GoogleUtils.BIGTABLE_CLIENT_VERSION)
+              .put("user-agent", "bigtable-java/" + Version.VERSION)
               .build();
       setInternalHeaderProvider(FixedHeaderProvider.create(headers));
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -29,7 +29,7 @@ import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
-import com.google.cloud.bigtable.Version;
+import com.google.cloud.bigtable.GoogleUtils;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -544,7 +544,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
               .putAll(
                   BigtableStubSettings.defaultApiClientHeaderProviderBuilder().build().getHeaders())
               // GrpcHeaderInterceptor treats the `user-agent` as a magic string
-              .put("user-agent", "bigtable-java/" + Version.VERSION)
+              .put("user-agent", "bigtable-java/" + GoogleUtils.BIGTABLE_CLIENT_VERSION)
               .build();
       setInternalHeaderProvider(FixedHeaderProvider.create(headers));
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -20,7 +20,6 @@ import com.google.api.gax.batching.BatchingCallSettings;
 import com.google.api.gax.batching.BatchingSettings;
 import com.google.api.gax.batching.FlowControlSettings;
 import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
-import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.retrying.RetrySettings;
@@ -30,6 +29,7 @@ import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.cloud.bigtable.Version;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -544,10 +544,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
               .putAll(
                   BigtableStubSettings.defaultApiClientHeaderProviderBuilder().build().getHeaders())
               // GrpcHeaderInterceptor treats the `user-agent` as a magic string
-              .put(
-                  "user-agent",
-                  "bigtable-java/"
-                      + GaxProperties.getLibraryVersion(EnhancedBigtableStubSettings.class))
+              .put("user-agent", "bigtable-java/" + Version.VERSION)
               .build();
       setInternalHeaderProvider(FixedHeaderProvider.create(headers));
 

--- a/google-cloud-bigtable/src/main/templates/com/google/cloud/bigtable/Version.java
+++ b/google-cloud-bigtable/src/main/templates/com/google/cloud/bigtable/Version.java
@@ -17,10 +17,8 @@ package com.google.cloud.bigtable;
 
 import com.google.api.core.InternalApi;
 
-/** Utility to get the current version of the Bigtable client. */
 @InternalApi("For internal use only")
-// Note: this file MUST be named GoogleUtils.java so that it can be picked up by releasetool
-public class GoogleUtils {
-  public static final String BIGTABLE_CLIENT_VERSION =
-      "1.16.1-SNAPSHOT"; // {x-version-update:google-cloud-bigtable:current}
+public final class Version {
+  // The released version, populated by maven.
+  public static String VERSION="${java-bigtable.version}";
 }

--- a/google-cloud-bigtable/src/main/templates/com/google/cloud/bigtable/Version.java
+++ b/google-cloud-bigtable/src/main/templates/com/google/cloud/bigtable/Version.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable;
+
+import com.google.api.core.InternalApi;
+
+@InternalApi("For internal use only")
+public final class Version {
+  // The released version, populated by maven.
+  public static String VERSION="${java-bigtable.version}";
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubTest.java
@@ -159,7 +159,7 @@ public class EnhancedBigtableStubTest {
     assertThat(metadataInterceptor.headers).hasSize(1);
     Metadata metadata = metadataInterceptor.headers.take();
     assertThat(metadata.get(Metadata.Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER)))
-        .contains("bigtable-java/");
+        .containsMatch("bigtable-java/\\d+\\.\\d+\\.\\d+(?:-SNAPSHOT)?");
   }
 
   private static class MetadataInterceptor implements ServerInterceptor {


### PR DESCRIPTION
The previous approach used the jar manifest. Unfortunately that approaches falls apart when the 
consumer shades the client jar. The new approach uses a combination of releasetool's version tag
replacement and maven-resources-plugin to generate a class with an embedded version string.