### PR TITLE
chore: update DirectPath profiles

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -330,7 +330,7 @@
                     <bigtable.data-endpoint>${bigtable.directpath-data-endpoint}</bigtable.data-endpoint>
                     <bigtable.admin-endpoint>${bigtable.directpath-admin-endpoint}</bigtable.admin-endpoint>
                     <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-it</bigtable.grpc-log-dir>
-                    <bigtable.connection-mode>RequireDirectPath</bigtable.connection-mode>
+                    <bigtable.connection-mode>REQUIRE_DIRECT_PATH</bigtable.connection-mode>
                   </systemPropertyVariables>
                   <includes>
                     <!-- TODO(igorbernstein): Once the control plane is accessible via directpath, add admin tests -->
@@ -367,7 +367,7 @@
                     <bigtable.data-endpoint>${bigtable.cfe-data-endpoint}</bigtable.data-endpoint>
                     <bigtable.admin-endpoint>${bigtable.cfe-admin-endpoint}</bigtable.admin-endpoint>
                     <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/cfe-it</bigtable.grpc-log-dir>
-                    <bigtable.connection-mode>RequireCfe</bigtable.connection-mode>
+                    <bigtable.connection-mode>REQUIRE_CFE</bigtable.connection-mode>
                   </systemPropertyVariables>
                   <includes>
                     <include>com.google.cloud.bigtable.**.it.*IT</include>
@@ -404,7 +404,7 @@
                     <bigtable.data-endpoint>${bigtable.directpath-data-endpoint}</bigtable.data-endpoint>
                     <bigtable.admin-endpoint>${bigtable.directpath-admin-endpoint}</bigtable.admin-endpoint>
                     <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-ipv4only-it</bigtable.grpc-log-dir>
-                    <bigtable.connection-mode>RequireDirectPathIPv4</bigtable.connection-mode>
+                    <bigtable.connection-mode>REQUIRE_DIRECT_PATH_IPV4</bigtable.connection-mode>
                   </systemPropertyVariables>
                   <includes>
                     <!-- TODO(igorbernstein): Once the control plane is accessible via directpath, add admin tests -->

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -330,7 +330,7 @@
                     <bigtable.data-endpoint>${bigtable.directpath-data-endpoint}</bigtable.data-endpoint>
                     <bigtable.admin-endpoint>${bigtable.directpath-admin-endpoint}</bigtable.admin-endpoint>
                     <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-it</bigtable.grpc-log-dir>
-                    <bigtable.attempt-directpath>true</bigtable.attempt-directpath>
+                    <bigtable.connection-mode>RequireDirectPath</bigtable.connection-mode>
                   </systemPropertyVariables>
                   <includes>
                     <!-- TODO(igorbernstein): Once the control plane is accessible via directpath, add admin tests -->
@@ -345,6 +345,43 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>bigtable-cfe-it</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>cfe-it</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <skip>false</skip>
+
+                  <systemPropertyVariables>
+                    <bigtable.env>cloud</bigtable.env>
+                    <bigtable.data-endpoint>${bigtable.cfe-data-endpoint}</bigtable.data-endpoint>
+                    <bigtable.admin-endpoint>${bigtable.cfe-admin-endpoint}</bigtable.admin-endpoint>
+                    <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/cfe-it</bigtable.grpc-log-dir>
+                    <bigtable.connection-mode>RequireCfe</bigtable.connection-mode>
+                  </systemPropertyVariables>
+                  <includes>
+                    <include>com.google.cloud.bigtable.**.it.*IT</include>
+                  </includes>
+                  <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-cfe-it.xml</summaryFile>
+                  <reportsDirectory>${project.build.directory}/failsafe-reports/cfe-it</reportsDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
 
     <profile>
       <id>bigtable-directpath-ipv4only-it</id>
@@ -367,8 +404,7 @@
                     <bigtable.data-endpoint>${bigtable.directpath-data-endpoint}</bigtable.data-endpoint>
                     <bigtable.admin-endpoint>${bigtable.directpath-admin-endpoint}</bigtable.admin-endpoint>
                     <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/directpath-ipv4only-it</bigtable.grpc-log-dir>
-                    <bigtable.attempt-directpath>true</bigtable.attempt-directpath>
-                    <bigtable.directpath-ipv4only>true</bigtable.directpath-ipv4only>
+                    <bigtable.connection-mode>RequireDirectPathIPv4</bigtable.connection-mode>
                   </systemPropertyVariables>
                   <includes>
                     <!-- TODO(igorbernstein): Once the control plane is accessible via directpath, add admin tests -->

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
@@ -93,7 +93,8 @@ public class DirectPathFallbackIT {
   @Before
   public void setup() throws IOException {
     Set<ConnectionMode> validModes =
-        ImmutableSet.of(ConnectionMode.REQUIRE_DIRECT_PATH, ConnectionMode.REQUIRE_DIRECT_PATH_IPV4);
+        ImmutableSet.of(
+            ConnectionMode.REQUIRE_DIRECT_PATH, ConnectionMode.REQUIRE_DIRECT_PATH_IPV4);
     assume()
         .withMessage("DirectPathFallbackIT can only return when explicitly requested")
         .that(validModes.contains(testEnvRule.env().getConnectionMode()))

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
@@ -93,7 +93,7 @@ public class DirectPathFallbackIT {
   @Before
   public void setup() throws IOException {
     Set<ConnectionMode> validModes =
-        ImmutableSet.of(ConnectionMode.RequireDirectPath, ConnectionMode.RequireDirectPathIPv4);
+        ImmutableSet.of(ConnectionMode.REQUIRE_DIRECT_PATH, ConnectionMode.REQUIRE_DIRECT_PATH_IPV4);
     assume()
         .withMessage("DirectPathFallbackIT can only return when explicitly requested")
         .that(validModes.contains(testEnvRule.env().getConnectionMode()))

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/DirectPathFallbackIT.java
@@ -24,8 +24,10 @@ import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.test_helpers.env.AbstractTestEnv.ConnectionMode;
 import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableSet;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.alts.ComputeEngineChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
@@ -42,6 +44,7 @@ import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -89,9 +92,11 @@ public class DirectPathFallbackIT {
 
   @Before
   public void setup() throws IOException {
+    Set<ConnectionMode> validModes =
+        ImmutableSet.of(ConnectionMode.RequireDirectPath, ConnectionMode.RequireDirectPathIPv4);
     assume()
-        .withMessage("DirectPath integration tests can only run against DirectPathEnv")
-        .that(testEnvRule.env().isDirectPathEnabled())
+        .withMessage("DirectPathFallbackIT can only return when explicitly requested")
+        .that(validModes.contains(testEnvRule.env().getConnectionMode()))
         .isTrue();
 
     BigtableDataSettings defaultSettings = testEnvRule.env().getDataClientSettings();

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
@@ -89,9 +89,11 @@ public abstract class AbstractTestEnv {
   }
 
   public ConnectionMode getConnectionMode() {
-    return MoreObjects.firstNonNull(
-        ConnectionMode.valueOf(System.getProperty("bigtable.connection-mode")),
-        ConnectionMode.Default);
+    String modeStr =
+        MoreObjects.firstNonNull(
+            System.getProperty("bigtable.connection-mode"), ConnectionMode.Default.name());
+
+    return ConnectionMode.valueOf(modeStr);
   }
 
   public String getPrimaryZone() {

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
@@ -39,10 +39,10 @@ public abstract class AbstractTestEnv {
   public static final String TEST_APP_PREFIX = "temp-Ap-";
 
   public enum ConnectionMode {
-    Default,
-    RequireCfe,
-    RequireDirectPath,
-    RequireDirectPathIPv4
+    DEFAULT,
+    REQUIRE_CFE,
+    REQUIRE_DIRECT_PATH,
+    REQUIRE_DIRECT_PATH_IPV4
   }
 
   abstract void start() throws Exception;
@@ -91,7 +91,7 @@ public abstract class AbstractTestEnv {
   public ConnectionMode getConnectionMode() {
     String modeStr =
         MoreObjects.firstNonNull(
-            System.getProperty("bigtable.connection-mode"), ConnectionMode.Default.name());
+            System.getProperty("bigtable.connection-mode"), ConnectionMode.DEFAULT.name());
 
     return ConnectionMode.valueOf(modeStr);
   }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
@@ -22,6 +22,7 @@ import com.google.cloud.bigtable.admin.v2.models.Cluster;
 import com.google.cloud.bigtable.admin.v2.models.Instance;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import org.threeten.bp.Instant;
 import org.threeten.bp.temporal.ChronoUnit;
@@ -36,6 +37,13 @@ public abstract class AbstractTestEnv {
   public static final String TEST_INSTANCE_PREFIX = "temp-instance-";
   public static final String TEST_CLUSTER_PREFIX = "temp-cluster-";
   public static final String TEST_APP_PREFIX = "temp-Ap-";
+
+  public enum ConnectionMode {
+    Default,
+    RequireCfe,
+    RequireDirectPath,
+    RequireDirectPathIPv4
+  }
 
   abstract void start() throws Exception;
 
@@ -80,12 +88,10 @@ public abstract class AbstractTestEnv {
     return true;
   }
 
-  public boolean isDirectPathEnabled() {
-    return Boolean.getBoolean("bigtable.attempt-directpath");
-  }
-
-  public boolean isDirectPathIpv4Only() {
-    return Boolean.getBoolean("bigtable.directpath-ipv4only");
+  public ConnectionMode getConnectionMode() {
+    return MoreObjects.firstNonNull(
+        ConnectionMode.valueOf(System.getProperty("bigtable.connection-mode")),
+        ConnectionMode.Default);
   }
 
   public String getPrimaryZone() {

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
@@ -17,14 +17,19 @@ package com.google.cloud.bigtable.test_helpers.env;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
-import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.api.gax.rpc.StubSettings;
 import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
 import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings;
+import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -37,9 +42,12 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -53,9 +61,20 @@ import javax.annotation.Nullable;
  * </ul>
  */
 class CloudEnv extends AbstractTestEnv {
-  // IP address prefixes allocated for DirectPath backends.
-  public static final String DP_IPV6_PREFIX = "2001:4860:8040";
-  public static final String DP_IPV4_PREFIX = "34.126";
+  private static final Predicate<InetSocketAddress> DIRECT_PATH_IPV6_MATCHER =
+      new Predicate<InetSocketAddress>() {
+        @Override
+        public boolean apply(InetSocketAddress input) {
+          return input.toString().startsWith("2001:4860:8040");
+        }
+      };
+  private static final Predicate<InetSocketAddress> DIRECT_PATH_IPV4_MATCHER =
+      new Predicate<InetSocketAddress>() {
+        @Override
+        public boolean apply(InetSocketAddress input) {
+          return input.toString().startsWith("34.126");
+        }
+      };
 
   private static final String DATA_ENDPOINT_PROPERTY_NAME = "bigtable.data-endpoint";
   private static final String ADMIN_ENDPOINT_PROPERTY_NAME = "bigtable.admin-endpoint";
@@ -101,25 +120,8 @@ class CloudEnv extends AbstractTestEnv {
       dataSettings.stubSettings().setEndpoint(dataEndpoint);
     }
 
-    if (isDirectPathEnabled()) {
-      TransportChannelProvider channelProvider =
-          dataSettings.stubSettings().getTransportChannelProvider();
-      InstantiatingGrpcChannelProvider defaultTransportProvider =
-          (InstantiatingGrpcChannelProvider) channelProvider;
-      InstantiatingGrpcChannelProvider instrumentedTransportChannelProvider =
-          defaultTransportProvider
-              .toBuilder()
-              .setChannelConfigurator(
-                  new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
-                    @Override
-                    public ManagedChannelBuilder apply(ManagedChannelBuilder builder) {
-                      builder.intercept(directPathAddressCheckInterceptor());
-                      return builder;
-                    }
-                  })
-              .build();
-      dataSettings.stubSettings().setTransportChannelProvider(instrumentedTransportChannelProvider);
-    }
+    setupRemoteAddrInterceptor(dataSettings.stubSettings());
+    configureUserAgent(dataSettings.stubSettings());
 
     this.tableAdminSettings =
         BigtableTableAdminSettings.newBuilder().setProjectId(projectId).setInstanceId(instanceId);
@@ -131,6 +133,131 @@ class CloudEnv extends AbstractTestEnv {
     if (!Strings.isNullOrEmpty(adminEndpoint)) {
       this.instanceAdminSettings.stubSettings().setEndpoint(adminEndpoint);
     }
+  }
+
+  private void setupRemoteAddrInterceptor(StubSettings.Builder stubSettings) {
+    // Build an remote address restricting interceptor
+    final ClientInterceptor interceptor;
+
+    switch (getConnectionMode()) {
+      case Default:
+        // nothing special
+        return;
+      case RequireDirectPath:
+        interceptor =
+            buildRemoteAddrInterceptor(
+                "DirectPath IPv4 or IPv6",
+                Predicates.or(DIRECT_PATH_IPV4_MATCHER, DIRECT_PATH_IPV6_MATCHER));
+        break;
+      case RequireDirectPathIPv4:
+        interceptor =
+            buildRemoteAddrInterceptor("DirectPath IPv4", Predicates.or(DIRECT_PATH_IPV4_MATCHER));
+        break;
+      case RequireCfe:
+        interceptor =
+            buildRemoteAddrInterceptor(
+                "a CFE ip",
+                Predicates.not(Predicates.or(DIRECT_PATH_IPV4_MATCHER, DIRECT_PATH_IPV6_MATCHER)));
+        break;
+      default:
+        throw new IllegalStateException("Unexpected ConnectionMode: " + getConnectionMode());
+    }
+
+    // Inject the interceptor into the channel provider, taking care to preserve existing channel
+    // configurator
+    InstantiatingGrpcChannelProvider.Builder channelProvider =
+        ((InstantiatingGrpcChannelProvider) stubSettings.getTransportChannelProvider()).toBuilder();
+
+    @SuppressWarnings("rawtypes")
+    final ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> oldConfigurator =
+        channelProvider.getChannelConfigurator();
+
+    @SuppressWarnings("rawtypes")
+    final ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> newConfigurator =
+        new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
+          @Override
+          @SuppressWarnings("rawtypes")
+          public ManagedChannelBuilder apply(ManagedChannelBuilder builder) {
+            if (oldConfigurator != null) {
+              builder = oldConfigurator.apply(builder);
+            }
+            return builder.intercept(interceptor);
+          }
+        };
+    channelProvider.setChannelConfigurator(newConfigurator);
+    stubSettings.setTransportChannelProvider(channelProvider.build());
+  }
+
+  private ClientInterceptor buildRemoteAddrInterceptor(
+      final String msg, final Predicate<InetSocketAddress> predicate) {
+    return new ClientInterceptor() {
+      @Override
+      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+          MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        final ClientCall<ReqT, RespT> clientCall = next.newCall(method, callOptions);
+
+        return new SimpleForwardingClientCall<ReqT, RespT>(clientCall) {
+          @Override
+          public void start(Listener<RespT> responseListener, Metadata headers) {
+            super.start(
+                new SimpleForwardingClientCallListener<RespT>(responseListener) {
+                  @Override
+                  public void onHeaders(Metadata headers) {
+                    // Check peer IP after connection is established.
+                    SocketAddress remoteAddr =
+                        clientCall.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
+
+                    if (!predicate.apply((InetSocketAddress) remoteAddr)) {
+                      throw new RuntimeException(
+                          String.format(
+                              "Synthetically aborting the current request because it did not adhere"
+                                  + " to the test environment's requirement ."
+                                  + " Expected %s, but ip was: %s",
+                              msg, remoteAddr));
+                    }
+                    super.onHeaders(headers);
+                  }
+                },
+                headers);
+          }
+        };
+      }
+    };
+  }
+
+  private void configureUserAgent(EnhancedBigtableStubSettings.Builder stubSettings) {
+    List<String> parts = new ArrayList<>();
+    parts.add("java-bigtable-int-test");
+
+    switch (getConnectionMode()) {
+      case Default:
+        // nothing special
+        break;
+      case RequireCfe:
+        parts.add("bigtable-directpath-disable");
+        break;
+      case RequireDirectPath:
+      case RequireDirectPathIPv4:
+        parts.add("bigtable-directpath-enable");
+        break;
+      default:
+        throw new IllegalStateException("Unexpected connectionMode: " + getConnectionMode());
+    }
+    String newUserAgent = Joiner.on(" ").join(parts);
+
+    // Use the existing user-agent to use as a prefix
+    Map<String, String> existingHeaders =
+        MoreObjects.firstNonNull(stubSettings.getHeaderProvider(), FixedHeaderProvider.create())
+            .getHeaders();
+    String existingUserAgent = existingHeaders.get("user-agent");
+    if (existingUserAgent != null) {
+      newUserAgent = existingUserAgent + " " + newUserAgent;
+    }
+
+    Map<String, String> newHeaders = new HashMap<>(existingHeaders);
+    newHeaders.put("user-agent", newUserAgent);
+
+    stubSettings.setHeaderProvider(FixedHeaderProvider.create(newHeaders));
   }
 
   @Override
@@ -216,60 +343,5 @@ class CloudEnv extends AbstractTestEnv {
       throw new RuntimeException("Missing system property: " + prop);
     }
     return value;
-  }
-
-  /**
-   * Captures the request attributes "Grpc.TRANSPORT_ATTR_REMOTE_ADDR" when connection is
-   * established and verifies if the remote address is a DirectPath address. This is only used for
-   * DirectPath testing. {@link ClientCall#getAttributes()}
-   */
-  private ClientInterceptor directPathAddressCheckInterceptor() {
-    return new ClientInterceptor() {
-      @Override
-      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-          MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
-        final ClientCall<ReqT, RespT> clientCall = next.newCall(method, callOptions);
-        return new SimpleForwardingClientCall<ReqT, RespT>(clientCall) {
-          @Override
-          public void start(Listener<RespT> responseListener, Metadata headers) {
-            super.start(
-                new SimpleForwardingClientCallListener<RespT>(responseListener) {
-                  @Override
-                  public void onHeaders(Metadata headers) {
-                    // Check peer IP after connection is established.
-                    SocketAddress remoteAddr =
-                        clientCall.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
-                    if (!verifyRemoteAddress(remoteAddr)) {
-                      throw new RuntimeException(
-                          String.format(
-                              "Synthetically aborting the current request because it did not adhere"
-                                  + " to the test environment's requirement for DirectPath."
-                                  + " Expected test to access DirectPath via %s,"
-                                  + " but RPC was destined for %s",
-                              isDirectPathIpv4Only() ? "ipv4 only" : "ipv4 or ipv6",
-                              remoteAddr.toString()));
-                    }
-                    super.onHeaders(headers);
-                  }
-                },
-                headers);
-          }
-        };
-      }
-    };
-  }
-
-  private boolean verifyRemoteAddress(SocketAddress remoteAddr) {
-    if (remoteAddr instanceof InetSocketAddress) {
-      InetAddress inetAddress = ((InetSocketAddress) remoteAddr).getAddress();
-      String addr = inetAddress.getHostAddress();
-      if (isDirectPathIpv4Only()) {
-        return addr.startsWith(DP_IPV4_PREFIX);
-      } else {
-        // For an ipv6-enabled VM, client could connect to either ipv4 or ipv6 balancer addresses.
-        return addr.startsWith(DP_IPV6_PREFIX) || addr.startsWith(DP_IPV4_PREFIX);
-      }
-    }
-    return true;
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/CloudEnv.java
@@ -140,20 +140,20 @@ class CloudEnv extends AbstractTestEnv {
     final ClientInterceptor interceptor;
 
     switch (getConnectionMode()) {
-      case Default:
+      case DEFAULT:
         // nothing special
         return;
-      case RequireDirectPath:
+      case REQUIRE_DIRECT_PATH:
         interceptor =
             buildRemoteAddrInterceptor(
                 "DirectPath IPv4 or IPv6",
                 Predicates.or(DIRECT_PATH_IPV4_MATCHER, DIRECT_PATH_IPV6_MATCHER));
         break;
-      case RequireDirectPathIPv4:
+      case REQUIRE_DIRECT_PATH_IPV4:
         interceptor =
             buildRemoteAddrInterceptor("DirectPath IPv4", Predicates.or(DIRECT_PATH_IPV4_MATCHER));
         break;
-      case RequireCfe:
+      case REQUIRE_CFE:
         interceptor =
             buildRemoteAddrInterceptor(
                 "a CFE ip",
@@ -230,14 +230,14 @@ class CloudEnv extends AbstractTestEnv {
     parts.add("java-bigtable-int-test");
 
     switch (getConnectionMode()) {
-      case Default:
+      case DEFAULT:
         // nothing special
         break;
-      case RequireCfe:
+      case REQUIRE_CFE:
         parts.add("bigtable-directpath-disable");
         break;
-      case RequireDirectPath:
-      case RequireDirectPathIPv4:
+      case REQUIRE_DIRECT_PATH:
+      case REQUIRE_DIRECT_PATH_IPV4:
         parts.add("bigtable-directpath-enable");
         break;
       default:


### PR DESCRIPTION
prod-it - runs connection agnostic integration tests using whatever connection is available
bigtable-directpath-it - runs directpath specific tests and augments the agnostic tests to check that they are running over DirectPath
bigtable-directpath-ipv4only-it - similar to bigtable-directpath-it but checks that connections are made only over ipv4
bigtable-cfe-it - runs connection agnostic tests but augments them to ensure that connections are not made over DirectPath
