### PR TITLE
test: small refactor to cmek test

### DIFF
--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
@@ -104,12 +104,12 @@ public class BigtableCmekIT {
 
   @AfterClass
   public static void teardown() {
-    if(tableAdmin != null) {
+    if (tableAdmin != null) {
       tableAdmin.deleteBackup(clusterId1, BACKUP_ID);
       tableAdmin.deleteTable(TEST_TABLE_ID);
       tableAdmin.close();
     }
-    if(instanceAdmin != null) {
+    if (instanceAdmin != null) {
       instanceAdmin.deleteInstance(instanceId);
       instanceAdmin.close();
     }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
@@ -104,14 +104,13 @@ public class BigtableCmekIT {
 
   @AfterClass
   public static void teardown() {
-    tableAdmin.deleteBackup(clusterId1, BACKUP_ID);
-    tableAdmin.deleteTable(TEST_TABLE_ID);
-    instanceAdmin.deleteInstance(instanceId);
-
-    if (tableAdmin != null) {
+    if(tableAdmin != null) {
+      tableAdmin.deleteBackup(clusterId1, BACKUP_ID);
+      tableAdmin.deleteTable(TEST_TABLE_ID);
       tableAdmin.close();
     }
-    if (instanceAdmin != null) {
+    if(instanceAdmin != null) {
+      instanceAdmin.deleteInstance(instanceId);
       instanceAdmin.close();
     }
   }


### PR DESCRIPTION
move `finally` blocks to `AfterClass`, move instance and table creation to `BeforeClass`

Add additional assertion when failure is expected