### PR TITLE
docs(sample): Add sample for native image support in Bigtable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:24.2.0')
+implementation platform('com.google.cloud:libraries-bom:24.3.0')
 
 implementation 'com.google.cloud:google-cloud-bigtable'
 ```
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigtable:2.5.2'
+implementation 'com.google.cloud:google-cloud-bigtable:2.5.3'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.5.2"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.5.3"
 ```
 
 ## Authentication
@@ -472,6 +472,7 @@ Samples are in the [`samples/`](https://github.com/googleapis/java-bigtable/tree
 
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
+| Native Image Bigtable Sample | [source code](https://github.com/googleapis/java-bigtable/blob/main/samples/native-image-sample/src/main/java/com/example/bigtable/NativeImageBigtableSample.java) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/java-bigtable&page=editor&open_in_editor=samples/native-image-sample/src/main/java/com/example/bigtable/NativeImageBigtableSample.java) |
 | Configure Connection Pool | [source code](https://github.com/googleapis/java-bigtable/blob/main/samples/snippets/src/main/java/com/example/bigtable/ConfigureConnectionPool.java) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/java-bigtable&page=editor&open_in_editor=samples/snippets/src/main/java/com/example/bigtable/ConfigureConnectionPool.java) |
 | Filters | [source code](https://github.com/googleapis/java-bigtable/blob/main/samples/snippets/src/main/java/com/example/bigtable/Filters.java) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/java-bigtable&page=editor&open_in_editor=samples/snippets/src/main/java/com/example/bigtable/Filters.java) |
 | Hello World | [source code](https://github.com/googleapis/java-bigtable/blob/main/samples/snippets/src/main/java/com/example/bigtable/HelloWorld.java) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/java-bigtable&page=editor&open_in_editor=samples/snippets/src/main/java/com/example/bigtable/HelloWorld.java) |

--- a/samples/native-image-sample/README.md
+++ b/samples/native-image-sample/README.md
@@ -6,12 +6,45 @@ The application runs through some simple BigTable Client Library operations to d
 
 ## Setup Instructions
 
-1. Follow the [GCP Project and Native Image Setup Instructions](../../README.md).
+You will need to follow these prerequisite steps in order to run the samples:
 
-2.  BigTable Environment setup -
-    The following sections describe how you can run the sample application against the BigTable emulator or a real BigTable instance.
+1. If you have not already, [create a Google Cloud Platform Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project).
 
-    1. *(Using emulator)* If you wish to run the application against the [BigTable emulator](https://cloud.google.com/bigtable/docs/emulator), ensure that you have the [Google Cloud SDK](https://cloud.google.com/sdk) installed.
+2. Install the [Google Cloud SDK](https://cloud.google.com/sdk/) which will allow you to run the sample with your project's credentials.
+
+   Once installed, log in with Application Default Credentials using the following command:
+
+    ```
+    gcloud auth application-default login
+    ```
+
+   **Note:** Authenticating with Application Default Credentials is convenient to use during development, but we recommend [alternate methods of authentication](https://cloud.google.com/docs/authentication/production) during production use.
+
+3. Install the GraalVM compiler.
+
+   You can follow the [official installation instructions](https://www.graalvm.org/docs/getting-started/#install-graalvm) from the GraalVM website.
+   After following the instructions, ensure that you install the native image extension installed by running:
+
+    ```
+    gu install native-image
+    ```
+
+   Once you finish following the instructions, verify that the default version of Java is set to the GraalVM version by running `java -version` in a terminal.
+
+   You will see something similar to the below output:
+
+    ```
+    $ java -version
+   
+    openjdk version "11.0.7" 2020-04-14
+    OpenJDK Runtime Environment GraalVM CE 20.1.0 (build 11.0.7+10-jvmci-20.1-b02)
+    OpenJDK 64-Bit Server VM GraalVM CE 20.1.0 (build 11.0.7+10-jvmci-20.1-b02, mixed mode, sharing)
+    ```
+   
+## BigTable Environment setup
+The following sections describe how you can run the sample application against the BigTable emulator or a real BigTable instance.
+
+1. *(Using emulator)* If you wish to run the application against the [BigTable emulator](https://cloud.google.com/bigtable/docs/emulator), ensure that you have the [Google Cloud SDK](https://cloud.google.com/sdk) installed.
 
        In a new terminal window, start the emulator via `gcloud`:
 
@@ -22,26 +55,26 @@ The application runs through some simple BigTable Client Library operations to d
        Leave the emulator running in this terminal for now.
        In the next section, we will run the sample application against the BigTable emulator instance.
 
-    2. *(Using real BigTable instance)* If instead you wish to run the application against a real BigTable instance, ensure you already have a BigTable instance created.
+2. *(Using real BigTable instance)* If instead you wish to run the application against a real BigTable instance, ensure you already have a BigTable instance created.
 
-       For example, the following command creates a new BigTable instance named `nativeimage-test-instance`.
+   For example, the following command creates a new BigTable instance named `nativeimage-test-instance`.
 
-       ```
-       gcloud bigtable instances create nativeimage-test-instance \
-           --cluster=nativeimage-test-cluster \
-           --cluster-zone=us-central1-c \
-           --cluster-num-nodes=1 \
-           --display-name=nativeimage-test-instance
-       ```
+   ```
+   gcloud bigtable instances create nativeimage-test-instance \
+       --cluster=nativeimage-test-cluster \
+       --cluster-zone=us-central1-c \
+       --cluster-num-nodes=1 \
+       --display-name=nativeimage-test-instance
+   ```
 
-       You can also manually manage your BigTable resources through the [BigTable Cloud Console view](http://console.cloud.google.com/bigtable).
+   You can also manually manage your BigTable resources through the [BigTable Cloud Console view](http://console.cloud.google.com/bigtable).
 
 ## Run with Native Image Compilation
 
 1. Compile the application with the Native Image compiler.
 
     ```
-    mvn package -P native
+    mvn package -P native -DskipTests
     ```
 
 2. **(Optional)** If you're using the emulator, export the `BIGTABLE_EMULATOR_HOST` as an environment variable in your terminal.
@@ -75,6 +108,6 @@ The application runs through some simple BigTable Client Library operations to d
 
 In order to run the sample's integration test, call the following command:
 
-```
+   ```
     mvn test -P native 
-```
+   ```

--- a/samples/native-image-sample/README.md
+++ b/samples/native-image-sample/README.md
@@ -1,0 +1,80 @@
+# BigTable Sample Application with Native Image
+
+This application uses the [Google Cloud BigTable Client Libraries](https://cloud.google.com/bigtable/docs/reference/libraries) and is compatible with Native Image compilation.
+
+The application runs through some simple BigTable Client Library operations to demonstrate compatibility.
+
+## Setup Instructions
+
+1. Follow the [GCP Project and Native Image Setup Instructions](../../README.md).
+
+2.  BigTable Environment setup -
+    The following sections describe how you can run the sample application against the BigTable emulator or a real BigTable instance.
+
+    1. *(Using emulator)* If you wish to run the application against the [BigTable emulator](https://cloud.google.com/bigtable/docs/emulator), ensure that you have the [Google Cloud SDK](https://cloud.google.com/sdk) installed.
+
+       In a new terminal window, start the emulator via `gcloud`:
+
+       ```
+       gcloud beta emulators bigtable start --host-port=localhost:9010
+       ```
+
+       Leave the emulator running in this terminal for now.
+       In the next section, we will run the sample application against the BigTable emulator instance.
+
+    2. *(Using real BigTable instance)* If instead you wish to run the application against a real BigTable instance, ensure you already have a BigTable instance created.
+
+       For example, the following command creates a new BigTable instance named `nativeimage-test-instance`.
+
+       ```
+       gcloud bigtable instances create nativeimage-test-instance \
+           --cluster=nativeimage-test-cluster \
+           --cluster-zone=us-central1-c \
+           --cluster-num-nodes=1 \
+           --display-name=nativeimage-test-instance
+       ```
+
+       You can also manually manage your BigTable resources through the [BigTable Cloud Console view](http://console.cloud.google.com/bigtable).
+
+## Run with Native Image Compilation
+
+1. Compile the application with the Native Image compiler.
+
+    ```
+    mvn package -P native
+    ```
+
+2. **(Optional)** If you're using the emulator, export the `BIGTABLE_EMULATOR_HOST` as an environment variable in your terminal.
+
+    ```
+    export BIGTABLE_EMULATOR_HOST=localhost:9010
+    ``` 
+
+   The BigTable Client Libraries will detect this environment variable and automatically connect to the emulator instance if this variable is set.
+
+3. Run the application.
+   Pass in the BigTable instance you wish to use via the `-Dbigtable.instance` property.
+
+    ```
+    ./target/bigtable-sample -Dbigtable.instance={BIGTABLE_INSTANCE_NAME}
+    ```
+
+4. The application will run through some basic BigTable operations and log some output statements.
+
+    ```
+    Created table: nativeimage-test-table2b5b0031-f4ea-4c39-bc0c-bf6c3c62c90c
+    Successfully wrote row: phone#1608775178843000
+    Reading phone data in table: 
+    Key: phone#1608775178843000
+        connected_cell:  @1608775178843000
+        connected_wifi:  @1608775178843000
+        os_build: PQ2A.190405.003 @1608775178843000
+    Deleted table: nativeimage-test-table2b5b0031-f4ea-4c39-bc0c-bf6c3c62c90c
+    ```
+## Run integration test for the sample
+
+In order to run the sample's integration test, call the following command:
+
+```
+    mvn test -P native 
+```

--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -1,0 +1,139 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.bigtable</groupId>
+  <artifactId>native-image-sample</artifactId>
+  <name>Native Image Sample</name>
+  <url>https://github.com/googleapis/java-bigtable</url>
+
+  <!--
+    The parent pom defines common style checks and testing strategies for our samples.
+    Removing or replacing it should not affect the execution of the samples in anyway.
+  -->
+  <parent>
+    <groupId>com.google.cloud.samples</groupId>
+    <artifactId>shared-configuration</artifactId>
+    <version>1.2.0</version>
+  </parent>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+
+  <!-- [START bigtable_install_with_bom] -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>24.2.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
+    </dependency>
+    <!-- [END bigtable_install_with_bom] -->
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.example.bigquery.NativeImageBigtableSample
+              </mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <!-- Native Profile-->
+  <profiles>
+    <profile>
+      <id>native</id>
+
+      <dependencies>
+        <dependency>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>native-image-support</artifactId>
+          <version>0.10.0</version>
+        </dependency>
+        <dependency>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+          <version>5.8.2</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.graalvm.buildtools</groupId>
+          <artifactId>junit-platform-native</artifactId>
+          <version>0.9.9</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <version>0.9.9</version>
+            <extensions>true</extensions>
+            <configuration>
+              <mainClass>com.example.bigtable.NativeImageBigtableSample
+              </mainClass>
+              <buildArgs>
+                <buildArg>--no-fallback</buildArg>
+                <buildArg>--no-server</buildArg>
+              </buildArgs>
+            </configuration>
+            <executions>
+              <execution>
+                <id>build-native</id>
+                <goals>
+                  <goal>build</goal>
+                  <goal>test</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+              <execution>
+                <id>test-native</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <phase>test</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/samples/native-image-sample/src/main/java/com/example/bigtable/NativeImageBigtableSample.java
+++ b/samples/native-image-sample/src/main/java/com/example/bigtable/NativeImageBigtableSample.java
@@ -38,9 +38,7 @@ import java.io.IOException;
 import java.util.Map.Entry;
 import java.util.UUID;
 
-/**
- * Sample Cloud BigTable application.
- */
+/** Sample Cloud BigTable application. */
 public class NativeImageBigtableSample {
 
   private static final String INSTANCE_NAME =
@@ -49,9 +47,7 @@ public class NativeImageBigtableSample {
 
   private static final String COLUMN_FAMILY_NAME = "stats_summary";
 
-  /**
-   * Entrypoint to the BigTable sample application.
-   */
+  /** Entrypoint to the BigTable sample application. */
   public static void main(String[] args) throws IOException {
     String projectId = ServiceOptions.getDefaultProjectId();
 
@@ -70,8 +66,8 @@ public class NativeImageBigtableSample {
 
     BigtableTableAdminClient adminClient = BigtableTableAdminClient.create(adminClientSettings);
     BigtableDataClient standardClient = BigtableDataClient.create(clientSettings);
-    BigtableInstanceAdminClient instanceAdminClient = BigtableInstanceAdminClient.create(
-        instanceAdminSettings);
+    BigtableInstanceAdminClient instanceAdminClient =
+        BigtableInstanceAdminClient.create(instanceAdminSettings);
 
     if (!instanceAdminClient.exists(INSTANCE_NAME)) {
       instanceAdminClient.createInstance(
@@ -85,8 +81,8 @@ public class NativeImageBigtableSample {
     createTable(adminClient, tableName);
 
     // Add data into table
-    ImmutableMap<String, Long> dataWithLong = ImmutableMap.of("connected_cell", 1L,
-        "connected_wifi", 1L);
+    ImmutableMap<String, Long> dataWithLong =
+        ImmutableMap.of("connected_cell", 1L, "connected_wifi", 1L);
     ImmutableMap<String, String> dataWithStrings = ImmutableMap.of("os_build", "PQ2A.190405.003");
 
     long timestamp = System.currentTimeMillis() * 1000;
@@ -115,22 +111,25 @@ public class NativeImageBigtableSample {
     }
   }
 
-  public static void insertData(BigtableDataClient client, String tableId, long timestamp,
-      ImmutableMap<String, Long> dataWithLong, ImmutableMap<String, String> dataWithStrings) {
+  public static void insertData(
+      BigtableDataClient client,
+      String tableId,
+      long timestamp,
+      ImmutableMap<String, Long> dataWithLong,
+      ImmutableMap<String, String> dataWithStrings) {
     String rowKey = String.format("phone#%d", timestamp);
-    RowMutation rowMutation =
-        RowMutation.create(tableId, rowKey);
+    RowMutation rowMutation = RowMutation.create(tableId, rowKey);
     for (Entry<String, Long> longEntry : dataWithLong.entrySet()) {
       rowMutation.setCell(
           COLUMN_FAMILY_NAME,
           ByteString.copyFrom(longEntry.getKey().getBytes()),
-          timestamp, longEntry.getValue());
-
+          timestamp,
+          longEntry.getValue());
     }
 
     for (Entry<String, String> stringEntry : dataWithStrings.entrySet()) {
-      rowMutation.setCell(COLUMN_FAMILY_NAME, stringEntry.getKey(), timestamp,
-          stringEntry.getValue());
+      rowMutation.setCell(
+          COLUMN_FAMILY_NAME, stringEntry.getKey(), timestamp, stringEntry.getValue());
     }
 
     client.mutateRow(rowMutation);

--- a/samples/native-image-sample/src/main/java/com/example/bigtable/NativeImageBigtableSample.java
+++ b/samples/native-image-sample/src/main/java/com/example/bigtable/NativeImageBigtableSample.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020-2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigtable;
+
+import com.google.api.gax.rpc.ServerStream;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
+import com.google.cloud.bigtable.admin.v2.models.CreateInstanceRequest;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.Instance;
+import com.google.cloud.bigtable.admin.v2.models.StorageType;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.data.v2.models.RowCell;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.Map.Entry;
+import java.util.UUID;
+
+/**
+ * Sample Cloud BigTable application.
+ */
+public class NativeImageBigtableSample {
+
+  private static final String INSTANCE_NAME =
+      System.getProperty("bigtable.instance", "nativeimage-test-instance");
+  private static final String TABLE_NAME = "nativeimage-test-";
+
+  private static final String COLUMN_FAMILY_NAME = "stats_summary";
+
+  /**
+   * Entrypoint to the BigTable sample application.
+   */
+  public static void main(String[] args) throws IOException {
+    String projectId = ServiceOptions.getDefaultProjectId();
+
+    BigtableTableAdminSettings adminClientSettings =
+        BigtableTableAdminSettings.newBuilder()
+            .setInstanceId(INSTANCE_NAME)
+            .setProjectId(projectId)
+            .build();
+    BigtableDataSettings clientSettings =
+        BigtableDataSettings.newBuilder()
+            .setInstanceId(INSTANCE_NAME)
+            .setProjectId(projectId)
+            .build();
+    BigtableInstanceAdminSettings instanceAdminSettings =
+        BigtableInstanceAdminSettings.newBuilder().setProjectId(projectId).build();
+
+    BigtableTableAdminClient adminClient = BigtableTableAdminClient.create(adminClientSettings);
+    BigtableDataClient standardClient = BigtableDataClient.create(clientSettings);
+    BigtableInstanceAdminClient instanceAdminClient = BigtableInstanceAdminClient.create(
+        instanceAdminSettings);
+
+    if (!instanceAdminClient.exists(INSTANCE_NAME)) {
+      instanceAdminClient.createInstance(
+          CreateInstanceRequest.of(INSTANCE_NAME)
+              .addCluster("cluster", "us-central1-f", 3, StorageType.SSD)
+              .setType(Instance.Type.PRODUCTION)
+              .addLabel("example", "instance_admin"));
+    }
+    String tableName = TABLE_NAME + UUID.randomUUID().toString().replace("-", "");
+
+    createTable(adminClient, tableName);
+
+    // Add data into table
+    ImmutableMap<String, Long> dataWithLong = ImmutableMap.of("connected_cell", 1L,
+        "connected_wifi", 1L);
+    ImmutableMap<String, String> dataWithStrings = ImmutableMap.of("os_build", "PQ2A.190405.003");
+
+    long timestamp = System.currentTimeMillis() * 1000;
+    insertData(standardClient, tableName, timestamp, dataWithLong, dataWithStrings);
+    readData(standardClient, tableName);
+
+    // Clean up
+    deleteTable(adminClient, tableName);
+  }
+
+  static void readData(BigtableDataClient client, String tableId) {
+    Query query = Query.create(tableId).prefix("");
+    ServerStream<Row> rows = client.readRows(query);
+
+    System.out.println("Reading phone data in table:");
+    for (Row row : rows) {
+      System.out.println("Key: " + row.getKey().toStringUtf8());
+      for (RowCell cell : row.getCells()) {
+        System.out.printf(
+            "\t%s: %s @%s\n",
+            cell.getQualifier().toStringUtf8(),
+            cell.getValue().toStringUtf8(),
+            cell.getTimestamp());
+      }
+      System.out.println();
+    }
+  }
+
+  public static void insertData(BigtableDataClient client, String tableId, long timestamp,
+      ImmutableMap<String, Long> dataWithLong, ImmutableMap<String, String> dataWithStrings) {
+    String rowKey = String.format("phone#%d", timestamp);
+    RowMutation rowMutation =
+        RowMutation.create(tableId, rowKey);
+    for (Entry<String, Long> longEntry : dataWithLong.entrySet()) {
+      rowMutation.setCell(
+          COLUMN_FAMILY_NAME,
+          ByteString.copyFrom(longEntry.getKey().getBytes()),
+          timestamp, longEntry.getValue());
+
+    }
+
+    for (Entry<String, String> stringEntry : dataWithStrings.entrySet()) {
+      rowMutation.setCell(COLUMN_FAMILY_NAME, stringEntry.getKey(), timestamp,
+          stringEntry.getValue());
+    }
+
+    client.mutateRow(rowMutation);
+    System.out.println("Successfully wrote row: " + rowKey);
+  }
+
+  public static void createTable(BigtableTableAdminClient adminClient, String table) {
+    adminClient.createTable(CreateTableRequest.of(table).addFamily(COLUMN_FAMILY_NAME));
+    System.out.println("Created table: " + table);
+  }
+
+  static void deleteTable(BigtableTableAdminClient adminClient, String table) {
+    adminClient.deleteTable(table);
+    System.out.println("Deleted table: " + table);
+  }
+}

--- a/samples/native-image-sample/src/test/java/com/example/bigtable/NativeImageBigtableTest.java
+++ b/samples/native-image-sample/src/test/java/com/example/bigtable/NativeImageBigtableTest.java
@@ -66,8 +66,8 @@ public class NativeImageBigtableTest {
     // Create instance if not present
     BigtableInstanceAdminSettings instanceAdminSettings =
         BigtableInstanceAdminSettings.newBuilder().setProjectId(PROJECT_ID).build();
-    BigtableInstanceAdminClient instanceAdminClient = BigtableInstanceAdminClient.create(
-        instanceAdminSettings);
+    BigtableInstanceAdminClient instanceAdminClient =
+        BigtableInstanceAdminClient.create(instanceAdminSettings);
     if (!instanceAdminClient.exists(INSTANCE_NAME)) {
       instanceAdminClient.createInstance(
           CreateInstanceRequest.of(INSTANCE_NAME)
@@ -76,12 +76,16 @@ public class NativeImageBigtableTest {
               .addLabel("example", "instance_admin"));
     }
 
-    BigtableTableAdminSettings adminClientSettings = BigtableTableAdminSettings.newBuilder()
-        .setInstanceId(INSTANCE_NAME).setProjectId(PROJECT_ID).build();
-    BigtableDataSettings clientSettings = BigtableDataSettings.newBuilder()
-        .setInstanceId(INSTANCE_NAME)
-        .setProjectId(PROJECT_ID)
-        .build();
+    BigtableTableAdminSettings adminClientSettings =
+        BigtableTableAdminSettings.newBuilder()
+            .setInstanceId(INSTANCE_NAME)
+            .setProjectId(PROJECT_ID)
+            .build();
+    BigtableDataSettings clientSettings =
+        BigtableDataSettings.newBuilder()
+            .setInstanceId(INSTANCE_NAME)
+            .setProjectId(PROJECT_ID)
+            .build();
     adminClient = BigtableTableAdminClient.create(adminClientSettings);
     tableName = TABLE_SUFFIX + UUID.randomUUID().toString().replace("-", "");
     NativeImageBigtableSample.createTable(adminClient, tableName);
@@ -98,22 +102,21 @@ public class NativeImageBigtableTest {
   public void testReadData() {
     ImmutableMap<String, Long> dataWithInts = ImmutableMap.of("connection_cell", 1L);
     ImmutableMap<String, String> dataWithStrings = ImmutableMap.of("os_build", "build_value");
-    NativeImageBigtableSample.insertData(dataClient, tableName, TIMESTAMP.getEpochSecond(),
-        dataWithInts, dataWithStrings);
+    NativeImageBigtableSample.insertData(
+        dataClient, tableName, TIMESTAMP.getEpochSecond(), dataWithInts, dataWithStrings);
 
     NativeImageBigtableSample.readData(dataClient, tableName);
 
     String output = bout.toString();
-    assertThat(output).contains(
-        "Successfully wrote row: phone#0\n"
-            + "Reading phone data in table:\n"
-            + "Key: phone#0\n"
-            + "\tconnection_cell: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001 @0\n"
-            + "\tos_build: build_value @0\n\n");
+    assertThat(output)
+        .contains(
+            "Successfully wrote row: phone#0\n"
+                + "Reading phone data in table:\n"
+                + "Key: phone#0\n"
+                + "\tconnection_cell: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001 @0\n"
+                + "\tos_build: build_value @0\n\n");
 
     // Clean up
     NativeImageBigtableSample.deleteTable(adminClient, tableName);
   }
-
-
 }

--- a/samples/native-image-sample/src/test/java/com/example/bigtable/NativeImageBigtableTest.java
+++ b/samples/native-image-sample/src/test/java/com/example/bigtable/NativeImageBigtableTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.bigtable;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
+import com.google.cloud.bigtable.admin.v2.models.CreateInstanceRequest;
+import com.google.cloud.bigtable.admin.v2.models.Instance;
+import com.google.cloud.bigtable.admin.v2.models.StorageType;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NativeImageBigtableTest {
+
+  private static final String INSTANCE_NAME =
+      System.getProperty("bigtable.instance", "nativeimage-it-instance");
+  private static final String TABLE_SUFFIX = "nativeimage-it-";
+
+  private static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
+
+  private static final Instant TIMESTAMP = Instant.EPOCH;
+
+  private String tableName;
+  private BigtableDataClient dataClient;
+  private BigtableTableAdminClient adminClient;
+
+  private static PrintStream originalOut;
+  public ByteArrayOutputStream bout;
+
+  @After
+  public void tearDown() {
+    System.setOut(originalOut);
+    bout.reset();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    // Create instance if not present
+    BigtableInstanceAdminSettings instanceAdminSettings =
+        BigtableInstanceAdminSettings.newBuilder().setProjectId(PROJECT_ID).build();
+    BigtableInstanceAdminClient instanceAdminClient = BigtableInstanceAdminClient.create(
+        instanceAdminSettings);
+    if (!instanceAdminClient.exists(INSTANCE_NAME)) {
+      instanceAdminClient.createInstance(
+          CreateInstanceRequest.of(INSTANCE_NAME)
+              .addCluster("cluster", "us-central1-f", 3, StorageType.SSD)
+              .setType(Instance.Type.PRODUCTION)
+              .addLabel("example", "instance_admin"));
+    }
+
+    BigtableTableAdminSettings adminClientSettings = BigtableTableAdminSettings.newBuilder()
+        .setInstanceId(INSTANCE_NAME).setProjectId(PROJECT_ID).build();
+    BigtableDataSettings clientSettings = BigtableDataSettings.newBuilder()
+        .setInstanceId(INSTANCE_NAME)
+        .setProjectId(PROJECT_ID)
+        .build();
+    adminClient = BigtableTableAdminClient.create(adminClientSettings);
+    tableName = TABLE_SUFFIX + UUID.randomUUID().toString().replace("-", "");
+    NativeImageBigtableSample.createTable(adminClient, tableName);
+
+    dataClient = BigtableDataClient.create(clientSettings);
+
+    // To test output stream
+    originalOut = System.out;
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+  }
+
+  @Test
+  public void testReadData() {
+    ImmutableMap<String, Long> dataWithInts = ImmutableMap.of("connection_cell", 1L);
+    ImmutableMap<String, String> dataWithStrings = ImmutableMap.of("os_build", "build_value");
+    NativeImageBigtableSample.insertData(dataClient, tableName, TIMESTAMP.getEpochSecond(),
+        dataWithInts, dataWithStrings);
+
+    NativeImageBigtableSample.readData(dataClient, tableName);
+
+    String output = bout.toString();
+    assertThat(output).contains(
+        "Successfully wrote row: phone#0\n"
+            + "Reading phone data in table:\n"
+            + "Key: phone#0\n"
+            + "\tconnection_cell: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001 @0\n"
+            + "\tos_build: build_value @0\n\n");
+
+    // Clean up
+    NativeImageBigtableSample.deleteTable(adminClient, tableName);
+  }
+
+
+}

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -31,6 +31,7 @@
     <module>install-without-bom</module>
     <module>snapshot</module>
     <module>snippets</module>
+    <module>native-image-sample</module>
   </modules>
 
   <build>


### PR DESCRIPTION
This PR copies over the sample for native image support in Bigtable from the [old native image support repo](https://github.com/GoogleCloudPlatform/native-image-support-java/tree/master/native-image-samples/native-image-samples-client-library/bigtable-sample). 

Some things to note:
1. This PR slightly modifies the sample code to be more test-friendly.
2. It also adds an integration test that can be run as a native image. 

Calling `mvn package -Pnative` in the `native-image-sample` directory  builds the native image for the application and calling `mvn test -Pnative` runs the test as a native image.

For more information: https://graalvm.github.io/native-build-tools/latest/maven-plugin.html#configuration 

