### PR TITLE
revert: Revert "feat: all setting timeouts for batchers + fix handling of timeouts for point reads"

### DIFF
--- a/google-cloud-bigtable/clirr-ignored-differences.xml
+++ b/google-cloud-bigtable/clirr-ignored-differences.xml
@@ -23,10 +23,4 @@
         <differenceType>8001</differenceType>
         <className>com/google/cloud/bigtable/gaxx/tracing/WrappedTracerFactory*</className>
     </difference>
-    <difference>
-        <!-- change method args is ok because EnhancedBigtableStub is InternalApi -->
-        <differenceType>7004</differenceType>
-        <className>com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub</className>
-        <method>*</method>
-    </difference>
 </differences>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataClient.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataClient.java
@@ -23,7 +23,6 @@ import com.google.api.core.ApiFutures;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.batching.Batcher;
-import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.rpc.ApiExceptions;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStream;
@@ -1074,40 +1073,7 @@ public class BigtableDataClient implements AutoCloseable {
    */
   @BetaApi("This surface is likely to change as the batching surface evolves.")
   public Batcher<RowMutationEntry, Void> newBulkMutationBatcher(@Nonnull String tableId) {
-    return newBulkMutationBatcher(tableId, null);
-  }
-
-  /**
-   * Mutates multiple rows in a batch. Each individual row is mutated atomically as in MutateRow,
-   * but the entire batch is not executed atomically. The returned Batcher instance is not
-   * threadsafe, it can only be used from single thread. This method allows customization of the
-   * underlying RPCs by passing in a {@link com.google.api.gax.grpc.GrpcCallContext}. The same
-   * context will be reused for all batches. This can be used to customize things like per attempt
-   * timeouts.
-   *
-   * <p>Sample Code:
-   *
-   * <pre>{@code
-   * try (BigtableDataClient bigtableDataClient = BigtableDataClient.create("[PROJECT]", "[INSTANCE]")) {
-   *   try (Batcher<RowMutationEntry, Void> batcher = bigtableDataClient.newBulkMutationBatcher("[TABLE]", GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(10)))) {
-   *     for (String someValue : someCollection) {
-   *       ApiFuture<Void> entryFuture =
-   *           batcher.add(
-   *               RowMutationEntry.create("[ROW KEY]")
-   *                   .setCell("[FAMILY NAME]", "[QUALIFIER]", "[VALUE]"));
-   *     }
-   *
-   *     // Blocks until mutations are applied on all submitted row entries.
-   *     batcher.flush();
-   *   }
-   *   // Before `batcher` is closed, all remaining(If any) mutations are applied.
-   * }
-   * }</pre>
-   */
-  @BetaApi("This surface is likely to change as the batching surface evolves.")
-  public Batcher<RowMutationEntry, Void> newBulkMutationBatcher(
-      @Nonnull String tableId, @Nullable GrpcCallContext ctx) {
-    return stub.newMutateRowsBatcher(tableId, ctx);
+    return stub.newMutateRowsBatcher(tableId);
   }
 
   /**
@@ -1193,61 +1159,11 @@ public class BigtableDataClient implements AutoCloseable {
    */
   public Batcher<ByteString, Row> newBulkReadRowsBatcher(
       String tableId, @Nullable Filters.Filter filter) {
-    return newBulkReadRowsBatcher(tableId, filter, null);
-  }
-
-  /**
-   * Reads rows for given tableId and filter criteria in a batch. If the row does not exist, the
-   * value will be null. The returned Batcher instance is not threadsafe, it can only be used from a
-   * single thread. This method allows customization of the underlying RPCs by passing in a {@link
-   * com.google.api.gax.grpc.GrpcCallContext}. The same context will be reused for all batches. This
-   * can be used to customize things like per attempt timeouts.
-   *
-   * <p>Performance notice: The ReadRows protocol requires that rows are sent in ascending key
-   * order, which means that the keys are processed sequentially on the server-side, so batching
-   * allows improving throughput but not latency. Lower latencies can be achieved by sending smaller
-   * requests concurrently.
-   *
-   * <p>Sample Code:
-   *
-   * <pre>{@code
-   * try (BigtableDataClient bigtableDataClient = BigtableDataClient.create("[PROJECT]", "[INSTANCE]")) {
-   *
-   *  // Build the filter expression
-   *  Filter filter = FILTERS.chain()
-   *         .filter(FILTERS.key().regex("prefix.*"))
-   *         .filter(FILTERS.limit().cellsPerRow(10));
-   *
-   *   List<ApiFuture<Row>> rows = new ArrayList<>();
-   *
-   *   try (Batcher<ByteString, Row> batcher = bigtableDataClient.newBulkReadRowsBatcher(
-   *    "[TABLE]", filter, GrpcCallContext.createDefault().withTimeout(Duration.ofSeconds(10)))) {
-   *     for (String someValue : someCollection) {
-   *       ApiFuture<Row> rowFuture =
-   *           batcher.add(ByteString.copyFromUtf8("[ROW KEY]"));
-   *       rows.add(rowFuture);
-   *     }
-   *
-   *     // [Optional] Sends collected elements for batching asynchronously.
-   *     batcher.sendOutstanding();
-   *
-   *     // [Optional] Invokes sendOutstanding() and awaits until all pending entries are resolved.
-   *     batcher.flush();
-   *   }
-   *   // batcher.close() invokes `flush()` which will in turn invoke `sendOutstanding()` with await for
-   *   pending batches until its resolved.
-   *
-   *   List<Row> actualRows = ApiFutures.allAsList(rows).get();
-   * }
-   * }</pre>
-   */
-  public Batcher<ByteString, Row> newBulkReadRowsBatcher(
-      String tableId, @Nullable Filters.Filter filter, @Nullable GrpcCallContext ctx) {
     Query query = Query.create(tableId);
     if (filter != null) {
-      query.filter(filter);
+      query = query.filter(filter);
     }
-    return stub.newBulkReadRowsBatcher(query, ctx);
+    return stub.newBulkReadRowsBatcher(query);
   }
 
   /**

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
@@ -23,7 +23,6 @@ import com.google.api.gax.batching.FlowController;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.grpc.GaxGrpcProperties;
-import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.grpc.GrpcCallSettings;
 import com.google.api.gax.grpc.GrpcRawCallableFactory;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
@@ -99,7 +98,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * The core client that converts method calls to RPCs.
@@ -538,15 +536,10 @@ public class EnhancedBigtableStub implements AutoCloseable {
    *   <li>Split the responses using {@link MutateRowsBatchingDescriptor}.
    * </ul>
    */
-  public Batcher<RowMutationEntry, Void> newMutateRowsBatcher(
-      @Nonnull String tableId, @Nullable GrpcCallContext ctx) {
-    UnaryCallable<BulkMutation, Void> callable = this.bulkMutateRowsCallable;
-    if (ctx != null) {
-      callable = callable.withDefaultCallContext(ctx);
-    }
+  public Batcher<RowMutationEntry, Void> newMutateRowsBatcher(@Nonnull String tableId) {
     return new BatcherImpl<>(
         settings.bulkMutateRowsSettings().getBatchingDescriptor(),
-        callable,
+        bulkMutateRowsCallable,
         BulkMutation.create(tableId),
         settings.bulkMutateRowsSettings().getBatchingSettings(),
         clientContext.getExecutor(),
@@ -568,16 +561,11 @@ public class EnhancedBigtableStub implements AutoCloseable {
    *   <li>Split the responses using {@link ReadRowsBatchingDescriptor}.
    * </ul>
    */
-  public Batcher<ByteString, Row> newBulkReadRowsBatcher(
-      @Nonnull Query query, @Nullable GrpcCallContext ctx) {
+  public Batcher<ByteString, Row> newBulkReadRowsBatcher(@Nonnull Query query) {
     Preconditions.checkNotNull(query, "query cannot be null");
-    UnaryCallable<Query, List<Row>> callable = readRowsCallable().all();
-    if (ctx != null) {
-      callable = callable.withDefaultCallContext(ctx);
-    }
     return new BatcherImpl<>(
         settings.bulkReadRowsSettings().getBatchingDescriptor(),
-        callable,
+        readRowsCallable().all(),
         query,
         settings.bulkReadRowsSettings().getBatchingSettings(),
         clientContext.getExecutor());

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/mutaterows/MutateRowsAttemptCallable.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/mutaterows/MutateRowsAttemptCallable.java
@@ -176,8 +176,7 @@ class MutateRowsAttemptCallable implements Callable<Void> {
 
       // Configure the deadline
       ApiCallContext currentCallContext = callContext;
-      if (currentCallContext.getTimeout() == null
-          && !externalFuture.getAttemptSettings().getRpcTimeout().isZero()) {
+      if (!externalFuture.getAttemptSettings().getRpcTimeout().isZero()) {
         currentCallContext =
             currentCallContext.withTimeout(externalFuture.getAttemptSettings().getRpcTimeout());
       }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/BigtableDataClientFactoryTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/BigtableDataClientFactoryTest.java
@@ -35,11 +35,8 @@ import com.google.bigtable.v2.RowSet;
 import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import io.grpc.Attributes;
-import io.grpc.BindableService;
-import io.grpc.ServerInterceptor;
 import io.grpc.ServerTransportFilter;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
@@ -98,11 +95,7 @@ public class BigtableDataClientFactoryTest {
             terminateAttributes.add(transportAttrs);
           }
         };
-    serviceHelper =
-        new FakeServiceHelper(
-            ImmutableList.<ServerInterceptor>of(),
-            transportFilter,
-            ImmutableList.<BindableService>of(service));
+    serviceHelper = new FakeServiceHelper(null, transportFilter, service);
     port = serviceHelper.getPort();
     serviceHelper.start();
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/BigtableDataClientTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/BigtableDataClientTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Matchers.any;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.batching.Batcher;
-import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
@@ -81,13 +80,9 @@ public class BigtableDataClientTest {
     Mockito.when(mockStub.bulkMutateRowsCallable()).thenReturn(mockBulkMutateRowsCallable);
     Mockito.when(mockStub.checkAndMutateRowCallable()).thenReturn(mockCheckAndMutateRowCallable);
     Mockito.when(mockStub.readModifyWriteRowCallable()).thenReturn(mockReadModifyWriteRowCallable);
-    Mockito.when(
-            mockStub.newMutateRowsBatcher(
-                Mockito.any(String.class), Mockito.any(GrpcCallContext.class)))
+    Mockito.when(mockStub.newMutateRowsBatcher(Mockito.any(String.class)))
         .thenReturn(mockBulkMutationBatcher);
-    Mockito.when(
-            mockStub.newBulkReadRowsBatcher(
-                Mockito.any(Query.class), Mockito.any(GrpcCallContext.class)))
+    Mockito.when(mockStub.newBulkReadRowsBatcher(Mockito.any(Query.class)))
         .thenReturn(mockBulkReadRowsBatcher);
   }
 
@@ -379,8 +374,7 @@ public class BigtableDataClientTest {
     ApiFuture<Void> actualRes = batcher.add(request);
     assertThat(actualRes).isSameInstanceAs(expectedResponse);
 
-    Mockito.verify(mockStub)
-        .newMutateRowsBatcher(Mockito.any(String.class), Mockito.any(GrpcCallContext.class));
+    Mockito.verify(mockStub).newMutateRowsBatcher(Mockito.any(String.class));
   }
 
   @Test
@@ -396,8 +390,7 @@ public class BigtableDataClientTest {
     ApiFuture<Row> actualResponse = batcher.add(request);
     assertThat(actualResponse).isSameInstanceAs(expectedResponse);
 
-    Mockito.verify(mockStub)
-        .newBulkReadRowsBatcher(Mockito.any(Query.class), Mockito.any(GrpcCallContext.class));
+    Mockito.verify(mockStub).newBulkReadRowsBatcher(Mockito.any(Query.class));
   }
 
   @Test
@@ -414,8 +407,7 @@ public class BigtableDataClientTest {
     ApiFuture<Row> actualResponse = batcher.add(request);
     assertThat(actualResponse).isSameInstanceAs(expectedResponse);
 
-    Mockito.verify(mockStub)
-        .newBulkReadRowsBatcher(Mockito.any(Query.class), Mockito.any(GrpcCallContext.class));
+    Mockito.verify(mockStub).newBulkReadRowsBatcher(Mockito.any(Query.class));
   }
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/FakeServiceHelper.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/FakeServiceHelper.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.data.v2;
 
-import com.google.common.collect.ImmutableList;
 import io.grpc.BindableService;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -23,7 +22,6 @@ import io.grpc.ServerInterceptor;
 import io.grpc.ServerTransportFilter;
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.util.List;
 
 /** Utility class to setup a fake grpc server on a random port. */
 public class FakeServiceHelper {
@@ -31,27 +29,26 @@ public class FakeServiceHelper {
   private final Server server;
 
   public FakeServiceHelper(BindableService... services) throws IOException {
-    this(ImmutableList.<ServerInterceptor>of(), null, ImmutableList.copyOf(services));
+    this(null, services);
   }
 
   public FakeServiceHelper(ServerInterceptor interceptor, BindableService... services)
       throws IOException {
-    this(ImmutableList.of(interceptor), null, ImmutableList.copyOf(services));
+    this(interceptor, null, services);
   }
 
   public FakeServiceHelper(
-      List<ServerInterceptor> interceptors,
+      ServerInterceptor interceptor,
       ServerTransportFilter transportFilter,
-      List<BindableService> services)
+      BindableService... services)
       throws IOException {
     try (ServerSocket ss = new ServerSocket(0)) {
       port = ss.getLocalPort();
     }
     ServerBuilder builder = ServerBuilder.forPort(port);
-    for (ServerInterceptor interceptor : interceptors) {
+    if (interceptor != null) {
       builder = builder.intercept(interceptor);
     }
-
     if (transportFilter != null) {
       builder = builder.addTransportFilter(transportFilter);
     }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/readrows/PointReadTimeoutCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/readrows/PointReadTimeoutCallableTest.java
@@ -106,7 +106,7 @@ public class PointReadTimeoutCallableTest {
   }
 
   @Test
-  public void doesntClobber() {
+  public void usesMinimum1() {
     Duration attemptTimeout = Duration.ofMillis(100);
     Duration streamTimeout = Duration.ofMillis(200);
     PointReadTimeoutCallable<Object> callable = new PointReadTimeoutCallable<>(inner);
@@ -119,6 +119,24 @@ public class PointReadTimeoutCallableTest {
       callable.call(req, responseObserver, ctx);
 
       assertThat(ctxCaptor.getValue().getTimeout()).isEqualTo(attemptTimeout);
+    }
+  }
+
+  @Test
+  public void usesMinimum2() {
+    Duration attemptTimeout = Duration.ofMillis(200);
+    Duration streamTimeout = Duration.ofMillis(100);
+    PointReadTimeoutCallable<Object> callable = new PointReadTimeoutCallable<>(inner);
+
+    for (ReadRowsRequest req : createPointReadRequests()) {
+      GrpcCallContext ctx =
+          GrpcCallContext.createDefault()
+              .withTimeout(attemptTimeout)
+              .withStreamWaitTimeout(streamTimeout);
+
+      callable.call(req, responseObserver, ctx);
+
+      assertThat(ctxCaptor.getValue().getTimeout()).isEqualTo(streamTimeout);
     }
   }
 


### PR DESCRIPTION
Reverts googleapis/java-bigtable#861

Unfortunately this doesnt work. The ServerStreamingAttemptCallable will stamp the total timeout as the timeout on ApiCallContext, which will prevent PointReadCallable from stamping the streamWaitTImeout.
