### PR TITLE
chore: cloud-rad doc generation

### DIFF
--- a/.kokoro/release/publish_javadoc11.sh
+++ b/.kokoro/release/publish_javadoc11.sh
@@ -38,7 +38,7 @@ export VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 
 # V3 generates docfx yml from javadoc
 # generate yml
-mvn clean site -B -q -P docFX
+mvn clean javadoc:aggregate-jar -B -q -P docFX
 
 # copy README to docfx-yml dir and rename index.md
 cp README.md target/docfx-yml/index.md

--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,42 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>docFX</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <configuration>
+                            <doclet>com.microsoft.doclet.DocFxDoclet</doclet>
+                            <useStandardDocletOptions>false</useStandardDocletOptions>
+                            <docletPath>${env.KOKORO_GFILE_DIR}/docfx-doclet-1.0-SNAPSHOT-jar-with-dependencies-172556.jar</docletPath>
+                            <additionalOptions>
+                                -outputpath ${project.build.directory}/docfx-yml
+                                <!-- List of excluded packages as regex, separated by a colon-->
+                                -excludeclasses com\.google\.cloud\.bigtable\.admin\.v2\.internal\.:com\.google\.cloud\.bigtable\.admin\.v2\.BaseBigtableInstanceAdminClient:com\.google\.cloud\.bigtable\.admin\.v2\.BaseBigtableInstanceAdminSettings:com\.google\.cloud\.bigtable\.admin\.v2\.stub\.GrpcBigtableInstanceAdminCallableFactory:com\.google\.cloud\.bigtable\.admin\.v2\.stub\.GrpcBigtableInstanceAdminStub:com\.google\.cloud\.bigtable\.admin\.v2\.stub\.BigtableInstanceAdminStub:com\.google\.cloud\.bigtable\.admin\.v2\.BaseBigtableTableAdminClient:com\.google\.cloud\.bigtable\.admin\.v2\.BaseBigtableTableAdminSettings:com\.google\.cloud\.bigtable\.admin\.v2\.stub\.GrpcBigtableTableAdminCallableFactory:com\.google\.cloud\.bigtable\.admin\.v2\.stub\.GrpcBigtableTableAdminStub:com\.google\.cloud\.bigtable\.admin\.v2\.stub\.BigtableTableAdminStub:com\.google\.cloud\.bigtable\.admin\.v2\.stub\.EnhancedBigtableTableAdminStub:com\.google\.cloud\.bigtable\.data\.v2\.internal\.:com\.google\.cloud\.bigtable\.data\.v2\.BaseBigtableDataClient:com\.google\.cloud\.bigtable\.data\.v2\.BaseBigtableDataSettings:com\.google\.cloud\.bigtable\.data\.v2\.stub\.BigtableStub:com\.google\.cloud\.bigtable\.data\.v2\.stub\.BigtableStubSettings:com\.google\.cloud\.bigtable\.data\.v2\.stub\.GrpcBigtableStub:com\.google\.cloud\.bigtable\.data\.v2\.stub\.GrpcBigtableCallableFactory:com\.google\.cloud\.bigtable\.data\.v2\.stub\.EnhancedBigtableStub:com\.google\.cloud\.bigtable\.data\.v2\.stub\.mutaterows\.:com\.google\.cloud\.bigtable\.data\.v2\.stub\.readrows\.:com\.google\.cloud\.bigtable\.data\.v2\.stub\.metrics\.
+                            </additionalOptions>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>aggregate</id>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                                <configuration>
+                                    <failOnError>false</failOnError>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <modules>
         <module>proto-google-cloud-bigtable-v2</module>
         <module>grpc-google-cloud-bigtable-v2</module>

--- a/pom.xml
+++ b/pom.xml
@@ -311,9 +311,6 @@
                                 <goals>
                                     <goal>aggregate</goal>
                                 </goals>
-                                <configuration>
-                                    <failOnError>false</failOnError>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
Fixes b/179935006

Due to the way v1 html javadocs are currently [configured](https://github.com/googleapis/java-bigtable/blob/master/pom.xml#L206) - we can't produce docs for cloud-rad in exactly the same manner as other java repos. This allows us to generate for cloud-rad (with excluded classes) without changing what we're doing with current doc generation yet.
