### PR TITLE
fix: change clusterId in Cmek test

### DIFF
--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
@@ -70,6 +70,7 @@ public class BigtableCmekIT {
   private static String instanceId;
   private static String clusterId1;
   private static String clusterId2;
+  private static String clusterId3;
   private static String kmsKeyName;
   private static List<String> zones;
   private static String otherZone;
@@ -91,6 +92,7 @@ public class BigtableCmekIT {
     instanceId = AbstractTestEnv.TEST_INSTANCE_PREFIX + Instant.now().getEpochSecond();
     clusterId1 = instanceId + "-c1";
     clusterId2 = instanceId + "-c2";
+    clusterId3 = instanceId + "-c3";
     zones = testEnvRule.env().getMultipleZonesInSameRegion();
     otherZone =
         Sets.difference(
@@ -149,7 +151,7 @@ public class BigtableCmekIT {
 
     try {
       instanceAdmin.createCluster(
-          CreateClusterRequest.of(instanceId, clusterId2)
+          CreateClusterRequest.of(instanceId, clusterId3)
               .setZone(otherZone)
               .setServeNodes(1)
               .setStorageType(StorageType.SSD)

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
@@ -112,6 +112,7 @@ public class BigtableCmekIT {
                 .setInstanceId(instanceId)
                 .build());
 
+    LOGGER.info("Creating cluster in zone: " + zones.get(0));
     instanceAdmin.createInstance(
         CreateInstanceRequest.of(instanceId)
             .addCmekCluster(clusterId1, zones.get(0), 1, StorageType.SSD, kmsKeyName));
@@ -139,6 +140,7 @@ public class BigtableCmekIT {
     Cluster cluster = instanceAdmin.getCluster(instanceId, clusterId1);
     assertThat(cluster.getKmsKeyName()).isEqualTo(kmsKeyName);
 
+    LOGGER.info("Creating cluster in zone: " + zones.get(1));
     instanceAdmin.createCluster(
         CreateClusterRequest.of(instanceId, clusterId2)
             .setZone(zones.get(1))
@@ -149,6 +151,7 @@ public class BigtableCmekIT {
     Cluster secondCluster = instanceAdmin.getCluster(instanceId, clusterId2);
     assertThat(secondCluster.getKmsKeyName()).isEqualTo(kmsKeyName);
 
+    LOGGER.info("Trying to create cluster in zone: " + otherZone);
     try {
       instanceAdmin.createCluster(
           CreateClusterRequest.of(instanceId, clusterId3)


### PR DESCRIPTION
Change-Id: Idc8ad885205190374b089349ee94cc627bafd782

Getting an error internally about cluster with clusterId2 already existing. So changing to use new clusterId for the other zone scenario.
