### PR TITLE
chore: remove duplicate deps (error_prone & autovalue) from bigtable specific pom

### DIFF
--- a/google-cloud-bigtable-deps-bom/pom.xml
+++ b/google-cloud-bigtable-deps-bom/pom.xml
@@ -70,10 +70,6 @@
     </license>
   </licenses>
 
-  <properties>
-    <autovalue.version>1.8</autovalue.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -82,23 +78,6 @@
         <version>0.21.1</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-
-      <!-- Production dependency version definitions in alphabetical order -->
-      <dependency>
-        <groupId>com.google.auto.value</groupId>
-        <artifactId>auto-value</artifactId>
-        <version>${autovalue.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.auto.value</groupId>
-        <artifactId>auto-value-annotations</artifactId>
-        <version>${autovalue.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.errorprone</groupId>
-        <artifactId>error_prone_annotations</artifactId>
-        <version>2.6.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-cloud-bigtable/EnableAutoValue.txt
+++ b/google-cloud-bigtable/EnableAutoValue.txt
@@ -1,0 +1,2 @@
+This is a marker file to trigger auto-value injection into the annotation processor path
+https://github.com/googleapis/java-shared-config/blob/51c9f68ff1736761b21c921f078ab2c8675ff268/pom.xml#L758

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -100,11 +100,6 @@
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
     </dependency>
     <dependency>
@@ -488,7 +483,7 @@
             grpc-auth is not directly used transitively, but is pulled to align with other grpc parts
             opencensus-impl-core is brought in transitively through opencensus-impl
             -->
-          <usedDependencies>io.grpc:grpc-auth,io.grpc:grpc-grpclb,com.google.auto.value:auto-value</usedDependencies>
+          <usedDependencies>io.grpc:grpc-auth,io.grpc:grpc-grpclb</usedDependencies>
           <ignoredUsedUndeclaredDependencies>
             <ignoredUsedUndeclaredDependency>io.opencensus:opencensus-impl-core</ignoredUsedUndeclaredDependency>
           </ignoredUsedUndeclaredDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -203,21 +203,6 @@
     </dependencyManagement>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
-                    <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
-                        <encoding>UTF-8</encoding>
-                        <compilerArgument>-Xlint:unchecked</compilerArgument>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
         <plugins>
             <!-- Using maven site plugin only as a hook for javadoc:aggregate, don't need the reports -->
             <plugin>


### PR DESCRIPTION
google-shared-config already has provisions for autovalue & error_prone. No need for us to track it separately.
This will remove auto-value-annotations from the compile path and into annotation processor path.
