### PR TITLE
refactor: Avoid setting empty builders in proto setters

### DIFF
--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/MutationTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/MutationTest.java
@@ -175,7 +175,7 @@ public class MutationTest {
     assertThat(actual)
         .containsExactly(
             com.google.bigtable.v2.Mutation.newBuilder()
-                .setDeleteFromRow(DeleteFromRow.newBuilder())
+                .setDeleteFromRow(DeleteFromRow.getDefaultInstance())
                 .build());
   }
 


### PR DESCRIPTION
Per Google internal cleanup