### PR TITLE
deps: fix UpperBoundsDep check for checker-qual

### DIFF
--- a/google-cloud-bigtable-emulator/pom.xml
+++ b/google-cloud-bigtable-emulator/pom.xml
@@ -150,6 +150,14 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- TODO: consider a different approach -->
+        <!-- exclude to resolve conflict with guava -->
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-qual</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -235,6 +235,8 @@
       <artifactId>truth</artifactId>
       <scope>test</scope>
       <exclusions>
+        <!-- TODO: consider a different approach -->
+        <!-- exclude to resolve conflict with guava -->
         <exclusion>
           <groupId>org.checkerframework</groupId>
           <artifactId>checker-qual</artifactId>
@@ -246,6 +248,8 @@
       <artifactId>truth-proto-extension</artifactId>
       <scope>test</scope>
       <exclusions>
+        <!-- TODO: consider a different approach -->
+        <!-- exclude to resolve conflict with guava -->
         <exclusion>
           <groupId>org.checkerframework</groupId>
           <artifactId>checker-qual</artifactId>


### PR DESCRIPTION
#939 switch guava from -android to -jre, which replaced the transitive dep checker-compat-qual with checker-qual. This introduced a version conflict between guava's transitive deps and truth's: gauva depends on version 3.8.0 while truth depends on 3.13.0. #939 tried to workaround the conflict by excluding the transitive dep from truth, but it didnt do it all places. This finishes the workaround.

I'm not convinced that this is the correct way to resolve the dependency conflict, but for now this PR just makes it consistent
