### PR TITLE
chore: use BaseApiTracer and BaseApiTracerFactory

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracer.java
@@ -16,13 +16,14 @@
 package com.google.cloud.bigtable.data.v2.stub.metrics;
 
 import com.google.api.gax.tracing.ApiTracer;
+import com.google.api.gax.tracing.BaseApiTracer;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import org.threeten.bp.Duration;
 
 /** Combines multiple {@link ApiTracer}s into a single {@link ApiTracer}. */
-class CompositeTracer implements ApiTracer {
+class CompositeTracer extends BaseApiTracer {
   private final List<ApiTracer> children;
 
   CompositeTracer(List<ApiTracer> children) {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracerFactory.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracerFactory.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.data.v2.stub.metrics;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.ApiTracerFactory;
+import com.google.api.gax.tracing.BaseApiTracerFactory;
 import com.google.api.gax.tracing.SpanName;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
@@ -25,7 +26,7 @@ import java.util.List;
 
 /** Combines multiple {@link ApiTracerFactory} into a single {@link ApiTracerFactory}. */
 @InternalApi("For internal use only")
-public class CompositeTracerFactory implements ApiTracerFactory {
+public class CompositeTracerFactory extends BaseApiTracerFactory {
   private final List<ApiTracerFactory> apiTracerFactories;
 
   public CompositeTracerFactory(List<ApiTracerFactory> apiTracerFactories) {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.data.v2.stub.metrics;
 
-import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import com.google.api.gax.tracing.BaseApiTracer;
 import com.google.api.gax.tracing.SpanName;

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.data.v2.stub.metrics;
 
 import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
+import com.google.api.gax.tracing.BaseApiTracer;
 import com.google.api.gax.tracing.SpanName;
 import com.google.common.base.Stopwatch;
 import io.opencensus.stats.MeasureMap;
@@ -34,7 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
-class MetricsTracer implements ApiTracer {
+class MetricsTracer extends BaseApiTracer {
 
   private final OperationType operationType;
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerFactory.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerFactory.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.data.v2.stub.metrics;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.ApiTracerFactory;
+import com.google.api.gax.tracing.BaseApiTracerFactory;
 import com.google.api.gax.tracing.SpanName;
 import com.google.common.collect.ImmutableMap;
 import io.opencensus.stats.StatsRecorder;
@@ -30,7 +31,7 @@ import io.opencensus.tags.Tagger;
  * api.
  */
 @InternalApi("For internal use only")
-public class MetricsTracerFactory implements ApiTracerFactory {
+public class MetricsTracerFactory extends BaseApiTracerFactory {
   private final Tagger tagger;
   private final StatsRecorder stats;
   private final ImmutableMap<TagKey, TagValue> statsAttributes;


### PR DESCRIPTION
Extends `BaseApiTracer` and `BaseApiTracerFactory` instead of implementing `ApiTracer` and `ApiTracerFactory` after gax change is picked up. New methods could be added to `ApiTracer` and won't break the client.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
