### PR TITLE
chore(test): log resource prefix to make debugging easier

### DIFF
--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableBackupIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableBackupIT.java
@@ -214,7 +214,7 @@ public class BigtableBackupIT {
   @Test
   public void restoreTableTest() throws InterruptedException, ExecutionException {
     String backupId = prefixGenerator.newPrefix();
-    String restoredTableId = prefixGenerator.newPrefix() + "-restore";
+    String restoredTableId = prefixGenerator.newPrefix();
     tableAdmin.createBackup(createBackupRequest(backupId));
 
     // Wait 2 minutes so that the RestoreTable API will trigger an optimize restored

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableBackupIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableBackupIT.java
@@ -39,6 +39,7 @@ import com.google.cloud.bigtable.admin.v2.models.UpdateBackupRequest;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.test_helpers.env.EmulatorEnv;
+import com.google.cloud.bigtable.test_helpers.env.PrefixGenerator;
 import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
 import com.google.common.base.Stopwatch;
 import com.google.protobuf.ByteString;
@@ -53,6 +54,7 @@ import java.util.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -62,6 +64,7 @@ import org.threeten.bp.Instant;
 @RunWith(JUnit4.class)
 public class BigtableBackupIT {
   @ClassRule public static final TestEnvRule testEnvRule = new TestEnvRule();
+  @Rule public final PrefixGenerator prefixGenerator = new PrefixGenerator();
 
   private static final Logger LOGGER = Logger.getLogger(BigtableBackupIT.class.getName());
 
@@ -102,7 +105,7 @@ public class BigtableBackupIT {
 
   @Test
   public void createAndGetBackupTest() {
-    String backupId = testEnvRule.env().newPrefix();
+    String backupId = prefixGenerator.newPrefix();
     Instant expireTime = Instant.now().plus(Duration.ofHours(6));
 
     CreateBackupRequest request =
@@ -148,8 +151,8 @@ public class BigtableBackupIT {
 
   @Test
   public void listBackupTest() {
-    String backupId1 = testEnvRule.env().newPrefix();
-    String backupId2 = testEnvRule.env().newPrefix();
+    String backupId1 = prefixGenerator.newPrefix();
+    String backupId2 = prefixGenerator.newPrefix();
 
     try {
       tableAdmin.createBackup(createBackupRequest(backupId1));
@@ -169,7 +172,7 @@ public class BigtableBackupIT {
 
   @Test
   public void updateBackupTest() {
-    String backupId = testEnvRule.env().newPrefix();
+    String backupId = prefixGenerator.newPrefix();
     tableAdmin.createBackup(createBackupRequest(backupId));
 
     Instant expireTime = Instant.now().plus(Duration.ofDays(20));
@@ -185,7 +188,7 @@ public class BigtableBackupIT {
 
   @Test
   public void deleteBackupTest() throws InterruptedException {
-    String backupId = testEnvRule.env().newPrefix();
+    String backupId = prefixGenerator.newPrefix();
 
     tableAdmin.createBackup(createBackupRequest(backupId));
     tableAdmin.deleteBackup(targetCluster, backupId);
@@ -210,8 +213,8 @@ public class BigtableBackupIT {
 
   @Test
   public void restoreTableTest() throws InterruptedException, ExecutionException {
-    String backupId = testEnvRule.env().newPrefix();
-    String restoredTableId = testEnvRule.env().newPrefix() + "-restore";
+    String backupId = prefixGenerator.newPrefix();
+    String restoredTableId = prefixGenerator.newPrefix() + "-restore";
     tableAdmin.createBackup(createBackupRequest(backupId));
 
     // Wait 2 minutes so that the RestoreTable API will trigger an optimize restored
@@ -244,8 +247,8 @@ public class BigtableBackupIT {
   @Test
   public void crossInstanceRestoreTest()
       throws InterruptedException, IOException, ExecutionException, TimeoutException {
-    String backupId = testEnvRule.env().newPrefix();
-    String restoredTableId = testEnvRule.env().newPrefix();
+    String backupId = prefixGenerator.newPrefix();
+    String restoredTableId = prefixGenerator.newPrefix();
 
     // Create the backup
     tableAdmin.createBackup(
@@ -256,7 +259,7 @@ public class BigtableBackupIT {
     Stopwatch stopwatch = Stopwatch.createStarted();
 
     // Set up a new instance to test cross-instance restore. The backup will be restored here
-    String targetInstance = testEnvRule.env().newPrefix();
+    String targetInstance = prefixGenerator.newPrefix();
     instanceAdmin.createInstance(
         CreateInstanceRequest.of(targetInstance)
             .addCluster(targetInstance, testEnvRule.env().getSecondaryZone(), 1, StorageType.SSD)
@@ -302,7 +305,7 @@ public class BigtableBackupIT {
 
   @Test
   public void backupIamTest() {
-    String backupId = testEnvRule.env().newPrefix();
+    String backupId = prefixGenerator.newPrefix();
 
     try {
       tableAdmin.createBackup(createBackupRequest(backupId));
@@ -341,7 +344,7 @@ public class BigtableBackupIT {
   private static Table createAndPopulateTestTable(
       BigtableTableAdminClient tableAdmin, BigtableDataClient dataClient)
       throws InterruptedException {
-    String tableId = testEnvRule.env().newPrefix();
+    String tableId = PrefixGenerator.newPrefix("BigtableBackupIT#createAndPopulateTestTable");
     Table testTable = tableAdmin.createTable(CreateTableRequest.of(tableId).addFamily("cf1"));
 
     // Populate test data.

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
@@ -34,6 +34,7 @@ import com.google.cloud.bigtable.admin.v2.models.StorageType;
 import com.google.cloud.bigtable.common.Status;
 import com.google.cloud.bigtable.common.Status.Code;
 import com.google.cloud.bigtable.test_helpers.env.EmulatorEnv;
+import com.google.cloud.bigtable.test_helpers.env.PrefixGenerator;
 import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -45,6 +46,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -65,6 +67,7 @@ public class BigtableCmekIT {
   private static final String BACKUP_ID = "test-table-for-cmek-it-backup";
 
   @ClassRule public static TestEnvRule testEnvRule = new TestEnvRule();
+  @Rule public final PrefixGenerator prefixGenerator = new PrefixGenerator();
 
   private static String instanceId;
   private static String clusterId1;
@@ -88,7 +91,7 @@ public class BigtableCmekIT {
     assertThat(kmsKeyName).isNotNull();
     assertThat(kmsKeyName).isNotEmpty();
 
-    instanceId = testEnvRule.env().newPrefix();
+    instanceId = PrefixGenerator.newPrefix("BigtableCmekIT#validatePlatform");
     clusterId1 = instanceId + "-c1";
     clusterId2 = instanceId + "-c2";
     clusterId3 = instanceId + "-c3";

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableInstanceAdminClientIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableInstanceAdminClientIT.java
@@ -32,11 +32,13 @@ import com.google.cloud.bigtable.admin.v2.models.StorageType;
 import com.google.cloud.bigtable.admin.v2.models.UpdateAppProfileRequest;
 import com.google.cloud.bigtable.admin.v2.models.UpdateInstanceRequest;
 import com.google.cloud.bigtable.test_helpers.env.EmulatorEnv;
+import com.google.cloud.bigtable.test_helpers.env.PrefixGenerator;
 import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
 import java.util.List;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -45,6 +47,7 @@ import org.junit.runners.JUnit4;
 public class BigtableInstanceAdminClientIT {
 
   @ClassRule public static TestEnvRule testEnvRule = new TestEnvRule();
+  @Rule public final PrefixGenerator prefixGenerator = new PrefixGenerator();
 
   private String instanceId = testEnvRule.env().getInstanceId();
   private BigtableInstanceAdminClient client;
@@ -66,7 +69,7 @@ public class BigtableInstanceAdminClientIT {
 
   @Test
   public void appProfileTest() {
-    String testAppProfile = testEnvRule.env().newPrefix();
+    String testAppProfile = prefixGenerator.newPrefix();
 
     AppProfile newlyCreatedAppProfile =
         client.createAppProfile(
@@ -115,7 +118,7 @@ public class BigtableInstanceAdminClientIT {
   /** To optimize test run time, instance & cluster creation is tested at the same time */
   @Test
   public void instanceAndClusterCreationDeletionTest() {
-    String newInstanceId = testEnvRule.env().newPrefix();
+    String newInstanceId = prefixGenerator.newPrefix();
     String newClusterId = newInstanceId;
 
     client.createInstance(
@@ -152,7 +155,7 @@ public class BigtableInstanceAdminClientIT {
   // This will avoid the need to copy any existing tables and will also reduce flakiness in case a
   // previous run failed to clean up a cluster in the secondary zone.
   private void clusterCreationDeletionTestHelper(String newInstanceId) {
-    String newClusterId = testEnvRule.env().newPrefix();
+    String newClusterId = prefixGenerator.newPrefix();
     boolean isClusterDeleted = false;
     client.createCluster(
         CreateClusterRequest.of(newInstanceId, newClusterId)

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableTableAdminClientIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableTableAdminClientIT.java
@@ -35,6 +35,7 @@ import com.google.cloud.bigtable.admin.v2.models.GCRules.VersionRule;
 import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.cloud.bigtable.test_helpers.env.EmulatorEnv;
+import com.google.cloud.bigtable.test_helpers.env.PrefixGenerator;
 import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
@@ -45,7 +46,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.threeten.bp.Duration;
@@ -53,7 +53,7 @@ import org.threeten.bp.Duration;
 @RunWith(JUnit4.class)
 public class BigtableTableAdminClientIT {
   @ClassRule public static TestEnvRule testEnvRule = new TestEnvRule();
-  @Rule public final TestName testNameRule = new TestName();
+  @Rule public final PrefixGenerator prefixGenerator = new PrefixGenerator();
 
   private BigtableTableAdminClient tableAdmin;
   private String tableId;
@@ -61,7 +61,7 @@ public class BigtableTableAdminClientIT {
   @Before
   public void setUp() {
     tableAdmin = testEnvRule.env().getTableAdminClient();
-    tableId = testEnvRule.env().newPrefix();
+    tableId = prefixGenerator.newPrefix();
   }
 
   @After

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/PrefixGenerator.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/PrefixGenerator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.test_helpers.env;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.threeten.bp.Instant;
+
+public class PrefixGenerator implements TestRule {
+  private static final Logger LOGGER = Logger.getLogger(TestEnvRule.class.getName());
+
+  static final String PREFIX = "temp-";
+  private static final AtomicInteger prefixCounter = new AtomicInteger(0);
+  private static final int SUFFIX = new Random().nextInt(Integer.MAX_VALUE);
+
+  private String testName;
+
+  @Override
+  public Statement apply(final Statement base, final Description description) {
+    return new Statement() {
+      public void evaluate() throws Throwable {
+        before(description);
+
+        try {
+          base.evaluate();
+        } finally {
+          after();
+        }
+      }
+    };
+  }
+
+  private void before(Description description) {
+    testName = description.toString();
+  }
+
+  private void after() {
+    testName = null;
+  }
+
+  public String newPrefix() {
+    return newPrefix(testName);
+  }
+
+  public static String newPrefix(String source) {
+    // Sortable resource prefix - time, process identifier, serial counterck
+    String prefix =
+        String.format(
+            "%s-%x-%x", newTimePrefix(Instant.now()), SUFFIX, prefixCounter.getAndIncrement());
+
+    LOGGER.info(source + ": newPrefix: " + prefix);
+    return prefix;
+  }
+
+  static String newTimePrefix(Instant instant) {
+    return String.format(PREFIX + "08%x", instant.getEpochSecond());
+  }
+}


### PR DESCRIPTION
Follow up to #801

* move prefix generation to its own instance rule
* log whenever a new prefix generated, which should make it easier to debug test failures
