### PR TITLE
feat: Add ability to start bigtable emulator on fixed port

### DIFF
--- a/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/Emulator.java
+++ b/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/Emulator.java
@@ -37,8 +37,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static java.lang.System.getenv;
+
 /**
  * Wraps the Bigtable emulator in a java api.
+ *
+ * Uses port-number from BIGTABLE_EMULATOR_HOST environment variable to create bundled emulator instances
  *
  * <p>This class will use the golang binaries embedded in this jar to launch the emulator as an
  * external process and redirect its output to a {@link Logger}.
@@ -51,6 +55,12 @@ public class Emulator {
   private Process process;
   private boolean isStopped = true;
   private Thread shutdownHook;
+
+  //Set environment variable as <HOST>:<RANDOMPORT>  Eg: 127.0.0.1:8465
+  private static final int PORT = Optional.ofNullable(System.getenv("BIGTABLE_EMULATOR_HOST"))
+                                        .filter(hostPort->hostPort.split(":").length>1)
+                                        .map(hostPort->hostPort.split(":")[1])
+                                        .map(Integer::parseInt).orElse(0);
 
   private int port;
   private ManagedChannel dataChannel;
@@ -262,7 +272,7 @@ public class Emulator {
 
   /** Gets a random open port number. */
   private static int getAvailablePort() {
-    try (ServerSocket serverSocket = new ServerSocket(0)) {
+    try (ServerSocket serverSocket = new ServerSocket(PORT)) {
       return serverSocket.getLocalPort();
     } catch (IOException e) {
       throw new RuntimeException("Failed to find open port");

--- a/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/Emulator.java
+++ b/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/Emulator.java
@@ -18,13 +18,8 @@ package com.google.cloud.bigtable.emulator.v2;
 import com.google.api.core.BetaApi;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+
+import java.io.*;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -36,8 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static java.lang.System.getenv;
 
 /**
  * Wraps the Bigtable emulator in a java api.

--- a/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/Emulator.java
+++ b/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/Emulator.java
@@ -18,8 +18,13 @@ package com.google.cloud.bigtable.emulator.v2;
 import com.google.api.core.BetaApi;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;


### PR DESCRIPTION
Change Summary: 

fixes: #1192
<br>
Read port number from BIGTABLE_EMULATOR_HOST environment variable 
- If available, use it for creating emulator instance
- else use 0 (random port numbers)