### PR TITLE
Revert "feat: attemp DirectPath by default"

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -89,6 +89,9 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   private static final int MAX_MESSAGE_SIZE = 256 * 1024 * 1024;
   private static final String SERVER_DEFAULT_APP_PROFILE_ID = "";
 
+  // TODO(weiranf): Remove this temporary endpoint once DirectPath goes to public beta
+  private static final String DIRECT_PATH_ENDPOINT = "test-bigtable.sandbox.googleapis.com:443";
+
   private static final Set<Code> IDEMPOTENT_RETRY_CODES =
       ImmutableSet.of(Code.DEADLINE_EXCEEDED, Code.UNAVAILABLE);
 
@@ -167,6 +170,12 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   private EnhancedBigtableStubSettings(Builder builder) {
     super(builder);
 
+    if (DIRECT_PATH_ENDPOINT.equals(builder.getEndpoint())) {
+      logger.warning(
+          "Connecting to Bigtable using DirectPath."
+              + " This is currently an experimental feature and should not be used in production.");
+    }
+
     // Since point reads, streaming reads, bulk reads share the same base callable that converts
     // grpc errors into ApiExceptions, they must have the same retry codes.
     Preconditions.checkState(
@@ -240,9 +249,13 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
         .setKeepAliveTimeout(
             Duration.ofSeconds(10)) // wait this long before considering the connection dead
         .setKeepAliveWithoutCalls(true) // sends ping without active streams
-        // Attempts direct access to CBT service over gRPC to improve throughput,
-        // whether the attempt is allowed is totally controlled by service owner.
-        .setAttemptDirectPath(true);
+        // TODO(weiranf): Set this to true by default once DirectPath goes to public beta
+        .setAttemptDirectPath(isDirectPathEnabled());
+  }
+
+  // TODO(weiranf): Remove this once DirectPath goes to public beta
+  private static boolean isDirectPathEnabled() {
+    return Boolean.getBoolean("bigtable.attempt-directpath");
   }
 
   static int getDefaultChannelPoolSize() {
@@ -517,7 +530,13 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
       // Defaults provider
       BigtableStubSettings.Builder baseDefaults = BigtableStubSettings.newBuilder();
 
-      setEndpoint(baseDefaults.getEndpoint());
+      // TODO(weiranf): remove this once DirectPath goes to public Beta and uses the default
+      // endpoint.
+      if (isDirectPathEnabled()) {
+        setEndpoint(DIRECT_PATH_ENDPOINT);
+      } else {
+        setEndpoint(baseDefaults.getEndpoint());
+      }
 
       setTransportChannelProvider(defaultTransportChannelProvider());
       setStreamWatchdogCheckInterval(baseDefaults.getStreamWatchdogCheckInterval());


### PR DESCRIPTION
Reverts googleapis/java-bigtable#467

After this PR, gax-java relies on `ComputeEngineCredentials` to determine whether the client should use `ComputeEngineChannelBuilder`: https://github.com/googleapis/gax-java/blob/master/gax-grpc/src/main/java/com/google/api/gax/grpc/InstantiatingGrpcChannelProvider.java#L253

However, `ComputeEngineCredentials` has different assumptions than `ComputeEngineChannelBuilder`, which causes `ComputeEngineChannelBuilder` to fail on AppEngine: https://github.com/grpc/grpc-java/issues/7604.

We need to rollback this PR, and make the fix in gax-java, and then roll-forward again.

@apolcyn 
@mohanli-ml 
@igorbernstein2
@mgarolera