### PR TITLE
feat: add CMEK Support 

### DIFF
--- a/.kokoro/nightly/integration.cfg
+++ b/.kokoro/nightly/integration.cfg
@@ -8,7 +8,11 @@ env_vars: {
 
 env_vars: {
     key: "INTEGRATION_TEST_ARGS"
-    value: "-P bigtable-emulator-it,bigtable-prod-it -Dbigtable.project=gcloud-devel -Dbigtable.instance=google-cloud-bigtable -Dbigtable.table=integration-tests"
+    value: "-P bigtable-emulator-it,bigtable-prod-it \
+    -Dbigtable.project=gcloud-devel \
+    -Dbigtable.instance=google-cloud-bigtable -Dbigtable.table=integration-tests \
+    -Dbigtable.kms_key_name=projects/gcloud-devel/locations/us-central1/keyRings/cmek-test-key-ring/cryptoKeys/cmek-test-key \
+    -Dbigtable.wait-for-cmek-key-status=true"
 }
 
 env_vars: {

--- a/.kokoro/nightly/integration.cfg
+++ b/.kokoro/nightly/integration.cfg
@@ -8,11 +8,7 @@ env_vars: {
 
 env_vars: {
     key: "INTEGRATION_TEST_ARGS"
-    value: "-P bigtable-emulator-it,bigtable-prod-it \
-    -Dbigtable.project=gcloud-devel \
-    -Dbigtable.instance=google-cloud-bigtable -Dbigtable.table=integration-tests \
-    -Dbigtable.kms_key_name=projects/gcloud-devel/locations/us-central1/keyRings/cmek-test-key-ring/cryptoKeys/cmek-test-key \
-    -Dbigtable.wait-for-cmek-key-status=true"
+    value: "-P bigtable-emulator-it,bigtable-prod-it -Dbigtable.project=gcloud-devel -Dbigtable.instance=google-cloud-bigtable -Dbigtable.table=integration-tests -Dbigtable.kms_key_name=projects/gcloud-devel/locations/us-central1/keyRings/cmek-test-key-ring/cryptoKeys/cmek-test-key -Dbigtable.wait-for-cmek-key-status=true"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/integration.cfg
+++ b/.kokoro/presubmit/integration.cfg
@@ -8,7 +8,12 @@ env_vars: {
 
 env_vars: {
     key: "INTEGRATION_TEST_ARGS"
-    value: "-P bigtable-emulator-it,bigtable-prod-it -Dbigtable.project=gcloud-devel -Dbigtable.instance=google-cloud-bigtable -Dbigtable.table=integration-tests"
+    value: "-P bigtable-emulator-it,bigtable-prod-it \
+    -Dbigtable.project=gcloud-devel \
+    -Dbigtable.instance=google-cloud-bigtable \
+    -Dbigtable.table=integration-tests \
+    -Dbigtable.kms_key_name=projects/gcloud-devel/locations/us-central1/keyRings/cmek-test-key-ring/cryptoKeys/cmek-test-key \
+    -Dbigtable.wait-for-cmek-key-status=true"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/integration.cfg
+++ b/.kokoro/presubmit/integration.cfg
@@ -8,12 +8,7 @@ env_vars: {
 
 env_vars: {
     key: "INTEGRATION_TEST_ARGS"
-    value: "-P bigtable-emulator-it,bigtable-prod-it \
-    -Dbigtable.project=gcloud-devel \
-    -Dbigtable.instance=google-cloud-bigtable \
-    -Dbigtable.table=integration-tests \
-    -Dbigtable.kms_key_name=projects/gcloud-devel/locations/us-central1/keyRings/cmek-test-key-ring/cryptoKeys/cmek-test-key \
-    -Dbigtable.wait-for-cmek-key-status=true"
+    value: "-P bigtable-emulator-it,bigtable-prod-it -Dbigtable.project=gcloud-devel -Dbigtable.instance=google-cloud-bigtable -Dbigtable.table=integration-tests -Dbigtable.kms_key_name=projects/gcloud-devel/locations/us-central1/keyRings/cmek-test-key-ring/cryptoKeys/cmek-test-key -Dbigtable.wait-for-cmek-key-status=true"
 }
 
 env_vars: {

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -215,6 +215,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.truth.extensions</groupId>
+      <artifactId>truth-proto-extension</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/Backup.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/Backup.java
@@ -142,6 +142,18 @@ public class Backup {
     return State.fromProto(proto.getState());
   }
 
+  /**
+   * Get the encryption information for the backup.
+   *
+   * <p>If encryption_type is CUSTOMER_MANAGED_ENCRYPTION, kms_key_version will be filled in with
+   * status UNKNOWN.
+   *
+   * <p>If encryption_type is GOOGLE_DEFAULT_ENCRYPTION, all other fields will have default value.
+   */
+  public EncryptionInfo getEncryptionInfo() {
+    return EncryptionInfo.fromProto(proto.getEncryptionInfo());
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/Cluster.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/Cluster.java
@@ -30,6 +30,7 @@ import javax.annotation.Nonnull;
  * in the instance.
  */
 public class Cluster {
+
   public enum State {
     /** The state of the cluster could not be determined. */
     NOT_KNOWN(com.google.bigtable.admin.v2.Cluster.State.STATE_NOT_KNOWN),
@@ -154,6 +155,18 @@ public class Cluster {
   @SuppressWarnings("WeakerAccess")
   public StorageType getStorageType() {
     return StorageType.fromProto(stateProto.getDefaultStorageType());
+  }
+
+  /**
+   * Google Cloud Key Management Service (KMS) settings for a CMEK-protected Bigtable cluster. This
+   * returns the full resource name of the Cloud KMS key in the format
+   * `projects/{key_project_id}/locations/{location}/keyRings/{ring_name}/cryptoKeys/{key_name}`
+   */
+  public String getKmsKeyName() {
+    if (stateProto.hasEncryptionConfig()) {
+      return stateProto.getEncryptionConfig().getKmsKeyName();
+    }
+    return null;
   }
 
   @Override

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateClusterRequest.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateClusterRequest.java
@@ -49,6 +49,7 @@ import javax.annotation.Nonnull;
  *     details</a>
  */
 public final class CreateClusterRequest {
+
   private final com.google.bigtable.admin.v2.CreateClusterRequest.Builder proto =
       com.google.bigtable.admin.v2.CreateClusterRequest.newBuilder();
   // instanceId and zone are short ids, which will be expanded to full names when the project name
@@ -101,6 +102,17 @@ public final class CreateClusterRequest {
         storageType != StorageType.UNRECOGNIZED, "StorageType can't be UNRECOGNIZED");
 
     proto.getClusterBuilder().setDefaultStorageType(storageType.toProto());
+    return this;
+  }
+
+  /**
+   * Sets the Google Cloud Key Management Service (KMS) key for a CMEK-protected Bigtable. This
+   * requires the full resource name of the Cloud KMS key, in the format
+   * `projects/{key_project_id}/locations/{location}/keyRings/{ring_name}/cryptoKeys/{key_name}`
+   */
+  public CreateClusterRequest setKmsKeyName(@Nonnull String kmsKeyName) {
+    Preconditions.checkNotNull(kmsKeyName);
+    proto.getClusterBuilder().getEncryptionConfigBuilder().setKmsKeyName(kmsKeyName);
     return this;
   }
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateInstanceRequest.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateInstanceRequest.java
@@ -148,6 +148,35 @@ public final class CreateInstanceRequest {
   }
 
   /**
+   * Adds a CMEK protected cluster using the specified KMS key name.
+   *
+   * @param clusterId the name of the cluster.
+   * @param zone the zone where the cluster will be created.
+   * @param serveNodes the number of nodes that cluster will contain. DEVELOPMENT instance clusters
+   *     must have exactly one node.
+   * @param storageType the type of storage used by this cluster to serve its parent instance's
+   *     tables.
+   * @param kmsKeyName the full name of the KMS key name to use in the format
+   *     `projects/{key_project_id}/locations/{location}/keyRings/{ring_name}/cryptoKeys/{key_name}`
+   */
+  public CreateInstanceRequest addCmekCluster(
+      @Nonnull String clusterId,
+      @Nonnull String zone,
+      int serveNodes,
+      @Nonnull StorageType storageType,
+      @Nonnull String kmsKeyName) {
+    CreateClusterRequest clusterRequest =
+        CreateClusterRequest.of("ignored-instance-id", clusterId)
+            .setZone(zone)
+            .setServeNodes(serveNodes)
+            .setStorageType(storageType)
+            .setKmsKeyName(kmsKeyName);
+    clusterRequests.add(clusterRequest);
+
+    return this;
+  }
+
+  /**
    * Adds a DEVELOPMENT cluster to the instance request.
    *
    * <p>This instance will have exactly one node cluster.

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/EncryptionInfo.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/EncryptionInfo.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2.models;
+
+import com.google.bigtable.admin.v2.EncryptionInfo.EncryptionType;
+import com.google.cloud.bigtable.common.Status;
+import com.google.common.base.Objects;
+
+/**
+ * Encryption information for a given resource.
+ *
+ * <p>If this resource is protected with customer managed encryption, the in-use Google Cloud Key
+ * Management Service (KMS) key versions will be specified along with their status.
+ */
+public final class EncryptionInfo {
+  public enum Type {
+    /** Encryption type was not specified, though data at rest remains encrypted. */
+    ENCRYPTION_TYPE_UNSPECIFIED(
+        com.google.bigtable.admin.v2.EncryptionInfo.EncryptionType.ENCRYPTION_TYPE_UNSPECIFIED),
+    /**
+     * The data backing this resource is encrypted at rest with a key that is fully managed by
+     * Google. No key version or status will be populated.
+     */
+    GOOGLE_DEFAULT_ENCRYPTION(
+        com.google.bigtable.admin.v2.EncryptionInfo.EncryptionType.GOOGLE_DEFAULT_ENCRYPTION),
+    /**
+     * The data backing this resource is encrypted at rest with a key that is fully managed by
+     * Google. No key version or status will be populated. This is the default state.
+     */
+    CUSTOMER_MANAGED_ENCRYPTION(
+        com.google.bigtable.admin.v2.EncryptionInfo.EncryptionType.CUSTOMER_MANAGED_ENCRYPTION),
+    /** Type not known by the client, please upgrade your client */
+    UNRECOGNIZED(com.google.bigtable.admin.v2.EncryptionInfo.EncryptionType.UNRECOGNIZED);
+
+    private final com.google.bigtable.admin.v2.EncryptionInfo.EncryptionType proto;
+
+    Type(EncryptionType proto) {
+      this.proto = proto;
+    }
+
+    /** Wraps the EncryptionInfo protobuf. */
+    public static Type fromProto(com.google.bigtable.admin.v2.EncryptionInfo.EncryptionType proto) {
+      for (Type type : values()) {
+        if (Objects.equal(type.proto, proto)) {
+          return type;
+        }
+      }
+      return UNRECOGNIZED;
+    }
+  }
+
+  private com.google.bigtable.admin.v2.EncryptionInfo proto;
+
+  public static EncryptionInfo fromProto(com.google.bigtable.admin.v2.EncryptionInfo proto) {
+    return new EncryptionInfo(proto);
+  }
+
+  private EncryptionInfo(com.google.bigtable.admin.v2.EncryptionInfo proto) {
+    this.proto = proto;
+  }
+
+  public Type getType() {
+    return EncryptionInfo.Type.fromProto(proto.getEncryptionType());
+  }
+
+  public String getKmsKeyVersion() {
+    return proto.getKmsKeyVersion();
+  }
+
+  public Status getStatus() {
+    return Status.fromProto(proto.getEncryptionStatus());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    EncryptionInfo that = (EncryptionInfo) o;
+    return Objects.equal(proto, that.proto);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(proto);
+  }
+
+  @Override
+  public String toString() {
+    return proto.toString();
+  }
+}

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/common/Status.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/common/Status.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.common;
+
+import com.google.common.base.Objects;
+
+/**
+ * The `Status` type defines a logical error model. Each `Status` message contains an error code and
+ * a error message.
+ *
+ * <p>This primarily wraps the protobuf {@link com.google.rpc.Status}.
+ */
+public final class Status {
+  public enum Code {
+    OK(com.google.rpc.Code.OK),
+    CANCELLED(com.google.rpc.Code.CANCELLED),
+    UNKNOWN(com.google.rpc.Code.UNKNOWN),
+    INVALID_ARGUMENT(com.google.rpc.Code.INVALID_ARGUMENT),
+    DEADLINE_EXCEEDED(com.google.rpc.Code.DEADLINE_EXCEEDED),
+    NOT_FOUND(com.google.rpc.Code.NOT_FOUND),
+    ALREADY_EXISTS(com.google.rpc.Code.ALREADY_EXISTS),
+    PERMISSION_DENIED(com.google.rpc.Code.PERMISSION_DENIED),
+    UNAUTHENTICATED(com.google.rpc.Code.UNAUTHENTICATED),
+    RESOURCE_EXHAUSTED(com.google.rpc.Code.RESOURCE_EXHAUSTED),
+    FAILED_PRECONDITION(com.google.rpc.Code.FAILED_PRECONDITION),
+    ABORTED(com.google.rpc.Code.ABORTED),
+    OUT_OF_RANGE(com.google.rpc.Code.OUT_OF_RANGE),
+    UNIMPLEMENTED(com.google.rpc.Code.UNIMPLEMENTED),
+    INTERNAL(com.google.rpc.Code.INTERNAL),
+    UNAVAILABLE(com.google.rpc.Code.UNAVAILABLE),
+    DATA_LOSS(com.google.rpc.Code.DATA_LOSS),
+
+    /** Code not known by the client, please upgrade your client */
+    UNRECOGNIZED(com.google.rpc.Code.UNRECOGNIZED);
+
+    private final com.google.rpc.Code proto;
+
+    public static Code fromProto(com.google.rpc.Code proto) {
+      for (Code code : values()) {
+        if (code.proto.equals(proto)) {
+          return code;
+        }
+      }
+      return UNRECOGNIZED;
+    }
+
+    public static Code fromCodeNumber(int num) {
+      for (Code code : values()) {
+        if (code.proto == com.google.rpc.Code.UNRECOGNIZED) {
+          continue;
+        }
+        if (code.proto.getNumber() == num) {
+          return code;
+        }
+      }
+      return UNRECOGNIZED;
+    }
+
+    Code(com.google.rpc.Code proto) {
+      this.proto = proto;
+    }
+
+    public com.google.rpc.Code toProto() {
+      return proto;
+    }
+  }
+
+  private final com.google.rpc.Status proto;
+
+  /** Wraps the given protobuf Status */
+  public static Status fromProto(com.google.rpc.Status proto) {
+    return new Status(proto);
+  }
+
+  private Status(com.google.rpc.Status proto) {
+    this.proto = proto;
+  }
+
+  /** Gets the typesafe code. */
+  public Code getCode() {
+    return Code.fromCodeNumber(proto.getCode());
+  }
+
+  /** Gets error message. */
+  public String getMessage() {
+    return proto.getMessage();
+  }
+
+  /** Gets the underlying protobuf. */
+  public com.google.rpc.Status toProto() {
+    return proto;
+  }
+
+  public String toString() {
+    return proto.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Status status = (Status) o;
+    return Objects.equal(proto, status.proto);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(proto);
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
@@ -102,8 +102,12 @@ public class BigtableCmekIT {
 
   @AfterClass
   public static void teardown() {
-    tableAdmin.close();
-    instanceAdmin.close();
+    if (tableAdmin != null) {
+      tableAdmin.close();
+    }
+    if (instanceAdmin != null) {
+      instanceAdmin.close();
+    }
   }
 
   @Test
@@ -147,7 +151,7 @@ public class BigtableCmekIT {
                     + kmsKeyName
                     + " cannot be used to protect a cluster in zone "
                     + NameUtil.formatLocationName(
-                    testEnvRule.env().getProjectId(), nonPrimaryRegionZoneId));
+                        testEnvRule.env().getProjectId(), nonPrimaryRegionZoneId));
       }
     } finally {
       instanceAdmin.deleteInstance(instanceId);
@@ -168,8 +172,8 @@ public class BigtableCmekIT {
       if (testEnvRule.env().shouldWaitForCmekKeyStatusUpdate()) {
         waitForCmekStatus(TEST_TABLE_ID, clusterId1);
       }
-      Map<String, List<EncryptionInfo>> encryptionInfos = tableAdmin
-          .getEncryptionInfo(TEST_TABLE_ID);
+      Map<String, List<EncryptionInfo>> encryptionInfos =
+          tableAdmin.getEncryptionInfo(TEST_TABLE_ID);
       assertThat(encryptionInfos).hasSize(1);
       assertThat(encryptionInfos.get(clusterId1)).hasSize(1);
       EncryptionInfo encryptionInfo = encryptionInfos.get(clusterId1).get(0);
@@ -179,7 +183,8 @@ public class BigtableCmekIT {
       if (testEnvRule.env().shouldWaitForCmekKeyStatusUpdate()) {
         assertThat(encryptionInfo.getStatus().getCode()).isEqualTo(Status.Code.OK);
       }
-      // For up to 5 minutes after a table is newly created, the key version and status fields are not
+      // For up to 5 minutes after a table is newly created, the key version and status fields are
+      // not
       // populated.
       // Set the `bigtable.wait-for-cmek-key-status` system property to `true` when running the test
       // in order to poll until the final state can be asserted.

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
@@ -180,7 +180,7 @@ public class BigtableCmekIT {
       waitForCmekStatus(TEST_TABLE_ID, clusterId);
     }
     Map<String, List<EncryptionInfo>> encryptionInfos = tableAdmin.getEncryptionInfo(TEST_TABLE_ID);
-    assertThat(encryptionInfos).hasSize(2);
+    assertThat(encryptionInfos).hasSize(1);
     assertThat(encryptionInfos.get(clusterId)).hasSize(1);
     EncryptionInfo encryptionInfo = encryptionInfos.get(clusterId).get(0);
     assertThat(encryptionInfo.getType()).isEqualTo(EncryptionInfo.Type.CUSTOMER_MANAGED_ENCRYPTION);

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
@@ -80,7 +80,8 @@ public class BigtableCmekIT {
         .isNotInstanceOf(EmulatorEnv.class);
 
     kmsKeyName = testEnvRule.env().getKmsKeyName();
-    assume().withMessage("%s property is not set, skipping CMEK test", kmsKeyName);
+    assertThat(kmsKeyName).isNotNull();
+    assertThat(kmsKeyName).isNotEmpty();
   }
 
   @Before
@@ -102,7 +103,7 @@ public class BigtableCmekIT {
   @After
   public void teardown() {
     try {
-      for (String backup : tableAdmin.listBackups("-")) {
+      for (String backup : tableAdmin.listBackups(clusterId)) {
         tableAdmin.deleteBackup(clusterId, backup);
       }
     } catch (NotFoundException ignored) {
@@ -114,6 +115,7 @@ public class BigtableCmekIT {
     }
 
     tableAdmin.close();
+    instanceAdmin.close();
   }
 
   @Test
@@ -163,6 +165,7 @@ public class BigtableCmekIT {
     }
   }
 
+  @Test
   public void tableTest() throws Exception {
     String zoneId = testEnvRule.env().getPrimaryZone();
 
@@ -200,6 +203,7 @@ public class BigtableCmekIT {
     }
   }
 
+  @Test
   public void backupTest() throws Exception {
     String backupId = "test-table-for-cmek-it-backup";
     String zoneId = testEnvRule.env().getPrimaryZone();

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2.it;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
+import static org.junit.Assert.fail;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
+import com.google.cloud.bigtable.admin.v2.models.Backup;
+import com.google.cloud.bigtable.admin.v2.models.Cluster;
+import com.google.cloud.bigtable.admin.v2.models.CreateBackupRequest;
+import com.google.cloud.bigtable.admin.v2.models.CreateClusterRequest;
+import com.google.cloud.bigtable.admin.v2.models.CreateInstanceRequest;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.EncryptionInfo;
+import com.google.cloud.bigtable.admin.v2.models.StorageType;
+import com.google.cloud.bigtable.common.Status;
+import com.google.cloud.bigtable.common.Status.Code;
+import com.google.cloud.bigtable.test_helpers.env.AbstractTestEnv;
+import com.google.cloud.bigtable.test_helpers.env.EmulatorEnv;
+import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.threeten.bp.Instant;
+import org.threeten.bp.temporal.ChronoUnit;
+
+/**
+ * Tests our CMEK offering. It can take up to 5 mins after a CMEK-protected table is created for the
+ * key version and status fields to be populated. Set the `bigtable.wait-for-cmek-key-status` system
+ * property to `true` when running the test in order to poll until the final state can be asserted.
+ */
+@RunWith(JUnit4.class)
+public class BigtableCmekIT {
+
+  private static final int[] BACKOFF_DURATION = {5, 10, 50, 100, 150, 200, 250, 300};
+  private static final Logger LOGGER = Logger.getLogger(BigtableCmekIT.class.getName());
+  private static final String TEST_TABLE_ID = "test-table-for-cmek-it";
+
+  @ClassRule public static TestEnvRule testEnvRule = new TestEnvRule();
+
+  private String instanceId;
+  private String clusterId;
+  private static String kmsKeyName;
+
+  private BigtableInstanceAdminClient instanceAdmin;
+  private BigtableTableAdminClient tableAdmin;
+
+  @BeforeClass
+  public static void validatePlatform() {
+    assume()
+        .withMessage("Emulator doesn't support CMEK")
+        .that(testEnvRule.env())
+        .isNotInstanceOf(EmulatorEnv.class);
+
+    kmsKeyName = testEnvRule.env().getKmsKeyName();
+    assume().withMessage("%s property is not set, skipping CMEK test", kmsKeyName);
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    instanceId = AbstractTestEnv.TEST_INSTANCE_PREFIX + Instant.now().getEpochSecond();
+    clusterId = instanceId + "-c1";
+
+    instanceAdmin = testEnvRule.env().getInstanceAdminClient();
+    tableAdmin =
+        BigtableTableAdminClient.create(
+            testEnvRule
+                .env()
+                .getTableAdminSettings()
+                .toBuilder()
+                .setInstanceId(instanceId)
+                .build());
+  }
+
+  @After
+  public void teardown() {
+    try {
+      for (String backup : tableAdmin.listBackups("-")) {
+        tableAdmin.deleteBackup(clusterId, backup);
+      }
+    } catch (NotFoundException ignored) {
+    }
+
+    try {
+      instanceAdmin.deleteInstance(instanceId);
+    } catch (NotFoundException ignored) {
+    }
+
+    tableAdmin.close();
+  }
+
+  @Test
+  public void instanceAndClusterTest() throws Exception {
+    final String secondClusterId = instanceId + "-c2";
+    String zoneId = testEnvRule.env().getPrimaryZone();
+
+    // With a KMS_KEY created and specified using `bigtable.kms_key_name` env variable, create a
+    // CMEK protected instance
+    instanceAdmin.createInstance(
+        CreateInstanceRequest.of(instanceId)
+            .addCmekCluster(clusterId, zoneId, 1, StorageType.SSD, kmsKeyName));
+
+    // Keys are specified per-cluster with each cluster requesting the same key and the cluster's
+    // zone must be within the region of the key
+    Cluster cluster = instanceAdmin.getCluster(instanceId, clusterId);
+    assertThat(cluster.getKmsKeyName()).isEqualTo(kmsKeyName);
+
+    String secondZoneId = testEnvRule.env().getPrimaryRegionSecondZone();
+    instanceAdmin.createCluster(
+        CreateClusterRequest.of(instanceId, secondClusterId)
+            .setZone(secondZoneId)
+            .setServeNodes(1)
+            .setStorageType(StorageType.SSD)
+            .setKmsKeyName(kmsKeyName));
+
+    Cluster secondCluster = instanceAdmin.getCluster(instanceId, secondClusterId);
+    assertThat(secondCluster.getKmsKeyName()).isEqualTo(kmsKeyName);
+
+    final String nonPrimaryRegionZoneId = testEnvRule.env().getSecondaryZone();
+    try {
+      instanceAdmin.createCluster(
+          CreateClusterRequest.of(instanceId, secondClusterId)
+              .setZone(nonPrimaryRegionZoneId)
+              .setServeNodes(1)
+              .setStorageType(StorageType.SSD)
+              .setKmsKeyName(kmsKeyName));
+    } catch (com.google.api.gax.rpc.FailedPreconditionException e) {
+      assertThat(e.getMessage())
+          .contains(
+              "FAILED_PRECONDITION: Error in field 'cluster' : "
+                  + "Error in field 'encryption_config.kms_key_name' : CMEK key "
+                  + kmsKeyName
+                  + " cannot be used to protect a cluster in zone "
+                  + NameUtil.formatLocationName(
+                      testEnvRule.env().getProjectId(), nonPrimaryRegionZoneId));
+    }
+  }
+
+  public void tableTest() throws Exception {
+    String zoneId = testEnvRule.env().getPrimaryZone();
+
+    instanceAdmin.createInstance(
+        CreateInstanceRequest.of(instanceId)
+            .addCmekCluster(clusterId, zoneId, 1, StorageType.SSD, kmsKeyName));
+
+    // Create a table. Key is inherited from the cluster configuration
+    tableAdmin.createTable(CreateTableRequest.of(TEST_TABLE_ID).addFamily("cf"));
+
+    // Confirm that table is CMEK-protected
+    if (testEnvRule.env().shouldWaitForCmekKeyStatusUpdate()) {
+      waitForCmekStatus(TEST_TABLE_ID, clusterId);
+    }
+    Map<String, List<EncryptionInfo>> encryptionInfos = tableAdmin.getEncryptionInfo(TEST_TABLE_ID);
+    assertThat(encryptionInfos).hasSize(2);
+    assertThat(encryptionInfos.get(clusterId)).hasSize(1);
+    EncryptionInfo encryptionInfo = encryptionInfos.get(clusterId).get(0);
+    assertThat(encryptionInfo.getType()).isEqualTo(EncryptionInfo.Type.CUSTOMER_MANAGED_ENCRYPTION);
+    assertThat(encryptionInfo.getStatus().getCode()).isAnyOf(Status.Code.OK, Status.Code.UNKNOWN);
+    if (testEnvRule.env().shouldWaitForCmekKeyStatusUpdate()) {
+      assertThat(encryptionInfo.getStatus().getCode()).isEqualTo(Status.Code.OK);
+    }
+    // For up to 5 minutes after a table is newly created, the key version and status fields are not
+    // populated.
+    // Set the `bigtable.wait-for-cmek-key-status` system property to `true` when running the test
+    // in order to poll until the final state can be asserted.
+    if (encryptionInfo.getStatus().getCode() == Code.UNKNOWN) {
+      assertThat(encryptionInfo.getKmsKeyVersion()).isEmpty();
+      assertThat(encryptionInfo.getStatus().getMessage())
+          .isEqualTo("Key version is not yet known.");
+    } else {
+      assertThat(encryptionInfo.getKmsKeyVersion()).startsWith(kmsKeyName);
+      assertThat(encryptionInfo.getStatus().getMessage()).isEqualTo("");
+    }
+  }
+
+  public void backupTest() throws Exception {
+    String backupId = "test-table-for-cmek-it-backup";
+    String zoneId = testEnvRule.env().getPrimaryZone();
+
+    instanceAdmin.createInstance(
+        CreateInstanceRequest.of(instanceId)
+            .addCmekCluster(clusterId, zoneId, 1, StorageType.SSD, kmsKeyName));
+    tableAdmin.createTable(CreateTableRequest.of(TEST_TABLE_ID).addFamily("cf"));
+
+    // Create a backup.
+    // Backups are pinned to the primary version of their table's CMEK key at the time they are
+    // taken
+    tableAdmin.createBackup(
+        CreateBackupRequest.of(clusterId, backupId)
+            .setExpireTime(Instant.now().plus(6, ChronoUnit.HOURS))
+            .setSourceTableId(TEST_TABLE_ID));
+
+    Backup backup = tableAdmin.getBackup(clusterId, backupId);
+
+    // Confirm encryption details for an existing backup
+    // The backup will be returned with the CMEK key version that the backup is pinned to.
+    // The status of that key version will always be UNKNOWN.
+    assertThat(backup.getEncryptionInfo().getKmsKeyVersion()).startsWith(kmsKeyName);
+    assertThat(backup.getEncryptionInfo().getStatus().getCode()).isEqualTo(Status.Code.UNKNOWN);
+    assertThat(backup.getEncryptionInfo().getType())
+        .isEqualTo(EncryptionInfo.Type.CUSTOMER_MANAGED_ENCRYPTION);
+    assertThat(backup.getEncryptionInfo().getStatus().getMessage())
+        .isEqualTo("Status of the associated key version is not tracked.");
+  }
+
+  private void waitForCmekStatus(String tableId, String clusterId) throws InterruptedException {
+    for (int i = 0; i < BACKOFF_DURATION.length; i++) {
+      try {
+        EncryptionInfo encryptionInfo = tableAdmin.getEncryptionInfo(tableId).get(clusterId).get(0);
+        if (encryptionInfo.getStatus().getCode() == Code.OK) {
+          return;
+        }
+      } catch (ApiException ex) {
+        LOGGER.info(
+            "Wait for "
+                + BACKOFF_DURATION[i]
+                + " seconds for key status for table "
+                + tableId
+                + " and cluster "
+                + clusterId);
+      }
+      Thread.sleep(BACKOFF_DURATION[i] * 1000);
+    }
+    fail("CMEK key status failed to return");
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
@@ -62,6 +62,7 @@ public class BigtableCmekIT {
   private static final int[] BACKOFF_DURATION = {5, 10, 50, 100, 150, 200, 250, 300};
   private static final Logger LOGGER = Logger.getLogger(BigtableCmekIT.class.getName());
   private static final String TEST_TABLE_ID = "test-table-for-cmek-it";
+  private final String BACKUP_ID = "test-table-for-cmek-it-backup";
 
   @ClassRule public static TestEnvRule testEnvRule = new TestEnvRule();
 
@@ -103,9 +104,7 @@ public class BigtableCmekIT {
   @After
   public void teardown() {
     try {
-      for (String backup : tableAdmin.listBackups(clusterId)) {
-        tableAdmin.deleteBackup(clusterId, backup);
-      }
+      tableAdmin.deleteBackup(clusterId, BACKUP_ID);
     } catch (NotFoundException ignored) {
     }
 
@@ -205,7 +204,6 @@ public class BigtableCmekIT {
 
   @Test
   public void backupTest() throws Exception {
-    String backupId = "test-table-for-cmek-it-backup";
     String zoneId = testEnvRule.env().getPrimaryZone();
 
     instanceAdmin.createInstance(
@@ -217,11 +215,11 @@ public class BigtableCmekIT {
     // Backups are pinned to the primary version of their table's CMEK key at the time they are
     // taken
     tableAdmin.createBackup(
-        CreateBackupRequest.of(clusterId, backupId)
+        CreateBackupRequest.of(clusterId, BACKUP_ID)
             .setExpireTime(Instant.now().plus(6, ChronoUnit.HOURS))
             .setSourceTableId(TEST_TABLE_ID));
 
-    Backup backup = tableAdmin.getBackup(clusterId, backupId);
+    Backup backup = tableAdmin.getBackup(clusterId, BACKUP_ID);
 
     // Confirm encryption details for an existing backup
     // The backup will be returned with the CMEK key version that the backup is pinned to.

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/ClusterTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/ClusterTest.java
@@ -17,6 +17,8 @@ package com.google.cloud.bigtable.admin.v2.models;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.bigtable.admin.v2.Cluster.EncryptionConfig;
+import com.google.bigtable.admin.v2.Cluster.State;
 import com.google.common.collect.Lists;
 import java.util.List;
 import org.junit.Test;
@@ -32,7 +34,7 @@ public class ClusterTest {
         com.google.bigtable.admin.v2.Cluster.newBuilder()
             .setName("projects/my-project/instances/my-instance/clusters/my-cluster")
             .setLocation("projects/my-project/locations/us-east1-c")
-            .setState(com.google.bigtable.admin.v2.Cluster.State.READY)
+            .setState(State.READY)
             .setServeNodes(30)
             .setDefaultStorageType(com.google.bigtable.admin.v2.StorageType.SSD)
             .build();
@@ -45,6 +47,30 @@ public class ClusterTest {
     assertThat(result.getState()).isEqualTo(Cluster.State.READY);
     assertThat(result.getServeNodes()).isEqualTo(30);
     assertThat(result.getStorageType()).isEqualTo(StorageType.SSD);
+    assertThat(result.getKmsKeyName()).isEqualTo(null);
+  }
+
+  @Test
+  public void testFromProtoCmek() {
+    com.google.bigtable.admin.v2.Cluster proto =
+        com.google.bigtable.admin.v2.Cluster.newBuilder()
+            .setName("projects/my-project/instances/my-instance/clusters/my-cluster")
+            .setLocation("projects/my-project/locations/us-east1-c")
+            .setState(State.READY)
+            .setServeNodes(30)
+            .setDefaultStorageType(com.google.bigtable.admin.v2.StorageType.SSD)
+            .setEncryptionConfig(
+                EncryptionConfig.newBuilder()
+                    .setKmsKeyName(
+                        "projects/my-project/locations/us-east1-c/keyRings/my-key-ring/cryptoKeys/my-key")
+                    .build())
+            .build();
+
+    Cluster result = Cluster.fromProto(proto);
+
+    assertThat(result.getKmsKeyName())
+        .isEqualTo(
+            "projects/my-project/locations/us-east1-c/keyRings/my-key-ring/cryptoKeys/my-key");
   }
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/CreateClusterRequestTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/CreateClusterRequestTest.java
@@ -16,7 +16,10 @@
 package com.google.cloud.bigtable.admin.v2.models;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 
+import com.google.bigtable.admin.v2.Cluster;
+import com.google.bigtable.admin.v2.Cluster.EncryptionConfig;
 import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -150,5 +153,29 @@ public class CreateClusterRequestTest {
             .build();
 
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void testCmek() {
+    String kmsKeyName =
+        "projects/my-project/locations/us-east1-c/keyRings/my-key-ring/cryptoKeys/my-key";
+
+    CreateInstanceRequest input =
+        CreateInstanceRequest.of("my-instance")
+            .addCmekCluster("cluster1", "us-east1-c", 1, StorageType.SSD, kmsKeyName);
+
+    com.google.bigtable.admin.v2.CreateInstanceRequest actual = input.toProto("my-project");
+
+    assertThat(actual)
+        .comparingExpectedFieldsOnly()
+        .isEqualTo(
+            com.google.bigtable.admin.v2.CreateInstanceRequest.newBuilder()
+                .putClusters(
+                    "cluster1",
+                    Cluster.newBuilder()
+                        .setEncryptionConfig(
+                            EncryptionConfig.newBuilder().setKmsKeyName(kmsKeyName).build())
+                        .build())
+                .build());
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/EncryptionInfoTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/EncryptionInfoTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2.models;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.bigtable.admin.v2.EncryptionInfo.EncryptionType;
+import com.google.cloud.bigtable.common.Status;
+import com.google.common.base.Objects;
+import com.google.rpc.Code;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class EncryptionInfoTest {
+
+  @Test
+  public void testAllTypes() {
+    for (EncryptionType protoValue :
+        com.google.bigtable.admin.v2.EncryptionInfo.EncryptionType.values()) {
+      EncryptionInfo.Type modelValue = EncryptionInfo.Type.fromProto(protoValue);
+
+      assertWithMessage("proto enum value %s should be wrapped", protoValue.toString())
+          .that(modelValue.toString())
+          .isEqualTo(protoValue.toString());
+    }
+
+    com.google.bigtable.admin.v2.EncryptionInfo randomEncryptionInfo =
+        com.google.bigtable.admin.v2.EncryptionInfo.newBuilder().setEncryptionTypeValue(14).build();
+    assertWithMessage("Unrecognized proto enum value should be wrapped")
+        .that(EncryptionInfo.Type.fromProto(randomEncryptionInfo.getEncryptionType()))
+        .isEqualTo(EncryptionInfo.Type.UNRECOGNIZED);
+  }
+
+  @Test
+  public void testFromProto() {
+    com.google.rpc.Status protoStatus =
+        com.google.rpc.Status.newBuilder()
+            .setCode(Code.UNAVAILABLE.getNumber())
+            .setMessage("kms is unavailable")
+            .build();
+
+    com.google.bigtable.admin.v2.EncryptionInfo proto =
+        com.google.bigtable.admin.v2.EncryptionInfo.newBuilder()
+            .setEncryptionType(EncryptionType.CUSTOMER_MANAGED_ENCRYPTION)
+            .setKmsKeyVersion("some version")
+            .setEncryptionStatus(protoStatus)
+            .build();
+    EncryptionInfo encryptionInfo = EncryptionInfo.fromProto(proto);
+
+    assertThat(encryptionInfo.getStatus()).isEqualTo(Status.fromProto(protoStatus));
+    assertThat(encryptionInfo.getType()).isEqualTo(EncryptionInfo.Type.CUSTOMER_MANAGED_ENCRYPTION);
+    assertThat(encryptionInfo.getKmsKeyVersion()).isEqualTo("some version");
+    assertThat(encryptionInfo.toString()).isEqualTo(proto.toString());
+    assertThat(encryptionInfo.hashCode()).isEqualTo(Objects.hashCode(proto));
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/common/StatusTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/common/StatusTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.common;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.rpc.Code;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class StatusTest {
+
+  @Test
+  public void testAllCodes() {
+    for (Code protoValue : com.google.rpc.Code.values()) {
+      Status.Code modelValue = Status.Code.fromProto(protoValue);
+
+      assertWithMessage("proto enum value %s should be wrapped", protoValue.toString())
+          .that(modelValue.toString())
+          .isEqualTo(protoValue.toString());
+    }
+
+    com.google.rpc.Status randomProto =
+        com.google.rpc.Status.newBuilder().setCode(49).setMessage("some message").build();
+    assertWithMessage("Unrecognized proto value should be wrapped")
+        .that(Status.Code.fromProto(com.google.rpc.Code.forNumber(randomProto.getCode())))
+        .isEqualTo(Status.Code.UNRECOGNIZED);
+  }
+
+  @Test
+  public void testAllCodeNumbers() {
+    for (Code protoValue : com.google.rpc.Code.values()) {
+      if (protoValue == com.google.rpc.Code.UNRECOGNIZED) {
+        continue;
+      }
+      Status.Code modelValue = Status.Code.fromCodeNumber(protoValue.getNumber());
+
+      assertWithMessage("proto enum value %s should be wrapped", protoValue.toString())
+          .that(modelValue.toString())
+          .isEqualTo(protoValue.toString());
+    }
+
+    assertWithMessage("Unrecognized proto enum value should be wrapped")
+        .that(Status.Code.fromCodeNumber(-1))
+        .isEqualTo(Status.Code.UNRECOGNIZED);
+  }
+
+  @Test
+  public void testFromProto() {
+    com.google.rpc.Status proto =
+        com.google.rpc.Status.newBuilder()
+            .setCode(Code.UNAVAILABLE.getNumber())
+            .setMessage("some message")
+            .build();
+
+    Status model = Status.fromProto(proto);
+    assertThat(model.getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+    assertThat(model.getMessage()).isEqualTo("some message");
+  }
+
+  @Test
+  public void testToProto() {
+    com.google.rpc.Code code = Code.UNAVAILABLE;
+    com.google.rpc.Status proto =
+        com.google.rpc.Status.newBuilder()
+            .setCode(code.getNumber())
+            .setMessage("some message")
+            .build();
+
+    Status model = Status.fromProto(proto);
+    assertThat(model.getCode().toProto()).isEqualTo(code);
+    assertThat(model.toProto()).isEqualTo(proto);
+
+    assertThat(model.toString()).isEqualTo(proto.toString());
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
@@ -16,7 +16,9 @@
 package com.google.cloud.bigtable.test_helpers.env;
 
 import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
 import com.google.cloud.bigtable.admin.v2.models.AppProfile;
 import com.google.cloud.bigtable.admin.v2.models.Cluster;
 import com.google.cloud.bigtable.admin.v2.models.Instance;
@@ -54,11 +56,17 @@ public abstract class AbstractTestEnv {
 
   public abstract BigtableDataSettings getDataClientSettings();
 
+  public abstract BigtableInstanceAdminSettings getInstanceAdminClientSettings();
+
+  public abstract BigtableTableAdminSettings getTableAdminSettings();
+
   public abstract String getProjectId();
 
   public abstract String getInstanceId();
 
   public abstract String getTableId();
+
+  public abstract String getKmsKeyName();
 
   public String getFamilyId() {
     return "cf";
@@ -88,8 +96,16 @@ public abstract class AbstractTestEnv {
     return Boolean.getBoolean("bigtable.directpath-ipv4only");
   }
 
+  public boolean shouldWaitForCmekKeyStatusUpdate() {
+    return Boolean.getBoolean("bigtable.wait-for-cmek-key-status");
+  }
+
   public String getPrimaryZone() {
     return "us-central1-b";
+  }
+
+  public String getPrimaryRegionSecondZone() {
+    return "us-central1-c";
   }
 
   public String getSecondaryZone() {

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
@@ -63,10 +63,12 @@ class CloudEnv extends AbstractTestEnv {
   private static final String PROJECT_PROPERTY_NAME = "bigtable.project";
   private static final String INSTANCE_PROPERTY_NAME = "bigtable.instance";
   private static final String TABLE_PROPERTY_NAME = "bigtable.table";
+  private static final String CMEK_KMS_KEY_PROPERTY_NAME = "bigtable.kms_key_name";
 
   private final String projectId;
   private final String instanceId;
   private final String tableId;
+  private final String kmsKeyName;
 
   private final BigtableDataSettings.Builder dataSettings;
   private final BigtableTableAdminSettings.Builder tableAdminSettings;
@@ -80,6 +82,7 @@ class CloudEnv extends AbstractTestEnv {
     return new CloudEnv(
         getOptionalProperty(DATA_ENDPOINT_PROPERTY_NAME, ""),
         getOptionalProperty(ADMIN_ENDPOINT_PROPERTY_NAME, ""),
+        getOptionalProperty(CMEK_KMS_KEY_PROPERTY_NAME, ""),
         getRequiredProperty(PROJECT_PROPERTY_NAME),
         getRequiredProperty(INSTANCE_PROPERTY_NAME),
         getRequiredProperty(TABLE_PROPERTY_NAME));
@@ -88,12 +91,14 @@ class CloudEnv extends AbstractTestEnv {
   private CloudEnv(
       @Nullable String dataEndpoint,
       @Nullable String adminEndpoint,
+      @Nullable String kmsKeyName,
       String projectId,
       String instanceId,
       String tableId) {
     this.projectId = projectId;
     this.instanceId = instanceId;
     this.tableId = tableId;
+    this.kmsKeyName = kmsKeyName;
 
     this.dataSettings =
         BigtableDataSettings.newBuilder().setProjectId(projectId).setInstanceId(instanceId);
@@ -192,6 +197,25 @@ class CloudEnv extends AbstractTestEnv {
   }
 
   @Override
+  public BigtableInstanceAdminSettings getInstanceAdminClientSettings() {
+    try {
+      return instanceAdminSettings.build();
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "Caught unexpected error building instance admin settings", e);
+    }
+  }
+
+  @Override
+  public BigtableTableAdminSettings getTableAdminSettings() {
+    try {
+      return tableAdminSettings.build();
+    } catch (IOException e) {
+      throw new IllegalStateException("Caught unexpected error building table admin settings", e);
+    }
+  }
+
+  @Override
   public String getProjectId() {
     return projectId;
   }
@@ -204,6 +228,10 @@ class CloudEnv extends AbstractTestEnv {
   @Override
   public String getTableId() {
     return tableId;
+  }
+
+  public String getKmsKeyName() {
+    return kmsKeyName;
   }
 
   private static String getOptionalProperty(String prop, String defaultValue) {

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/EmulatorEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/EmulatorEnv.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.test_helpers.env;
 
 import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
@@ -38,6 +39,7 @@ public class EmulatorEnv extends AbstractTestEnv {
   private BigtableDataClient dataClient;
 
   private BigtableDataSettings dataSettings;
+  private BigtableTableAdminSettings tableAdminSettings;
 
   public static EmulatorEnv createBundled() {
     return new EmulatorEnv();
@@ -63,12 +65,13 @@ public class EmulatorEnv extends AbstractTestEnv {
 
     dataClient = BigtableDataClient.create(dataSettings);
 
-    tableAdminClient =
-        BigtableTableAdminClient.create(
-            BigtableTableAdminSettings.newBuilderForEmulator(emulator.getPort())
-                .setProjectId("fake-project")
-                .setInstanceId("fake-instance")
-                .build());
+    tableAdminSettings =
+        BigtableTableAdminSettings.newBuilderForEmulator(emulator.getPort())
+            .setProjectId("fake-project")
+            .setInstanceId("fake-instance")
+            .build();
+
+    tableAdminClient = BigtableTableAdminClient.create(tableAdminSettings);
 
     tableAdminClient.createTable(CreateTableRequest.of(TABLE_ID).addFamily(getFamilyId()));
   }
@@ -83,6 +86,16 @@ public class EmulatorEnv extends AbstractTestEnv {
   @Override
   public BigtableDataSettings getDataClientSettings() {
     return dataSettings;
+  }
+
+  @Override
+  public BigtableInstanceAdminSettings getInstanceAdminClientSettings() {
+    throw new UnsupportedOperationException("instance admin is not support by the emulator");
+  }
+
+  @Override
+  public BigtableTableAdminSettings getTableAdminSettings() {
+    return tableAdminSettings;
   }
 
   @Override
@@ -124,6 +137,10 @@ public class EmulatorEnv extends AbstractTestEnv {
   @Override
   public BigtableInstanceAdminClient getInstanceAdminClient() {
     throw new UnsupportedOperationException("InstanceAdminClient is not supported with emulator");
+  }
+
+  public String getKmsKeyName() {
+    throw new UnsupportedOperationException("CMEK is not supported with emulator");
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,12 @@
                 <version>1.1.2</version>
             </dependency>
             <dependency>
+                <groupId>com.google.truth.extensions</groupId>
+                <artifactId>truth-proto-extension</artifactId>
+                <version>1.0.1</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.13.2</version>


### PR DESCRIPTION
#673 

### Summary
All data at rest is typically encrypted with Google's default encryption. This feature will provide support for Customer Managed Encryption Keys (CMEK) in the JAVA client, allowing users to control their encryption keys. CMEK data at rest is protected using an encryption key that users control and manage through Cloud Key Management Service (Cloud KMS).

### Checklist
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


