### PR TITLE
chore: fix emulator bundling for 1.22.0 sp

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -61,6 +61,7 @@ javadoc)
 integration)
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \
+      -e \
       -Penable-integration-tests \
       -DtrimStackTrace=false \
       -Dclirr.skip=true \

--- a/google-cloud-bigtable-emulator/pom.xml
+++ b/google-cloud-bigtable-emulator/pom.xml
@@ -41,7 +41,7 @@
         <!-- https://github.com/googleapis/java-gcloud-maven-plugin -->
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-gcloud-maven-plugin</artifactId>
-        <version>0.1.2</version>
+        <version>0.1.4</version>
 
         <executions>
           <execution>
@@ -52,7 +52,6 @@
             </goals>
             <configuration>
               <componentNames>
-                <componentName>bigtable-darwin-x86</componentName>
                 <componentName>bigtable-darwin-x86_64</componentName>
                 <componentName>bigtable-linux-x86</componentName>
                 <componentName>bigtable-linux-x86_64</componentName>

--- a/google-cloud-bigtable-emulator/pom.xml
+++ b/google-cloud-bigtable-emulator/pom.xml
@@ -37,6 +37,58 @@
 
   <build>
     <plugins>
+      <!-- Start Skip publishing -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <skipDeploy>true</skipDeploy>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <skipSource>true</skipSource>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <!-- End Skip publishing -->
       <plugin>
         <!-- https://github.com/googleapis/java-gcloud-maven-plugin -->
         <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
Bump the version of the google-cloud-gcloud-maven-plugin to fix directory creation
Remove darn x86 artifact since it's no longer published

port of #1107