### PR TITLE
chore: update rowset sharding to use split points as start keys

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/RowSetUtil.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/RowSetUtil.java
@@ -25,13 +25,13 @@ import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.cloud.bigtable.data.v2.stub.readrows.ReadRowsResumptionStrategy;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
-import java.util.Arrays;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.SortedSet;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -52,171 +52,172 @@ public final class RowSetUtil {
   /**
    * Splits the provided {@link RowSet} along the provided splitPoint into 2 segments. The right
    * segment will contain all keys that are strictly greater than the splitPoint and all {@link
-   * RowRange}s truncated to start right after the splitPoint.
+   * RowRange}s truncated to start right after the splitPoint. The primary usecase is to resume a
+   * broken ReadRows stream.
    */
   @Nonnull
   public static Split split(@Nonnull RowSet rowSet, @Nonnull ByteString splitPoint) {
-    ImmutableSortedSet<ByteString> splitPoints =
-        ImmutableSortedSet.orderedBy(ByteStringComparator.INSTANCE).add(splitPoint).build();
+    // Edgecase: splitPoint is the leftmost key ("")
+    if (splitPoint.isEmpty()) {
+      return Split.of(null, rowSet);
+    }
 
-    List<RowSet> splits = split(rowSet, splitPoints, true);
+    // An empty RowSet represents a full table scan. Make that explicit so that there is RowRange to
+    // split.
+    if (rowSet.getRowKeysList().isEmpty() && rowSet.getRowRangesList().isEmpty()) {
+      rowSet = RowSet.newBuilder().addRowRanges(RowRange.getDefaultInstance()).build();
+    }
 
-    return Split.of(splits.get(0), splits.get(1));
+    RowSet.Builder leftBuilder = RowSet.newBuilder();
+    boolean leftIsEmpty = true;
+    RowSet.Builder rightBuilder = RowSet.newBuilder();
+    boolean rightIsEmpty = true;
+
+    for (ByteString key : rowSet.getRowKeysList()) {
+      if (ByteStringComparator.INSTANCE.compare(key, splitPoint) <= 0) {
+        leftBuilder.addRowKeys(key);
+        leftIsEmpty = false;
+      } else {
+        rightBuilder.addRowKeys(key);
+        rightIsEmpty = false;
+      }
+    }
+
+    for (RowRange range : rowSet.getRowRangesList()) {
+      StartPoint startPoint = StartPoint.extract(range);
+      int startCmp =
+          ComparisonChain.start()
+              .compare(startPoint.value, splitPoint, ByteStringComparator.INSTANCE)
+              // when value lies on the split point, only closed start points are on the left
+              .compareTrueFirst(startPoint.isClosed, true)
+              .result();
+
+      // Range is fully on the right side
+      if (startCmp > 0) {
+        rightBuilder.addRowRanges(range);
+        rightIsEmpty = false;
+        continue;
+      }
+
+      EndPoint endPoint = EndPoint.extract(range);
+      int endCmp =
+          ComparisonChain.start()
+              // empty (true) end key means rightmost regardless of the split point
+              .compareFalseFirst(endPoint.value.isEmpty(), false)
+              .compare(endPoint.value, splitPoint, ByteStringComparator.INSTANCE)
+              // don't care if the endpoint is open/closed: both will be on the left if the value is
+              // <=
+              .result();
+
+      if (endCmp <= 0) {
+        // Range is fully on the left
+        leftBuilder.addRowRanges(range);
+        leftIsEmpty = false;
+      } else {
+        // Range is split
+        leftBuilder.addRowRanges(range.toBuilder().setEndKeyClosed(splitPoint));
+        leftIsEmpty = false;
+        rightBuilder.addRowRanges(range.toBuilder().setStartKeyOpen(splitPoint));
+        rightIsEmpty = false;
+      }
+    }
+
+    return Split.of(
+        leftIsEmpty ? null : leftBuilder.build(), rightIsEmpty ? null : rightBuilder.build());
   }
 
   /**
    * Splits the provided {@link RowSet} into segments partitioned by the provided {@code
-   * splitPoints}. Each split point represents the last row of the corresponding segment. The row
-   * keys contained in the provided {@link RowSet} will be distributed across the segments. Each
-   * range in the {@link RowSet} will be split up across each segment.
-   *
-   * @see #split(RowSet, SortedSet, boolean) for more details.
+   * splitPoints}. The split points will be treated as start keys of the segments. The primary
+   * usecase is for sharding a query for MapReduce style processing.
    */
   @Nonnull
   public static List<RowSet> shard(
       @Nonnull RowSet rowSet, @Nonnull SortedSet<ByteString> splitPoints) {
-    return split(rowSet, splitPoints, false);
-  }
 
-  /**
-   * Split a {@link RowSet} into segments.
-   *
-   * <p>Each segment is defined by a split point. The split point identifies the segment's inclusive
-   * end. This means that the first segment will start at the beginning of the table and extend to
-   * include the first split point. The last segment will start just after the last split point and
-   * extend until the end of the table. The maximum number of segments that can be returned is the
-   * number of split points + 1.
-   *
-   * <p>Each segment is represented by a RowSet in the returned List. Each of the returned RowSets
-   * will contain all of the {@link RowRange}s and keys that fall between the previous segment and
-   * this segment's split point. If there are no {@link RowRange}s or keys that belong to a segment,
-   * then that segment will either be omitted or if {@code preserveNullSegments} is true, then it
-   * will be represented by a null value in the returned list.
-   *
-   * <p>The segments in the returned list are guaranteed to be sorted. If {@code
-   * preserveNullSegments} is true, then it will have exactly {@code splitPoints.size() + 1} items.
-   * The extra segment will contain keys and {@link RowRange}s between the last splitPoint and the
-   * end of the table.
-   *
-   * <p>Please note that an empty {@link RowSet} is treated like a full table scan and each segment
-   * will contain a {@link RowRange} that covers the full extent of the segment.
-   */
-  @Nonnull
-  static List<RowSet> split(
-      @Nonnull RowSet rowSet,
-      @Nonnull SortedSet<ByteString> splitPoints,
-      boolean preserveNullSegments) {
     // An empty RowSet represents a full table scan. Make that explicit so that there is RowRange to
     // split.
-    if (RowSet.getDefaultInstance().equals(rowSet)) {
+    if (rowSet.getRowKeysList().isEmpty() && rowSet.getRowRangesList().isEmpty()) {
       rowSet = RowSet.newBuilder().addRowRanges(RowRange.getDefaultInstance()).build();
     }
 
-    // Create sorted copies of the ranges and keys in the RowSet
-    ByteString[] rowKeys =
-        rowSet.getRowKeysList().toArray(new ByteString[rowSet.getRowKeysCount()]);
-    RowRange[] rowRanges =
-        rowSet.getRowRangesList().toArray(new RowRange[rowSet.getRowRangesCount()]);
+    ArrayDeque<ByteString> keys =
+        rowSet.getRowKeysList().stream()
+            .sorted(ByteStringComparator.INSTANCE)
+            .collect(Collectors.toCollection(ArrayDeque::new));
+    ArrayDeque<RowRange> ranges =
+        rowSet.getRowRangesList().stream()
+            .sorted(Comparator.comparing(StartPoint::extract))
+            .collect(Collectors.toCollection(ArrayDeque::new));
 
-    Arrays.sort(rowKeys, ByteStringComparator.INSTANCE);
-    Arrays.sort(rowRanges, RANGE_START_COMPARATOR);
+    List<RowSet> segments = new ArrayList<>();
 
-    List<RowSet> results = Lists.newArrayList();
-
-    // Track consumption of input ranges & keys.
-    int rowKeysStart = 0;
-    int rowRangesStart = 0;
-
-    // Keys and ranges that lie before the current split point,
-    RowSet.Builder segment = RowSet.newBuilder();
-    boolean isSegmentEmpty = true;
+    boolean currentSegmentIsEmpty;
+    RowSet.Builder segment;
 
     for (ByteString splitPoint : splitPoints) {
-      Preconditions.checkState(!splitPoint.isEmpty(), "Split point can't be empty");
+      Preconditions.checkArgument(!splitPoint.isEmpty(), "Can't handle empty splitPoints");
 
-      // Consume all of the row keys that lie on and to the left of the split point. Consumption is
-      // designated by advancing rowKeysStart.
-      for (int i = rowKeysStart; i < rowKeys.length; i++) {
-        ByteString rowKey = rowKeys[i];
-        if (ByteStringComparator.INSTANCE.compare(rowKey, splitPoint) <= 0) {
-          segment.addRowKeys(rowKey);
-          isSegmentEmpty = false;
-          rowKeysStart++;
+      segment = RowSet.newBuilder();
+      currentSegmentIsEmpty = true;
+
+      // Handle keys - add all keys strictly < split point
+      while (!keys.isEmpty()) {
+        if (ByteStringComparator.INSTANCE.compare(keys.peek(), splitPoint) < 0) {
+          segment.addRowKeys(keys.poll());
+          currentSegmentIsEmpty = false;
         } else {
-          // This key and all following keys belong to a later segment.
+          // This key and the following will be in a later segment
           break;
         }
       }
 
-      // Consume all of the ranges that lie before the split point (splitting the range if
-      // necessary). Consumption is designated by advancing rowRangesStart.
-      for (int i = rowRangesStart; i < rowRanges.length; i++) {
-        RowRange rowRange = rowRanges[i];
-
+      // Handle ranges
+      while (!ranges.isEmpty()) {
         // Break early when encountering the first start point that is past the split point.
-        // (The split point is the inclusive end of of the segment)
-        int startCmp = StartPoint.extract(rowRange).compareTo(new StartPoint(splitPoint, true));
-        if (startCmp > 0) {
+        // Ranges start on or after the split point lay to the right
+        StartPoint startPoint = StartPoint.extract(ranges.peek());
+        int startCmp =
+            ComparisonChain.start()
+                .compareTrueFirst(startPoint.value.isEmpty(), false)
+                .compare(startPoint.value, splitPoint, ByteStringComparator.INSTANCE)
+                // when start point is on the split point, it will always be on the right
+                .result();
+        if (startCmp >= 0) {
           break;
         }
+        RowRange range = ranges.poll();
 
-        // Some part of this range will be in the segment.
-        isSegmentEmpty = false;
+        @SuppressWarnings("ConstantConditions")
+        EndPoint endPoint = EndPoint.extract(range);
 
-        // Figure out the endpoint and remainder.
-        int endCmp = EndPoint.extract(rowRange).compareTo(new EndPoint(splitPoint, true));
-        if (endCmp <= 0) {
-          // The range is fully contained in the segment.
-          segment.addRowRanges(rowRange);
-
-          // Consume the range, but take care to shift partially consumed ranges to fill the gap
-          // created by consuming the current range. For example if the list contained the following
-          // ranges: [a-z], [b-d], [f-z] and the split point was 'e'. Then after processing the
-          // split point, the list would contain: (d-z], GAP, [f-z]. So we fill the gap by shifting
-          // (d-z] over by one and advancing rowRangesStart.
-          // Partially consumed ranges will only exist if the original RowSet had overlapping
-          // ranges, this should be a rare occurrence.
-          System.arraycopy(
-              rowRanges, rowRangesStart, rowRanges, rowRangesStart + 1, i - rowRangesStart);
-          rowRangesStart++;
+        int endCmp =
+            ComparisonChain.start()
+                .compareFalseFirst(endPoint.value.isEmpty(), false)
+                .compare(endPoint.value, splitPoint, ByteStringComparator.INSTANCE)
+                .compareFalseFirst(endPoint.isClosed, true)
+                .result();
+        if (endCmp < 0) {
+          segment.addRowRanges(range);
+          currentSegmentIsEmpty = false;
         } else {
-          // The range is split:
-          // Add the left part to the segment
-          RowRange leftSubRange = rowRange.toBuilder().setEndKeyClosed(splitPoint).build();
-          segment.addRowRanges(leftSubRange);
-          // Save the remainder for the next segment. This is done by replacing the current rowRange
-          // with the remainder and not advancing rowRangesStart.
-          RowRange rightSubRange = rowRange.toBuilder().setStartKeyOpen(splitPoint).build();
-          rowRanges[i] = rightSubRange;
+          segment.addRowRanges(range.toBuilder().setEndKeyOpen(splitPoint));
+          currentSegmentIsEmpty = false;
+          ranges.addFirst(range.toBuilder().setStartKeyClosed(splitPoint).build());
         }
       }
 
-      // Build the current segment
-      if (!isSegmentEmpty) {
-        results.add(segment.build());
-        isSegmentEmpty = true;
-        segment = RowSet.newBuilder();
-      } else if (preserveNullSegments) {
-        results.add(null);
+      if (!currentSegmentIsEmpty) {
+        segments.add(segment.build());
       }
     }
 
-    // Create the last segment (from the last splitKey to the end of the table)
-    for (int i = rowKeysStart; i < rowKeys.length; i++) {
-      isSegmentEmpty = false;
-      segment.addRowKeys(rowKeys[i]);
-    }
-    for (int i = rowRangesStart; i < rowRanges.length; i++) {
-      isSegmentEmpty = false;
-      segment.addRowRanges(rowRanges[i]);
-    }
-    if (!isSegmentEmpty) {
-      results.add(segment.build());
-    } else if (preserveNullSegments) {
-      results.add(null);
+    if (!keys.isEmpty() || !ranges.isEmpty()) {
+      segment = RowSet.newBuilder().addAllRowKeys(keys).addAllRowRanges(ranges);
+      segments.add(segment.build());
     }
 
-    return results;
+    return segments;
   }
 
   /** Get the bounding range of a {@link RowSet}. */
@@ -296,14 +297,6 @@ public final class RowSetUtil {
       return new AutoValue_RowSetUtil_Split(left, right);
     }
   }
-
-  private static final Comparator<RowRange> RANGE_START_COMPARATOR =
-      new Comparator<RowRange>() {
-        @Override
-        public int compare(@Nonnull RowRange o1, @Nonnull RowRange o2) {
-          return StartPoint.extract(o1).compareTo(StartPoint.extract(o2));
-        }
-      };
 
   /** Helper class to ease comparison of RowRange start points. */
   private static final class StartPoint implements Comparable<StartPoint> {

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/QueryTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/QueryTest.java
@@ -193,7 +193,7 @@ public class QueryTest {
                         .addRowRanges(
                             RowRange.newBuilder()
                                 .setStartKeyClosed(ByteString.copyFromUtf8("a"))
-                                .setEndKeyClosed(ByteString.copyFromUtf8("j"))))
+                                .setEndKeyOpen(ByteString.copyFromUtf8("j"))))
                 .build());
     assertThat(subQueries.get(1).toProto(requestContext))
         .isEqualTo(
@@ -204,7 +204,7 @@ public class QueryTest {
                     RowSet.newBuilder()
                         .addRowRanges(
                             RowRange.newBuilder()
-                                .setStartKeyOpen(ByteString.copyFromUtf8("j"))
+                                .setStartKeyClosed(ByteString.copyFromUtf8("j"))
                                 .setEndKeyOpen(ByteString.copyFromUtf8("z"))))
                 .build());
   }
@@ -231,7 +231,7 @@ public class QueryTest {
                         .addRowRanges(
                             RowRange.newBuilder()
                                 .setStartKeyClosed(ByteString.copyFromUtf8("a"))
-                                .setEndKeyClosed(ByteString.copyFromUtf8("j"))))
+                                .setEndKeyOpen(ByteString.copyFromUtf8("j"))))
                 .build());
     assertThat(subQueries.get(1).toProto(requestContext))
         .isEqualTo(
@@ -242,7 +242,7 @@ public class QueryTest {
                     RowSet.newBuilder()
                         .addRowRanges(
                             RowRange.newBuilder()
-                                .setStartKeyOpen(ByteString.copyFromUtf8("j"))
+                                .setStartKeyClosed(ByteString.copyFromUtf8("j"))
                                 .setEndKeyOpen(ByteString.copyFromUtf8("z"))))
                 .build());
   }


### PR DESCRIPTION
RowSetUtil has 2 methods to split a RowSet: split and shard.
Split is used for ReadRows resumption, so the split needs to be included in the segment.
Shard is used for map/reduce style frameworks to parallelize the work. In this case the split points should be treated as start keys (since they usually come from SampleRowKeys and align with the start of a tablet. This PR fixes the shard behavior to use splits as start keys. It introduces some code duplication but overall makes it easier to reason about the 2 behaviors