### PR TITLE
Revert "fix: revert conformance test version"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
             <dependency>
               <groupId>com.google.cloud</groupId>
               <artifactId>google-cloud-conformance-tests</artifactId>
-              <version>0.0.13</version>
+              <version>0.1.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.truth</groupId>


### PR DESCRIPTION
Undo revert, the issue was caused by an old maven version in internal tests which has been updated