### PR TITLE
fix: make placeholder class public

### DIFF
--- a/google-cloud-bigtable-stats/src/main/java/com/google/cloud/bigtable/stats/MavenPlaceholderShaded.java
+++ b/google-cloud-bigtable-stats/src/main/java/com/google/cloud/bigtable/stats/MavenPlaceholderShaded.java
@@ -15,9 +15,6 @@
  */
 package com.google.cloud.bigtable.stats;
 
-import com.google.api.core.InternalApi;
-
-@InternalApi
 public final class MavenPlaceholderShaded {
   /**
    * This class is here to force generation of source javadoc jars so that the maven release process

--- a/google-cloud-bigtable-stats/src/main/java/com/google/cloud/bigtable/stats/MavenPlaceholderShaded.java
+++ b/google-cloud-bigtable-stats/src/main/java/com/google/cloud/bigtable/stats/MavenPlaceholderShaded.java
@@ -15,6 +15,9 @@
  */
 package com.google.cloud.bigtable.stats;
 
+import com.google.api.core.InternalApi;
+
+@InternalApi
 public final class MavenPlaceholderShaded {
   /**
    * This class is here to force generation of source javadoc jars so that the maven release process

--- a/google-cloud-bigtable-stats/src/main/java/com/google/cloud/bigtable/stats/MavenPlaceholderShaded.java
+++ b/google-cloud-bigtable-stats/src/main/java/com/google/cloud/bigtable/stats/MavenPlaceholderShaded.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.bigtable.stats;
 
-final class MavenPlaceholderShaded {
+public final class MavenPlaceholderShaded {
   /**
    * This class is here to force generation of source javadoc jars so that the maven release process
    * doesn't complain. The shading plugin generated a shaded jar of bigtable-stats, but it doesn't


### PR DESCRIPTION
Currently javadoc build is failing:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.3.1:jar (attach-javadocs) on project google-cloud-bigtable-stats: MavenReportException: Error while generating Javadoc: 
[ERROR] Exit code: 1 - javadoc: error - No public or protected classes found to document.
```