### PR TITLE
fix: rename response observer and callbacks

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracerStreamingCallable.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracerStreamingCallable.java
@@ -58,8 +58,8 @@ public class BigtableTracerStreamingCallable<RequestT, ResponseT>
     final GrpcResponseMetadata responseMetadata = new GrpcResponseMetadata();
     // tracer should always be an instance of bigtable tracer
     if (context.getTracer() instanceof BigtableTracer) {
-      HeaderTracerResponseObserver<ResponseT> innerObserver =
-          new HeaderTracerResponseObserver<>(
+      BigtableTracerResponseObserver<ResponseT> innerObserver =
+          new BigtableTracerResponseObserver<>(
               responseObserver, (BigtableTracer) context.getTracer(), responseMetadata);
       innerCallable.call(request, innerObserver, responseMetadata.addHandlers(context));
     } else {
@@ -67,13 +67,13 @@ public class BigtableTracerStreamingCallable<RequestT, ResponseT>
     }
   }
 
-  private class HeaderTracerResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
+  private class BigtableTracerResponseObserver<ResponseT> implements ResponseObserver<ResponseT> {
 
     private final BigtableTracer tracer;
     private final ResponseObserver<ResponseT> outerObserver;
     private final GrpcResponseMetadata responseMetadata;
 
-    HeaderTracerResponseObserver(
+    BigtableTracerResponseObserver(
         ResponseObserver<ResponseT> observer,
         BigtableTracer tracer,
         GrpcResponseMetadata metadata) {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracerUnaryCallable.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracerUnaryCallable.java
@@ -53,8 +53,8 @@ public class BigtableTracerUnaryCallable<RequestT, ResponseT>
     if (context.getTracer() instanceof BigtableTracer) {
       final GrpcResponseMetadata responseMetadata = new GrpcResponseMetadata();
       final ApiCallContext contextWithResponseMetadata = responseMetadata.addHandlers(context);
-      HeaderTracerUnaryCallback callback =
-          new HeaderTracerUnaryCallback((BigtableTracer) context.getTracer(), responseMetadata);
+      BigtableTracerUnaryCallback callback =
+          new BigtableTracerUnaryCallback((BigtableTracer) context.getTracer(), responseMetadata);
       ApiFuture<ResponseT> future = innerCallable.futureCall(request, contextWithResponseMetadata);
       ApiFutures.addCallback(future, callback, MoreExecutors.directExecutor());
       return future;
@@ -63,12 +63,12 @@ public class BigtableTracerUnaryCallable<RequestT, ResponseT>
     }
   }
 
-  class HeaderTracerUnaryCallback<ResponseT> implements ApiFutureCallback<ResponseT> {
+  class BigtableTracerUnaryCallback<ResponseT> implements ApiFutureCallback<ResponseT> {
 
     private final BigtableTracer tracer;
     private final GrpcResponseMetadata responseMetadata;
 
-    HeaderTracerUnaryCallback(BigtableTracer tracer, GrpcResponseMetadata responseMetadata) {
+    BigtableTracerUnaryCallback(BigtableTracer tracer, GrpcResponseMetadata responseMetadata) {
       this.tracer = tracer;
       this.responseMetadata = responseMetadata;
     }


### PR DESCRIPTION
Rename HeaderTracer* to BigtableTracer*