### PR TITLE
chore: fix emulator bundling for 2.2.x sp

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -61,6 +61,7 @@ javadoc)
 integration)
     mvn -B ${INTEGRATION_TEST_ARGS} \
       -ntp \
+      -e \
       -Penable-integration-tests \
       -DtrimStackTrace=false \
       -Dclirr.skip=true \

--- a/google-cloud-bigtable-emulator/pom.xml
+++ b/google-cloud-bigtable-emulator/pom.xml
@@ -41,7 +41,7 @@
         <!-- https://github.com/googleapis/java-gcloud-maven-plugin -->
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-gcloud-maven-plugin</artifactId>
-        <version>0.1.2</version>
+        <version>0.1.4</version>
 
         <executions>
           <execution>
@@ -52,7 +52,6 @@
             </goals>
             <configuration>
               <componentNames>
-                <componentName>bigtable-darwin-x86</componentName>
                 <componentName>bigtable-darwin-x86_64</componentName>
                 <componentName>bigtable-linux-x86</componentName>
                 <componentName>bigtable-linux-x86_64</componentName>


### PR DESCRIPTION
Bump the version of the google-cloud-gcloud-maven-plugin to fix directory creation
Remove darn x86 artifact since it's no longer published

port of #1107 