### PR TITLE
feat: add batch throttled ms metric

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
@@ -89,6 +89,7 @@ import com.google.cloud.bigtable.data.v2.stub.readrows.ReadRowsRetryCompletedCal
 import com.google.cloud.bigtable.data.v2.stub.readrows.ReadRowsUserCallable;
 import com.google.cloud.bigtable.data.v2.stub.readrows.RowMergingCallable;
 import com.google.cloud.bigtable.gaxx.retrying.ApiResultRetryAlgorithm;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -632,7 +633,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
         settings.bulkMutateRowsSettings().getBatchingSettings(),
         clientContext.getExecutor(),
         bulkMutationFlowController,
-        ctx == null ? clientContext.getDefaultCallContext() : ctx);
+        MoreObjects.firstNonNull(ctx, clientContext.getDefaultCallContext()));
   }
 
   /**
@@ -660,7 +661,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
         settings.bulkReadRowsSettings().getBatchingSettings(),
         clientContext.getExecutor(),
         null,
-        ctx == null ? clientContext.getDefaultCallContext() : ctx);
+        MoreObjects.firstNonNull(ctx, clientContext.getDefaultCallContext()));
   }
 
   /**

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
@@ -460,8 +460,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
     SpanName span = getSpanName("ReadRows");
 
     // The TracedBatcherUnaryCallable has to be wrapped by the TracedUnaryCallable, so that
-    // TracedUnaryCallable can
-    // inject a tracer for the TracedBatcherUnaryCallable to interact with
+    // TracedUnaryCallable can inject a tracer for the TracedBatcherUnaryCallable to interact with
     UnaryCallable<Query, List<RowT>> tracedBatcher =
         new TracedBatcherUnaryCallable<>(readRowsUserCallable.all());
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracer.java
@@ -21,24 +21,34 @@ import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.BaseApiTracer;
 import javax.annotation.Nullable;
 
-/** A Bigtable specific {@link ApiTracer} that includes additional contexts. */
+/**
+ * A Bigtable specific {@link ApiTracer} that includes additional contexts. This class is a base
+ * implementation that does nothing.
+ */
 @BetaApi("This surface is stable yet it might be removed in the future.")
-public abstract class BigtableTracer extends BaseApiTracer {
+public class BigtableTracer extends BaseApiTracer {
 
   /**
    * Get the attempt number of the current call. Attempt number for the current call is passed in
    * and should be recorded in {@link #attemptStarted(int)}. With the getter we can access it from
    * {@link ApiCallContext}. Attempt number starts from 0.
    */
-  public abstract int getAttempt();
+  public int getAttempt() {
+    // noop
+    return 0;
+  }
 
   /**
    * Record the latency between Google's network receives the RPC and reads back the first byte of
    * the response from server-timing header. If server-timing header is missing, increment the
    * missing header count.
    */
-  public abstract void recordGfeMetadata(@Nullable Long latency, @Nullable Throwable throwable);
+  public void recordGfeMetadata(@Nullable Long latency, @Nullable Throwable throwable) {
+    // noop
+  }
 
   /** Adds an annotation of the total throttled time of a batch. */
-  public abstract void batchRequestThrottled(long throttledTimeMs);
+  public void batchRequestThrottled(long throttledTimeMs) {
+    // noop
+  }
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracer.java
@@ -38,4 +38,7 @@ public abstract class BigtableTracer extends BaseApiTracer {
    * missing header count.
    */
   public abstract void recordGfeMetadata(@Nullable Long latency, @Nullable Throwable throwable);
+
+  /** Adds an annotation of the total throttled time of a batch. */
+  public abstract void batchRequestThrottled(long throttledTimeMs);
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracer.java
@@ -28,14 +28,20 @@ import javax.annotation.Nullable;
 @BetaApi("This surface is stable yet it might be removed in the future.")
 public class BigtableTracer extends BaseApiTracer {
 
+  private volatile int attempt = 0;
+
+  @Override
+  public void attemptStarted(int attemptNumber) {
+    this.attempt = attemptNumber;
+  }
+
   /**
    * Get the attempt number of the current call. Attempt number for the current call is passed in
    * and should be recorded in {@link #attemptStarted(int)}. With the getter we can access it from
    * {@link ApiCallContext}. Attempt number starts from 0.
    */
   public int getAttempt() {
-    // noop
-    return 0;
+    return attempt;
   }
 
   /**

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracer.java
@@ -178,4 +178,11 @@ class CompositeTracer extends BigtableTracer {
       tracer.recordGfeMetadata(latency, throwable);
     }
   }
+
+  @Override
+  public void batchRequestThrottled(long throttledTimeMs) {
+    for (BigtableTracer tracer : bigtableTracers) {
+      tracer.batchRequestThrottled(throttledTimeMs);
+    }
+  }
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
@@ -129,8 +129,8 @@ class MetricsTracer extends BigtableTracer {
   }
 
   @Override
-  public void attemptStarted(int i) {
-    attempt = i;
+  public void attemptStarted(int attemptNumber) {
+    attempt = attemptNumber;
     attemptCount++;
     attemptTimer = Stopwatch.createStarted();
     attemptResponseCount = 0;

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
@@ -226,6 +226,15 @@ class MetricsTracer extends BigtableTracer {
             .build());
   }
 
+  @Override
+  public void batchRequestThrottled(long totalThrottledMs) {
+    MeasureMap measures =
+        stats
+            .newMeasureMap()
+            .put(RpcMeasureConstants.BIGTABLE_BATCH_THROTTLED_TIME, totalThrottledMs);
+    measures.record(newTagCtxBuilder().build());
+  }
+
   private TagContextBuilder newTagCtxBuilder() {
     TagContextBuilder tagCtx =
         tagger

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/RpcMeasureConstants.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/RpcMeasureConstants.java
@@ -88,4 +88,11 @@ public class RpcMeasureConstants {
           "cloud.google.com/java/bigtable/gfe_header_missing_count",
           "Number of RPC responses received without the server-timing header, most likely means that the RPC never reached Google's network",
           COUNT);
+
+  /** Total throttled time of a batch in msecs. */
+  public static final MeasureLong BIGTABLE_BATCH_THROTTLED_TIME =
+      MeasureLong.create(
+          "cloud.google.com/java/bigtable/batch_throttled_time",
+          "Total throttled time of a batch in msecs",
+          MILLISECOND);
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/RpcViewConstants.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/RpcViewConstants.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.data.v2.stub.metrics;
 
 import static com.google.cloud.bigtable.data.v2.stub.metrics.RpcMeasureConstants.BIGTABLE_APP_PROFILE_ID;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.RpcMeasureConstants.BIGTABLE_ATTEMPT_LATENCY;
+import static com.google.cloud.bigtable.data.v2.stub.metrics.RpcMeasureConstants.BIGTABLE_BATCH_THROTTLED_TIME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.RpcMeasureConstants.BIGTABLE_GFE_HEADER_MISSING_COUNT;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.RpcMeasureConstants.BIGTABLE_GFE_LATENCY;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.RpcMeasureConstants.BIGTABLE_INSTANCE_ID;
@@ -154,4 +155,13 @@ class RpcViewConstants {
               BIGTABLE_APP_PROFILE_ID,
               BIGTABLE_OP,
               BIGTABLE_STATUS));
+
+  static final View BIGTABLE_BATCH_THROTTLED_TIME_VIEW =
+      View.create(
+          View.Name.create("cloud.google.com/java/bigtable/batch_throttled_time"),
+          "Total throttled time of a batch in msecs",
+          BIGTABLE_BATCH_THROTTLED_TIME,
+          AGGREGATION_WITH_MILLIS_HISTOGRAM,
+          ImmutableList.of(
+              BIGTABLE_INSTANCE_ID, BIGTABLE_PROJECT_ID, BIGTABLE_APP_PROFILE_ID, BIGTABLE_OP));
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/RpcViewConstants.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/RpcViewConstants.java
@@ -156,6 +156,7 @@ class RpcViewConstants {
               BIGTABLE_OP,
               BIGTABLE_STATUS));
 
+  // use distribution so we can correlate batch throttled time with op_latency
   static final View BIGTABLE_BATCH_THROTTLED_TIME_VIEW =
       View.create(
           View.Name.create("cloud.google.com/java/bigtable/batch_throttled_time"),

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/RpcViews.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/RpcViews.java
@@ -31,7 +31,8 @@ public class RpcViews {
           RpcViewConstants.BIGTABLE_COMPLETED_OP_VIEW,
           RpcViewConstants.BIGTABLE_READ_ROWS_FIRST_ROW_LATENCY_VIEW,
           RpcViewConstants.BIGTABLE_ATTEMPT_LATENCY_VIEW,
-          RpcViewConstants.BIGTABLE_ATTEMPTS_PER_OP_VIEW);
+          RpcViewConstants.BIGTABLE_ATTEMPTS_PER_OP_VIEW,
+          RpcViewConstants.BIGTABLE_BATCH_THROTTLED_TIME_VIEW);
 
   private static final ImmutableSet<View> GFE_VIEW_SET =
       ImmutableSet.of(

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/TracedBatcherUnaryCallable.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/TracedBatcherUnaryCallable.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.data.v2.stub.metrics;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.batching.Batcher;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.gax.tracing.ApiTracer;
+
+/**
+ * This callable will extract total throttled time from {@link ApiCallContext} and add it to {@link
+ * ApiTracer}.
+ */
+@InternalApi
+public final class TracedBatcherUnaryCallable<RequestT, ResponseT>
+    extends UnaryCallable<RequestT, ResponseT> {
+  private final UnaryCallable<RequestT, ResponseT> innerCallable;
+
+  public TracedBatcherUnaryCallable(UnaryCallable innerCallable) {
+    this.innerCallable = innerCallable;
+  }
+
+  @Override
+  public ApiFuture<ResponseT> futureCall(RequestT request, ApiCallContext context) {
+    if (context.getOption(Batcher.THROTTLED_TIME_KEY) != null) {
+      ApiTracer tracer = context.getTracer();
+      // this should always be true
+      if (tracer instanceof BigtableTracer) {
+        ((BigtableTracer) tracer)
+            .batchRequestThrottled(context.getOption(Batcher.THROTTLED_TIME_KEY));
+      }
+    }
+    return innerCallable.futureCall(request, context);
+  }
+}

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/TracedBatcherUnaryCallable.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/TracedBatcherUnaryCallable.java
@@ -24,7 +24,7 @@ import com.google.api.gax.tracing.ApiTracer;
 
 /**
  * This callable will extract total throttled time from {@link ApiCallContext} and add it to {@link
- * ApiTracer}.
+ * ApiTracer}. This class needs to be wrapped by a callable that injects the {@link ApiTracer}.
  */
 @InternalApi
 public final class TracedBatcherUnaryCallable<RequestT, ResponseT>

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracerTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.data.v2.stub.metrics;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,11 +24,13 @@ import static org.mockito.Mockito.when;
 import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.ApiTracer.Scope;
 import com.google.common.collect.ImmutableList;
-import com.google.common.truth.Truth;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.junit.Assert;
 import org.junit.Before;
@@ -246,11 +249,15 @@ public class CompositeTracerTest {
     Method[] baseMethods = BigtableTracer.class.getDeclaredMethods();
     Method[] compositeTracerMethods = CompositeTracer.class.getDeclaredMethods();
     Set<String> compositeTracerMethodNames = new HashSet<>();
+    List<String> baseTracerMethodNames = new ArrayList<>();
     for (Method method : compositeTracerMethods) {
       compositeTracerMethodNames.add(method.getName());
     }
-    for (Method method : baseMethods) {
-      Truth.assertThat(compositeTracerMethodNames).contains(method.getName());
+    for (int i = 0; i < baseMethods.length; i++) {
+      if (baseMethods[i].getModifiers() == Modifier.PUBLIC) {
+        baseTracerMethodNames.add(baseMethods[i].getName());
+      }
     }
+    assertThat(compositeTracerMethodNames).containsAtLeastElementsIn(baseTracerMethodNames);
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracerTest.java
@@ -23,15 +23,12 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.ApiTracer.Scope;
+import com.google.cloud.bigtable.misc_utilities.MethodComparator;
 import com.google.common.collect.ImmutableList;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -248,16 +245,8 @@ public class CompositeTracerTest {
   public void testMethodsOverride() {
     Method[] baseMethods = BigtableTracer.class.getDeclaredMethods();
     Method[] compositeTracerMethods = CompositeTracer.class.getDeclaredMethods();
-    Set<String> compositeTracerMethodNames = new HashSet<>();
-    List<String> baseTracerMethodNames = new ArrayList<>();
-    for (Method method : compositeTracerMethods) {
-      compositeTracerMethodNames.add(method.getName());
-    }
-    for (int i = 0; i < baseMethods.length; i++) {
-      if (baseMethods[i].getModifiers() == Modifier.PUBLIC) {
-        baseTracerMethodNames.add(baseMethods[i].getName());
-      }
-    }
-    assertThat(compositeTracerMethodNames).containsAtLeastElementsIn(baseTracerMethodNames);
+    assertThat(Arrays.asList(compositeTracerMethods))
+        .comparingElementsUsing(MethodComparator.METHOD_CORRESPONDENCE)
+        .containsAtLeastElementsIn(baseMethods);
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerTest.java
@@ -45,6 +45,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
+import com.google.common.truth.Truth;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
 import com.google.protobuf.StringValue;
@@ -55,6 +56,9 @@ import io.opencensus.impl.stats.StatsComponentImpl;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tags;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -468,6 +472,19 @@ public class MetricsTracerTest {
       Assert.assertTrue(throttledTimeMetric >= throttled);
     } catch (Exception e) {
       throw e;
+    }
+  }
+
+  @Test
+  public void testMethodsOverride() {
+    Method[] baseMethods = BigtableTracer.class.getDeclaredMethods();
+    Method[] metricsTracerMethods = MetricsTracer.class.getDeclaredMethods();
+    Set<String> metricsTracerMethodNames = new HashSet<>();
+    for (Method method : metricsTracerMethods) {
+      metricsTracerMethodNames.add(method.getName());
+    }
+    for (Method method : baseMethods) {
+      Truth.assertThat(metricsTracerMethodNames).contains(method.getName());
     }
   }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerTest.java
@@ -18,9 +18,18 @@ package com.google.cloud.bigtable.data.v2.stub.metrics;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 
+import com.google.api.gax.batching.Batcher;
+import com.google.api.gax.batching.BatcherImpl;
+import com.google.api.gax.batching.BatchingDescriptor;
+import com.google.api.gax.batching.FlowController;
+import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsResponse;
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.bigtable.v2.ReadRowsResponse.CellChunk;
@@ -28,8 +37,10 @@ import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import com.google.cloud.bigtable.data.v2.FakeServiceHelper;
 import com.google.cloud.bigtable.data.v2.models.BulkMutation;
 import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStub;
 import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings;
+import com.google.cloud.bigtable.data.v2.stub.mutaterows.MutateRowsBatchingDescriptor;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -44,6 +55,7 @@ import io.opencensus.impl.stats.StatsComponentImpl;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tags;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
@@ -55,6 +67,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -88,6 +101,7 @@ public class MetricsTracerTest {
 
   private StatsComponentImpl localStats = new StatsComponentImpl();
   private EnhancedBigtableStub stub;
+  private BigtableDataSettings settings;
 
   @Before
   public void setUp() throws Exception {
@@ -96,7 +110,7 @@ public class MetricsTracerTest {
 
     RpcViews.registerBigtableClientViews(localStats.getViewManager());
 
-    BigtableDataSettings settings =
+    settings =
         BigtableDataSettings.newBuilderForEmulator(serviceHelper.getPort())
             .setProjectId(PROJECT_ID)
             .setInstanceId(INSTANCE_ID)
@@ -348,6 +362,112 @@ public class MetricsTracerTest {
               INSTANCE_ID,
               APP_PROFILE_ID);
       assertThat(attemptLatency).isAtLeast(0);
+    }
+  }
+
+  @Test
+  public void testBatchReadRowsThrottledTime() throws Exception {
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) {
+                @SuppressWarnings("unchecked")
+                StreamObserver<ReadRowsResponse> observer =
+                    (StreamObserver<ReadRowsResponse>) invocation.getArguments()[1];
+                observer.onNext(DEFAULT_READ_ROWS_RESPONSES);
+                observer.onCompleted();
+                return null;
+              }
+            })
+        .when(mockService)
+        .readRows(any(ReadRowsRequest.class), any());
+
+    try (Batcher batcher =
+        stub.newBulkReadRowsBatcher(Query.create(TABLE_ID), GrpcCallContext.createDefault())) {
+      batcher.add(ByteString.copyFromUtf8("row1"));
+      batcher.sendOutstanding();
+
+      // Give OpenCensus a chance to update the views asynchronously.
+      Thread.sleep(100);
+
+      long throttledTimeMetric =
+          StatsTestUtils.getAggregationValueAsLong(
+              localStats,
+              RpcViewConstants.BIGTABLE_BATCH_THROTTLED_TIME_VIEW,
+              ImmutableMap.of(
+                  RpcMeasureConstants.BIGTABLE_OP, TagValue.create("Bigtable.ReadRows")),
+              PROJECT_ID,
+              INSTANCE_ID,
+              APP_PROFILE_ID);
+      Assert.assertEquals(0, throttledTimeMetric);
+    }
+  }
+
+  @Test
+  public void testBatchMutateRowsThrottledTime() throws Exception {
+    FlowController flowController = Mockito.mock(FlowController.class);
+    BatchingDescriptor batchingDescriptor = Mockito.mock(MutateRowsBatchingDescriptor.class);
+    // Mock throttling
+    final long throttled = 50;
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) throws Throwable {
+                Thread.sleep(throttled);
+                return null;
+              }
+            })
+        .when(flowController)
+        .reserve(any(Long.class), any(Long.class));
+    when(flowController.getMaxElementCountLimit()).thenReturn(null);
+    when(flowController.getMaxRequestBytesLimit()).thenReturn(null);
+    when(batchingDescriptor.countBytes(any())).thenReturn(1l);
+    when(batchingDescriptor.newRequestBuilder(any())).thenCallRealMethod();
+
+    doAnswer(
+            new Answer() {
+              @Override
+              public Object answer(InvocationOnMock invocation) {
+                @SuppressWarnings("unchecked")
+                StreamObserver<MutateRowsResponse> observer =
+                    (StreamObserver<MutateRowsResponse>) invocation.getArguments()[1];
+                observer.onNext(MutateRowsResponse.newBuilder().build());
+                observer.onCompleted();
+                return null;
+              }
+            })
+        .when(mockService)
+        .mutateRows(any(MutateRowsRequest.class), any());
+
+    ApiCallContext defaultContext = GrpcCallContext.createDefault();
+
+    try {
+      Batcher batcher =
+          new BatcherImpl(
+              batchingDescriptor,
+              stub.bulkMutateRowsCallable().withDefaultCallContext(defaultContext),
+              BulkMutation.create(TABLE_ID),
+              settings.getStubSettings().bulkMutateRowsSettings().getBatchingSettings(),
+              Executors.newSingleThreadScheduledExecutor(),
+              flowController,
+              defaultContext);
+
+      batcher.add(RowMutationEntry.create("key"));
+      batcher.sendOutstanding();
+
+      Thread.sleep(100);
+      long throttledTimeMetric =
+          StatsTestUtils.getAggregationValueAsLong(
+              localStats,
+              RpcViewConstants.BIGTABLE_BATCH_THROTTLED_TIME_VIEW,
+              ImmutableMap.of(
+                  RpcMeasureConstants.BIGTABLE_OP, TagValue.create("Bigtable.MutateRows")),
+              PROJECT_ID,
+              INSTANCE_ID,
+              APP_PROFILE_ID);
+      Assert.assertTrue(throttledTimeMetric >= throttled);
+    } catch (Exception e) {
+      throw e;
     }
   }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerTest.java
@@ -41,6 +41,7 @@ import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStub;
 import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings;
 import com.google.cloud.bigtable.data.v2.stub.mutaterows.MutateRowsBatchingDescriptor;
+import com.google.cloud.bigtable.misc_utilities.MethodComparator;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -56,11 +57,7 @@ import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tags;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.Arrays;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -405,7 +402,7 @@ public class MetricsTracerTest {
               PROJECT_ID,
               INSTANCE_ID,
               APP_PROFILE_ID);
-      Assert.assertEquals(0, throttledTimeMetric);
+      assertThat(throttledTimeMetric).isEqualTo(0);
     }
   }
 
@@ -470,24 +467,16 @@ public class MetricsTracerTest {
             PROJECT_ID,
             INSTANCE_ID,
             APP_PROFILE_ID);
-    Assert.assertTrue(throttledTimeMetric >= throttled);
+    assertThat(throttledTimeMetric).isAtLeast(throttled);
   }
 
   @Test
   public void testMethodsOverride() {
     Method[] baseMethods = BigtableTracer.class.getDeclaredMethods();
     Method[] metricsTracerMethods = MetricsTracer.class.getDeclaredMethods();
-    Set<String> metricsTracerMethodNames = new HashSet<>();
-    List<String> baseTracerMethodNames = new ArrayList<>();
-    for (Method method : metricsTracerMethods) {
-      metricsTracerMethodNames.add(method.getName());
-    }
-    for (int i = 0; i < baseMethods.length; i++) {
-      if (baseMethods[i].getModifiers() == Modifier.PUBLIC) {
-        baseTracerMethodNames.add(baseMethods[i].getName());
-      }
-    }
-    assertThat(metricsTracerMethodNames).containsAtLeastElementsIn(baseTracerMethodNames);
+    assertThat(Arrays.asList(metricsTracerMethods))
+        .comparingElementsUsing(MethodComparator.METHOD_CORRESPONDENCE)
+        .containsAtLeastElementsIn(baseMethods);
   }
 
   @SuppressWarnings("unchecked")

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/MethodComparator.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/MethodComparator.java
@@ -31,12 +31,9 @@ public class MethodComparator {
           MethodComparator::compareMethods, "compare method names, parameters and return types");
 
   private static boolean compareMethods(Method actual, Method expected) {
-    if (!actual.getName().equals(expected.getName())
-        || !Arrays.equals(actual.getParameterTypes(), expected.getParameterTypes())
-        || actual.getModifiers() != expected.getModifiers()
-        || !actual.getReturnType().equals(expected.getReturnType())) {
-      return false;
-    }
-    return true;
+    return actual.getName().equals(expected.getName())
+        && Arrays.equals(actual.getParameterTypes(), expected.getParameterTypes())
+        && actual.getModifiers() == expected.getModifiers()
+        && actual.getReturnType().equals(expected.getReturnType());
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/MethodComparator.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/MethodComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/MethodComparator.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/MethodComparator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.misc_utilities;
+
+import com.google.common.truth.Correspondence;
+import java.lang.reflect.Method;
+
+/**
+ * A {@link Correspondence} to compare methods names and parameters in different classes. An example
+ * usage is to make sure a child class is implementing all the methods in the non-abstract parent
+ * class.
+ */
+public class MethodComparator {
+
+  public static final Correspondence<Method, Method> METHOD_CORRESPONDENCE =
+      Correspondence.from(MethodComparator::compareMethods, "compare method names and parameters");
+
+  private static boolean compareMethods(Method actual, Method expected) {
+    if (!actual.getName().equals(expected.getName())
+        || actual.getParameters().equals(expected.getParameters())
+        || actual.getModifiers() != expected.getModifiers()) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/MethodComparator.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/misc_utilities/MethodComparator.java
@@ -17,21 +17,24 @@ package com.google.cloud.bigtable.misc_utilities;
 
 import com.google.common.truth.Correspondence;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 /**
- * A {@link Correspondence} to compare methods names and parameters in different classes. An example
- * usage is to make sure a child class is implementing all the methods in the non-abstract parent
- * class.
+ * A {@link Correspondence} to compare methods names, parameters and return types in different
+ * classes. An example usage is to make sure a child class is implementing all the methods in the
+ * non-abstract parent class.
  */
 public class MethodComparator {
 
   public static final Correspondence<Method, Method> METHOD_CORRESPONDENCE =
-      Correspondence.from(MethodComparator::compareMethods, "compare method names and parameters");
+      Correspondence.from(
+          MethodComparator::compareMethods, "compare method names, parameters and return types");
 
   private static boolean compareMethods(Method actual, Method expected) {
     if (!actual.getName().equals(expected.getName())
-        || actual.getParameters().equals(expected.getParameters())
-        || actual.getModifiers() != expected.getModifiers()) {
+        || !Arrays.equals(actual.getParameterTypes(), expected.getParameterTypes())
+        || actual.getModifiers() != expected.getModifiers()
+        || !actual.getReturnType().equals(expected.getReturnType())) {
       return false;
     }
     return true;


### PR DESCRIPTION
`BatcherImpl` will add [throttled time to ApiCallContext](https://github.com/googleapis/gax-java/blob/main/gax/src/main/java/com/google/api/gax/batching/BatcherImpl.java#L277). Get the time from call context and export it to `batch_throttled_time` metric.

(This change depends on new gax release with https://github.com/googleapis/gax-java/pull/1463)