### PR TITLE
fix: add back in extraFiles and fix file path

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -6,3 +6,5 @@ branches:
     handleGHRelease: true
     releaseType: java-lts
     branch: 1.22.0-sp
+extraFiles:
+  - google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/Version.java


### PR DESCRIPTION
file path was removed in last sp merge. It was pointing to the wrong file https://github.com/googleapis/java-bigtable/blob/1af8925747c22f4e8d50a76dc60f6fafddac20d2/.github/release-please.yml#L4