### PR TITLE
chore: rename HeaderTracerCallables to BigtableTracerCallables

### DIFF
--- a/google-cloud-bigtable/clirr-ignored-differences.xml
+++ b/google-cloud-bigtable/clirr-ignored-differences.xml
@@ -61,4 +61,14 @@
         <className>com/google/cloud/bigtable/data/v2/stub/metrics/HeaderTracerUnaryCallable</className>
         <method>*</method>
     </difference>
+    <!-- InternalApi that was removed -->
+    <difference>
+        <differenceType>8001</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/stub/metrics/HeaderTracerStreamingCallable</className>
+    </difference>
+    <!-- InternalApi that was removed -->
+    <difference>
+        <differenceType>8001</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/stub/metrics/HeaderTracerUnaryCallable</className>
+    </difference>
 </differences>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
@@ -70,9 +70,9 @@ import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowAdapter;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.cloud.bigtable.data.v2.stub.metrics.BigtableTracerStreamingCallable;
+import com.google.cloud.bigtable.data.v2.stub.metrics.BigtableTracerUnaryCallable;
 import com.google.cloud.bigtable.data.v2.stub.metrics.CompositeTracerFactory;
-import com.google.cloud.bigtable.data.v2.stub.metrics.HeaderTracerStreamingCallable;
-import com.google.cloud.bigtable.data.v2.stub.metrics.HeaderTracerUnaryCallable;
 import com.google.cloud.bigtable.data.v2.stub.metrics.MetricsTracerFactory;
 import com.google.cloud.bigtable.data.v2.stub.metrics.RpcMeasureConstants;
 import com.google.cloud.bigtable.data.v2.stub.metrics.StatsHeadersServerStreamingCallable;
@@ -369,7 +369,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
    *   <li>Upon receiving the response stream, it will merge the {@link
    *       com.google.bigtable.v2.ReadRowsResponse.CellChunk}s in logical rows. The actual row
    *       implementation can be configured by the {@code rowAdapter} parameter.
-   *   <li>Add header tracer for tracking GFE metrics.
+   *   <li>Add BigtableTracer callable for tracking Bigtable specific metrics
    *   <li>Retry/resume on failure.
    *   <li>Filter out marker rows.
    * </ul>
@@ -420,13 +420,13 @@ public class EnhancedBigtableStub implements AutoCloseable {
     ServerStreamingCallable<ReadRowsRequest, RowT> watched =
         Callables.watched(merging, innerSettings, clientContext);
 
-    ServerStreamingCallable<ReadRowsRequest, RowT> withHeaderTracer =
-        new HeaderTracerStreamingCallable<>(watched);
+    ServerStreamingCallable<ReadRowsRequest, RowT> withBigtableTracer =
+        new BigtableTracerStreamingCallable<>(watched);
 
     // Retry logic is split into 2 parts to workaround a rare edge case described in
     // ReadRowsRetryCompletedCallable
     ServerStreamingCallable<ReadRowsRequest, RowT> retrying1 =
-        new ReadRowsRetryCompletedCallable<>(withHeaderTracer);
+        new ReadRowsRetryCompletedCallable<>(withBigtableTracer);
 
     ServerStreamingCallable<ReadRowsRequest, RowT> retrying2 =
         Callables.retrying(retrying1, innerSettings, clientContext);
@@ -465,11 +465,11 @@ public class EnhancedBigtableStub implements AutoCloseable {
     UnaryCallable<Query, List<RowT>> tracedBatcher =
         new TracedBatcherUnaryCallable<>(readRowsUserCallable.all());
 
-    UnaryCallable<Query, List<RowT>> withHeaderTracer =
-        new HeaderTracerUnaryCallable(tracedBatcher);
+    UnaryCallable<Query, List<RowT>> withBigtableTracer =
+        new BigtableTracerUnaryCallable<>(tracedBatcher);
 
     UnaryCallable<Query, List<RowT>> traced =
-        new TracedUnaryCallable<>(withHeaderTracer, clientContext.getTracerFactory(), span);
+        new TracedUnaryCallable<>(withBigtableTracer, clientContext.getTracerFactory(), span);
 
     return traced.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
@@ -511,11 +511,11 @@ public class EnhancedBigtableStub implements AutoCloseable {
     UnaryCallable<SampleRowKeysRequest, List<SampleRowKeysResponse>> withStatsHeaders =
         new StatsHeadersUnaryCallable<>(spoolable);
 
-    UnaryCallable<SampleRowKeysRequest, List<SampleRowKeysResponse>> withHeaderTracer =
-        new HeaderTracerUnaryCallable<>(withStatsHeaders);
+    UnaryCallable<SampleRowKeysRequest, List<SampleRowKeysResponse>> withBigtableTracer =
+        new BigtableTracerUnaryCallable<>(withStatsHeaders);
 
     UnaryCallable<SampleRowKeysRequest, List<SampleRowKeysResponse>> retryable =
-        Callables.retrying(withHeaderTracer, settings.sampleRowKeysSettings(), clientContext);
+        Callables.retrying(withBigtableTracer, settings.sampleRowKeysSettings(), clientContext);
 
     return createUserFacingUnaryCallable(
         methodName, new SampleRowKeysCallable(retryable, requestContext));
@@ -550,11 +550,11 @@ public class EnhancedBigtableStub implements AutoCloseable {
     UnaryCallable<MutateRowRequest, MutateRowResponse> withStatsHeaders =
         new StatsHeadersUnaryCallable<>(base);
 
-    UnaryCallable<MutateRowRequest, MutateRowResponse> withHeaderTracer =
-        new HeaderTracerUnaryCallable<>(withStatsHeaders);
+    UnaryCallable<MutateRowRequest, MutateRowResponse> withBigtableTracer =
+        new BigtableTracerUnaryCallable<>(withStatsHeaders);
 
     UnaryCallable<MutateRowRequest, MutateRowResponse> retrying =
-        Callables.retrying(withHeaderTracer, settings.mutateRowSettings(), clientContext);
+        Callables.retrying(withBigtableTracer, settings.mutateRowSettings(), clientContext);
 
     return createUserFacingUnaryCallable(
         methodName, new MutateRowCallable(retrying, requestContext));
@@ -594,13 +594,13 @@ public class EnhancedBigtableStub implements AutoCloseable {
 
     SpanName spanName = getSpanName("MutateRows");
 
-    UnaryCallable<BulkMutation, Void> tracedBatcher = new TracedBatcherUnaryCallable<>(userFacing);
+    UnaryCallable<BulkMutation, Void> tracedBatcherUnaryCallable =
+        new TracedBatcherUnaryCallable<>(userFacing);
 
-    UnaryCallable<BulkMutation, Void> withHeaderTracer =
-        new HeaderTracerUnaryCallable<>(tracedBatcher);
-
+    UnaryCallable<BulkMutation, Void> withBigtableTracer =
+        new BigtableTracerUnaryCallable<>(tracedBatcherUnaryCallable);
     UnaryCallable<BulkMutation, Void> traced =
-        new TracedUnaryCallable<>(withHeaderTracer, clientContext.getTracerFactory(), spanName);
+        new TracedUnaryCallable<>(withBigtableTracer, clientContext.getTracerFactory(), spanName);
 
     return traced.withDefaultCallContext(clientContext.getDefaultCallContext());
   }
@@ -738,11 +738,11 @@ public class EnhancedBigtableStub implements AutoCloseable {
     UnaryCallable<CheckAndMutateRowRequest, CheckAndMutateRowResponse> withStatsHeaders =
         new StatsHeadersUnaryCallable<>(base);
 
-    UnaryCallable<CheckAndMutateRowRequest, CheckAndMutateRowResponse> withHeaderTracer =
-        new HeaderTracerUnaryCallable<>(withStatsHeaders);
+    UnaryCallable<CheckAndMutateRowRequest, CheckAndMutateRowResponse> withBigtableTracer =
+        new BigtableTracerUnaryCallable<>(withStatsHeaders);
 
     UnaryCallable<CheckAndMutateRowRequest, CheckAndMutateRowResponse> retrying =
-        Callables.retrying(withHeaderTracer, settings.checkAndMutateRowSettings(), clientContext);
+        Callables.retrying(withBigtableTracer, settings.checkAndMutateRowSettings(), clientContext);
 
     return createUserFacingUnaryCallable(
         methodName, new CheckAndMutateRowCallable(retrying, requestContext));
@@ -779,11 +779,12 @@ public class EnhancedBigtableStub implements AutoCloseable {
         new StatsHeadersUnaryCallable<>(base);
 
     String methodName = "ReadModifyWriteRow";
-    UnaryCallable<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse> withHeaderTracer =
-        new HeaderTracerUnaryCallable<>(withStatsHeaders);
+    UnaryCallable<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse> withBigtableTracer =
+        new BigtableTracerUnaryCallable<>(withStatsHeaders);
 
     UnaryCallable<ReadModifyWriteRowRequest, ReadModifyWriteRowResponse> retrying =
-        Callables.retrying(withHeaderTracer, settings.readModifyWriteRowSettings(), clientContext);
+        Callables.retrying(
+            withBigtableTracer, settings.readModifyWriteRowSettings(), clientContext);
 
     return createUserFacingUnaryCallable(
         methodName, new ReadModifyWriteRowCallable(retrying, requestContext));

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracerUnaryCallable.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracerUnaryCallable.java
@@ -15,13 +15,15 @@
  */
 package com.google.cloud.bigtable.data.v2.stub.metrics;
 
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.grpc.GrpcResponseMetadata;
 import com.google.api.gax.rpc.ApiCallContext;
-import com.google.api.gax.rpc.ResponseObserver;
-import com.google.api.gax.rpc.ServerStreamingCallable;
-import com.google.api.gax.rpc.StreamController;
+import com.google.api.gax.rpc.UnaryCallable;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.grpc.Metadata;
 import javax.annotation.Nonnull;
 
@@ -40,72 +42,53 @@ import javax.annotation.Nonnull;
  * applications.
  */
 @InternalApi
-public class HeaderTracerStreamingCallable<RequestT, ResponseT>
-    extends ServerStreamingCallable<RequestT, ResponseT> {
+public class BigtableTracerUnaryCallable<RequestT, ResponseT>
+    extends UnaryCallable<RequestT, ResponseT> {
 
-  private final ServerStreamingCallable<RequestT, ResponseT> innerCallable;
+  private final UnaryCallable<RequestT, ResponseT> innerCallable;
 
-  public HeaderTracerStreamingCallable(
-      @Nonnull ServerStreamingCallable<RequestT, ResponseT> callable) {
-    this.innerCallable = Preconditions.checkNotNull(callable, "Inner callable must be set");
+  public BigtableTracerUnaryCallable(@Nonnull UnaryCallable<RequestT, ResponseT> innerCallable) {
+    this.innerCallable = Preconditions.checkNotNull(innerCallable, "Inner callable must be set");
   }
 
   @Override
-  public void call(
-      RequestT request, ResponseObserver<ResponseT> responseObserver, ApiCallContext context) {
-    final GrpcResponseMetadata responseMetadata = new GrpcResponseMetadata();
-    // tracer should always be an instance of bigtable tracer
+  public ApiFuture futureCall(RequestT request, ApiCallContext context) {
+    // tracer should always be an instance of BigtableTracer
     if (RpcViews.isGfeMetricsRegistered() && context.getTracer() instanceof BigtableTracer) {
-      HeaderTracerResponseObserver<ResponseT> innerObserver =
-          new HeaderTracerResponseObserver<>(
-              responseObserver, (BigtableTracer) context.getTracer(), responseMetadata);
-      innerCallable.call(request, innerObserver, responseMetadata.addHandlers(context));
+      final GrpcResponseMetadata responseMetadata = new GrpcResponseMetadata();
+      final ApiCallContext contextWithResponseMetadata = responseMetadata.addHandlers(context);
+      BigtableTracerUnaryCallback callback =
+          new BigtableTracerUnaryCallback((BigtableTracer) context.getTracer(), responseMetadata);
+      ApiFuture<ResponseT> future = innerCallable.futureCall(request, contextWithResponseMetadata);
+      ApiFutures.addCallback(future, callback, MoreExecutors.directExecutor());
+      return future;
     } else {
-      innerCallable.call(request, responseObserver, context);
+      return innerCallable.futureCall(request, context);
     }
   }
 
-  private class HeaderTracerResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
+  class BigtableTracerUnaryCallback<ResponseT> implements ApiFutureCallback<ResponseT> {
 
     private final BigtableTracer tracer;
-    private final ResponseObserver<ResponseT> outerObserver;
     private final GrpcResponseMetadata responseMetadata;
 
-    HeaderTracerResponseObserver(
-        ResponseObserver<ResponseT> observer,
-        BigtableTracer tracer,
-        GrpcResponseMetadata metadata) {
+    BigtableTracerUnaryCallback(BigtableTracer tracer, GrpcResponseMetadata responseMetadata) {
       this.tracer = tracer;
-      this.outerObserver = observer;
-      this.responseMetadata = metadata;
+      this.responseMetadata = responseMetadata;
     }
 
     @Override
-    public void onStart(final StreamController controller) {
-      outerObserver.onStart(controller);
-    }
-
-    @Override
-    public void onResponse(ResponseT response) {
-      outerObserver.onResponse(response);
-    }
-
-    @Override
-    public void onError(Throwable t) {
-      // server-timing metric will be added through GrpcResponseMetadata#onHeaders(Metadata),
-      // so it's not checking trailing metadata here.
+    public void onFailure(Throwable throwable) {
       Metadata metadata = responseMetadata.getMetadata();
       Long latency = Util.getGfeLatency(metadata);
-      tracer.recordGfeMetadata(latency, t);
-      outerObserver.onError(t);
+      tracer.recordGfeMetadata(latency, throwable);
     }
 
     @Override
-    public void onComplete() {
+    public void onSuccess(ResponseT response) {
       Metadata metadata = responseMetadata.getMetadata();
       Long latency = Util.getGfeLatency(metadata);
       tracer.recordGfeMetadata(latency, null);
-      outerObserver.onComplete();
     }
   }
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracer.java
@@ -92,9 +92,14 @@ class CompositeTracer extends BigtableTracer {
 
   @Override
   public void attemptStarted(int attemptNumber) {
+    attemptStarted(null, attemptNumber);
+  }
+
+  @Override
+  public void attemptStarted(Object request, int attemptNumber) {
     this.attempt = attemptNumber;
     for (ApiTracer child : children) {
-      child.attemptStarted(attemptNumber);
+      child.attemptStarted(request, attemptNumber);
     }
   }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracerCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracerCallableTest.java
@@ -68,7 +68,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class HeaderTracerCallableTest {
+public class BigtableTracerCallableTest {
   private FakeServiceHelper serviceHelper;
   private FakeServiceHelper serviceHelperNoHeader;
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.ApiTracer.Scope;
+import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.misc_utilities.MethodComparator;
 import com.google.common.collect.ImmutableList;
 import io.grpc.Status;
@@ -118,11 +119,12 @@ public class CompositeTracerTest {
 
   @Test
   public void testAttemptStarted() {
-    compositeTracer.attemptStarted(3);
-    verify(child1, times(1)).attemptStarted(3);
-    verify(child2, times(1)).attemptStarted(3);
-    verify(child3, times(1)).attemptStarted(3);
-    verify(child4, times(1)).attemptStarted(3);
+    ReadRowsRequest request = ReadRowsRequest.getDefaultInstance();
+    compositeTracer.attemptStarted(request, 3);
+    verify(child1, times(1)).attemptStarted(request, 3);
+    verify(child2, times(1)).attemptStarted(request, 3);
+    verify(child3, times(1)).attemptStarted(request, 3);
+    verify(child4, times(1)).attemptStarted(request, 3);
   }
 
   @Test


### PR DESCRIPTION
This is part of #1054, rename HeaderTracerCallables to BigtableTracerCallables so the callables can be used to track other bigtable specific metrics