### PR TITLE
fix: make keepalive params a bit conservative

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
@@ -124,10 +124,9 @@ public final class BigtableDataSettings {
                         return input.usePlaintext();
                       }
                     })
-                .setKeepAliveTime(Duration.ofSeconds(10)) // sends ping in this interval
+                .setKeepAliveTime(Duration.ofSeconds(30)) // sends ping in this interval
                 .setKeepAliveTimeout(
                     Duration.ofSeconds(10)) // wait this long before considering the connection dead
-                .setKeepAliveWithoutCalls(true) // sends ping without active streams
                 .build());
 
     LOGGER.info("Connecting to the Bigtable emulator at " + hostname + ":" + port);

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -245,10 +245,9 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
     return BigtableStubSettings.defaultGrpcTransportProviderBuilder()
         .setPoolSize(getDefaultChannelPoolSize())
         .setMaxInboundMessageSize(MAX_MESSAGE_SIZE)
-        .setKeepAliveTime(Duration.ofSeconds(10)) // sends ping in this interval
+        .setKeepAliveTime(Duration.ofSeconds(30)) // sends ping in this interval
         .setKeepAliveTimeout(
             Duration.ofSeconds(10)) // wait this long before considering the connection dead
-        .setKeepAliveWithoutCalls(true) // sends ping without active streams
         // TODO(weiranf): Set this to true by default once DirectPath goes to public beta
         .setAttemptDirectPath(isDirectPathEnabled());
   }


### PR DESCRIPTION
Having keepalive pings at 10s can cause too_many_ping commands and it will double the keepalive time for new connections on that channel.

This PR sets keepalive pings at 30s (allowed by Google Frontends) which will avoid too many pings warnings.

Do not set keepAliveWithoutCalls(true) as enabling keepalive on idle streams can increase load.
