### PR TITLE
feat: Change CDC related APIs to return ByteStringRange instead of Ro…

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataClient.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataClient.java
@@ -29,7 +29,6 @@ import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.bigtable.v2.RowRange;
 import com.google.cloud.bigtable.data.v2.models.BulkMutation;
 import com.google.cloud.bigtable.data.v2.models.ChangeStreamRecord;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
@@ -37,6 +36,7 @@ import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.cloud.bigtable.data.v2.models.ReadChangeStreamQuery;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.Row;
@@ -1503,11 +1503,11 @@ public class BigtableDataClient implements AutoCloseable {
    *   String tableId = "[TABLE]";
    *
    *   try {
-   *     ServerStream<RowRange> stream = bigtableDataClient.generateInitialChangeStreamPartitions(tableId);
+   *     ServerStream<ByteStringRange> stream = bigtableDataClient.generateInitialChangeStreamPartitions(tableId);
    *     int count = 0;
    *
    *     // Iterator style
-   *     for (RowRange partition : stream) {
+   *     for (ByteStringRange partition : stream) {
    *       if (++count > 10) {
    *         stream.cancel();
    *         break;
@@ -1525,7 +1525,7 @@ public class BigtableDataClient implements AutoCloseable {
    * @see ServerStreamingCallable For call styles.
    */
   @InternalApi("Used in Changestream beam pipeline.")
-  public ServerStream<RowRange> generateInitialChangeStreamPartitions(String tableId) {
+  public ServerStream<ByteStringRange> generateInitialChangeStreamPartitions(String tableId) {
     return generateInitialChangeStreamPartitionsCallable().call(tableId);
   }
 
@@ -1545,7 +1545,7 @@ public class BigtableDataClient implements AutoCloseable {
    *     public void onStart(StreamController controller) {
    *       this.controller = controller;
    *     }
-   *     public void onResponse(RowRange partition) {
+   *     public void onResponse(ByteStringRange partition) {
    *       if (++count > 10) {
    *         controller.cancel();
    *         return;
@@ -1568,7 +1568,7 @@ public class BigtableDataClient implements AutoCloseable {
    */
   @InternalApi("Used in Changestream beam pipeline.")
   public void generateInitialChangeStreamPartitionsAsync(
-      String tableId, ResponseObserver<RowRange> observer) {
+      String tableId, ResponseObserver<ByteStringRange> observer) {
     generateInitialChangeStreamPartitionsCallable().call(tableId, observer);
   }
 
@@ -1584,7 +1584,7 @@ public class BigtableDataClient implements AutoCloseable {
    *
    *   // Iterator style
    *   try {
-   *     for(RowRange partition : bigtableDataClient.generateInitialChangeStreamPartitionsCallable().call(tableId)) {
+   *     for(ByteStringRange partition : bigtableDataClient.generateInitialChangeStreamPartitionsCallable().call(tableId)) {
    *       // Do something with partition
    *     }
    *   } catch (NotFoundException e) {
@@ -1595,7 +1595,7 @@ public class BigtableDataClient implements AutoCloseable {
    *
    *   // Sync style
    *   try {
-   *     List<RowRange> partitions = bigtableDataClient.generateInitialChangeStreamPartitionsCallable().all().call(tableId);
+   *     List<ByteStringRange> partitions = bigtableDataClient.generateInitialChangeStreamPartitionsCallable().all().call(tableId);
    *   } catch (NotFoundException e) {
    *     System.out.println("Tried to read a non-existent table");
    *   } catch (RuntimeException e) {
@@ -1603,10 +1603,10 @@ public class BigtableDataClient implements AutoCloseable {
    *   }
    *
    *   // Point look up
-   *   ApiFuture<RowRange> partitionFuture =
+   *   ApiFuture<ByteStringRange> partitionFuture =
    *     bigtableDataClient.generateInitialChangeStreamPartitionsCallable().first().futureCall(tableId);
    *
-   *   ApiFutures.addCallback(partitionFuture, new ApiFutureCallback<RowRange>() {
+   *   ApiFutures.addCallback(partitionFuture, new ApiFutureCallback<ByteStringRange>() {
    *     public void onFailure(Throwable t) {
    *       if (t instanceof NotFoundException) {
    *         System.out.println("Tried to read a non-existent table");
@@ -1626,7 +1626,8 @@ public class BigtableDataClient implements AutoCloseable {
    * @see ServerStreamingCallable For call styles.
    */
   @InternalApi("Used in Changestream beam pipeline.")
-  public ServerStreamingCallable<String, RowRange> generateInitialChangeStreamPartitionsCallable() {
+  public ServerStreamingCallable<String, ByteStringRange>
+      generateInitialChangeStreamPartitionsCallable() {
     return stub.generateInitialChangeStreamPartitionsCallable();
   }
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamContinuationToken.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamContinuationToken.java
@@ -54,9 +54,10 @@ public final class ChangeStreamContinuationToken implements Serializable {
             .build();
   }
 
-  // TODO: Change this to return ByteStringRange.
-  public RowRange getRowRange() {
-    return this.tokenProto.getPartition().getRowRange();
+  public ByteStringRange getRowRange() {
+    return ByteStringRange.create(
+        this.tokenProto.getPartition().getRowRange().getStartKeyClosed(),
+        this.tokenProto.getPartition().getRowRange().getEndKeyOpen());
   }
 
   public String getToken() {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamContinuationToken.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamContinuationToken.java
@@ -54,7 +54,10 @@ public final class ChangeStreamContinuationToken implements Serializable {
             .build();
   }
 
-  public ByteStringRange getRowRange() {
+  /**
+   * Get the partition of the current continuation token, represented by a {@link ByteStringRange}.
+   */
+  public ByteStringRange getPartition() {
     return ByteStringRange.create(
         this.tokenProto.getPartition().getRowRange().getStartKeyClosed(),
         this.tokenProto.getPartition().getRowRange().getEndKeyOpen());
@@ -96,19 +99,19 @@ public final class ChangeStreamContinuationToken implements Serializable {
       return false;
     }
     ChangeStreamContinuationToken otherToken = (ChangeStreamContinuationToken) o;
-    return Objects.equal(getRowRange(), otherToken.getRowRange())
+    return Objects.equal(getPartition(), otherToken.getPartition())
         && Objects.equal(getToken(), otherToken.getToken());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getRowRange(), getToken());
+    return Objects.hashCode(getPartition(), getToken());
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("rowRange", getRowRange())
+        .add("partition", getPartition())
         .add("token", getToken())
         .toString();
   }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Range.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Range.java
@@ -15,10 +15,13 @@
  */
 package com.google.cloud.bigtable.data.v2.models;
 
+import com.google.api.core.InternalApi;
 import com.google.api.core.InternalExtensionOnly;
+import com.google.bigtable.v2.RowRange;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -393,6 +396,22 @@ public abstract class Range<T, R extends Range<T, R>> implements Serializable {
 
     private void writeObject(ObjectOutputStream output) throws IOException {
       output.defaultWriteObject();
+    }
+
+    @InternalApi("Used in Changestream beam pipeline.")
+    static ByteString serializeByteStringRange(ByteStringRange byteStringRange) {
+      return RowRange.newBuilder()
+          .setStartKeyClosed(byteStringRange.getStart())
+          .setEndKeyOpen(byteStringRange.getEnd())
+          .build()
+          .toByteString();
+    }
+
+    @InternalApi("Used in Changestream beam pipeline.")
+    static ByteStringRange deserializeByteStringRange(ByteString byteString)
+        throws InvalidProtocolBufferException {
+      RowRange rowRange = RowRange.newBuilder().mergeFrom(byteString).build();
+      return ByteStringRange.create(rowRange.getStartKeyClosed(), rowRange.getEndKeyOpen());
     }
 
     @Override

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Range.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Range.java
@@ -399,7 +399,7 @@ public abstract class Range<T, R extends Range<T, R>> implements Serializable {
     }
 
     @InternalApi("Used in Changestream beam pipeline.")
-    static ByteString serializeByteStringRange(ByteStringRange byteStringRange) {
+    public static ByteString toByteString(ByteStringRange byteStringRange) {
       return RowRange.newBuilder()
           .setStartKeyClosed(byteStringRange.getStart())
           .setEndKeyOpen(byteStringRange.getEnd())
@@ -408,7 +408,7 @@ public abstract class Range<T, R extends Range<T, R>> implements Serializable {
     }
 
     @InternalApi("Used in Changestream beam pipeline.")
-    static ByteStringRange deserializeByteStringRange(ByteString byteString)
+    public static ByteStringRange toByteStringRange(ByteString byteString)
         throws InvalidProtocolBufferException {
       RowRange rowRange = RowRange.newBuilder().mergeFrom(byteString).build();
       return ByteStringRange.create(rowRange.getStartKeyClosed(), rowRange.getEndKeyOpen());

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
@@ -74,6 +74,7 @@ import com.google.cloud.bigtable.data.v2.models.DefaultChangeStreamRecordAdapter
 import com.google.cloud.bigtable.data.v2.models.DefaultRowAdapter;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.cloud.bigtable.data.v2.models.ReadChangeStreamQuery;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.Row;
@@ -155,7 +156,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
   private final UnaryCallable<ConditionalRowMutation, Boolean> checkAndMutateRowCallable;
   private final UnaryCallable<ReadModifyWriteRow, Row> readModifyWriteRowCallable;
 
-  private final ServerStreamingCallable<String, RowRange>
+  private final ServerStreamingCallable<String, ByteStringRange>
       generateInitialChangeStreamPartitionsCallable;
 
   private final ServerStreamingCallable<ReadChangeStreamQuery, ChangeStreamRecord>
@@ -833,7 +834,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
    *       RowRange}.
    * </ul>
    */
-  private ServerStreamingCallable<String, RowRange>
+  private ServerStreamingCallable<String, ByteStringRange>
       createGenerateInitialChangeStreamPartitionsCallable() {
     ServerStreamingCallable<
             GenerateInitialChangeStreamPartitionsRequest,
@@ -862,22 +863,22 @@ public class EnhancedBigtableStub implements AutoCloseable {
                     .build(),
                 settings.generateInitialChangeStreamPartitionsSettings().getRetryableCodes());
 
-    ServerStreamingCallable<String, RowRange> userCallable =
+    ServerStreamingCallable<String, ByteStringRange> userCallable =
         new GenerateInitialChangeStreamPartitionsUserCallable(base, requestContext);
 
-    ServerStreamingCallable<String, RowRange> withStatsHeaders =
+    ServerStreamingCallable<String, ByteStringRange> withStatsHeaders =
         new StatsHeadersServerStreamingCallable<>(userCallable);
 
     // Sometimes GenerateInitialChangeStreamPartitions connections are disconnected via an RST
     // frame. This error is transient and should be treated similar to UNAVAILABLE. However, this
     // exception has an INTERNAL error code which by default is not retryable. Convert the exception
     // so it can be retried in the client.
-    ServerStreamingCallable<String, RowRange> convertException =
+    ServerStreamingCallable<String, ByteStringRange> convertException =
         new ConvertStreamExceptionCallable<>(withStatsHeaders);
 
     // Copy idle timeout settings for watchdog.
-    ServerStreamingCallSettings<String, RowRange> innerSettings =
-        ServerStreamingCallSettings.<String, RowRange>newBuilder()
+    ServerStreamingCallSettings<String, ByteStringRange> innerSettings =
+        ServerStreamingCallSettings.<String, ByteStringRange>newBuilder()
             .setRetryableCodes(
                 settings.generateInitialChangeStreamPartitionsSettings().getRetryableCodes())
             .setRetrySettings(
@@ -886,17 +887,17 @@ public class EnhancedBigtableStub implements AutoCloseable {
                 settings.generateInitialChangeStreamPartitionsSettings().getIdleTimeout())
             .build();
 
-    ServerStreamingCallable<String, RowRange> watched =
+    ServerStreamingCallable<String, ByteStringRange> watched =
         Callables.watched(convertException, innerSettings, clientContext);
 
-    ServerStreamingCallable<String, RowRange> withBigtableTracer =
+    ServerStreamingCallable<String, ByteStringRange> withBigtableTracer =
         new BigtableTracerStreamingCallable<>(watched);
 
-    ServerStreamingCallable<String, RowRange> retrying =
+    ServerStreamingCallable<String, ByteStringRange> retrying =
         Callables.retrying(withBigtableTracer, innerSettings, clientContext);
 
     SpanName span = getSpanName("GenerateInitialChangeStreamPartitions");
-    ServerStreamingCallable<String, RowRange> traced =
+    ServerStreamingCallable<String, ByteStringRange> traced =
         new TracedServerStreamingCallable<>(retrying, clientContext.getTracerFactory(), span);
 
     return traced.withDefaultCallContext(clientContext.getDefaultCallContext());
@@ -1039,7 +1040,8 @@ public class EnhancedBigtableStub implements AutoCloseable {
   }
 
   /** Returns a streaming generate initial change stream partitions callable */
-  public ServerStreamingCallable<String, RowRange> generateInitialChangeStreamPartitionsCallable() {
+  public ServerStreamingCallable<String, ByteStringRange>
+      generateInitialChangeStreamPartitionsCallable() {
     return generateInitialChangeStreamPartitionsCallable;
   }
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -33,12 +33,12 @@ import com.google.api.gax.rpc.StubSettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.auth.Credentials;
-import com.google.bigtable.v2.RowRange;
 import com.google.cloud.bigtable.Version;
 import com.google.cloud.bigtable.data.v2.models.ChangeStreamRecord;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.cloud.bigtable.data.v2.models.ReadChangeStreamQuery;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.Row;
@@ -212,7 +212,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   private final BigtableBulkReadRowsCallSettings bulkReadRowsSettings;
   private final UnaryCallSettings<ConditionalRowMutation, Boolean> checkAndMutateRowSettings;
   private final UnaryCallSettings<ReadModifyWriteRow, Row> readModifyWriteRowSettings;
-  private final ServerStreamingCallSettings<String, RowRange>
+  private final ServerStreamingCallSettings<String, ByteStringRange>
       generateInitialChangeStreamPartitionsSettings;
   private final ServerStreamingCallSettings<ReadChangeStreamQuery, ChangeStreamRecord>
       readChangeStreamSettings;
@@ -537,7 +537,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
     return readModifyWriteRowSettings;
   }
 
-  public ServerStreamingCallSettings<String, RowRange>
+  public ServerStreamingCallSettings<String, ByteStringRange>
       generateInitialChangeStreamPartitionsSettings() {
     return generateInitialChangeStreamPartitionsSettings;
   }
@@ -571,7 +571,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
     private final UnaryCallSettings.Builder<ConditionalRowMutation, Boolean>
         checkAndMutateRowSettings;
     private final UnaryCallSettings.Builder<ReadModifyWriteRow, Row> readModifyWriteRowSettings;
-    private final ServerStreamingCallSettings.Builder<String, RowRange>
+    private final ServerStreamingCallSettings.Builder<String, ByteStringRange>
         generateInitialChangeStreamPartitionsSettings;
     private final ServerStreamingCallSettings.Builder<ReadChangeStreamQuery, ChangeStreamRecord>
         readChangeStreamSettings;

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/BigtableDataClientTests.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/BigtableDataClientTests.java
@@ -24,7 +24,6 @@ import com.google.api.gax.batching.Batcher;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.bigtable.v2.RowRange;
 import com.google.cloud.bigtable.data.v2.models.BulkMutation;
 import com.google.cloud.bigtable.data.v2.models.ChangeStreamRecord;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
@@ -32,6 +31,7 @@ import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.cloud.bigtable.data.v2.models.ReadChangeStreamQuery;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.Row;
@@ -83,7 +83,7 @@ public class BigtableDataClientTests {
   @Mock private Batcher<ByteString, Row> mockBulkReadRowsBatcher;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  private ServerStreamingCallable<String, RowRange>
+  private ServerStreamingCallable<String, ByteStringRange>
       mockGenerateInitialChangeStreamPartitionsCallable;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -342,7 +342,7 @@ public class BigtableDataClientTests {
         .thenReturn(mockGenerateInitialChangeStreamPartitionsCallable);
 
     @SuppressWarnings("unchecked")
-    ResponseObserver<RowRange> mockObserver = Mockito.mock(ResponseObserver.class);
+    ResponseObserver<ByteStringRange> mockObserver = Mockito.mock(ResponseObserver.class);
     bigtableDataClient.generateInitialChangeStreamPartitionsAsync("fake-table", mockObserver);
 
     Mockito.verify(mockGenerateInitialChangeStreamPartitionsCallable)

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamContinuationTokenTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamContinuationTokenTest.java
@@ -39,12 +39,10 @@ public class ChangeStreamContinuationTokenTest {
     return ByteStringRange.create("a", "b");
   }
 
-  // TODO: Get rid of this once we change ChangeStreamContinuationToken::getRowRange()
-  // to ChangeStreamContinuationToken::getByteStringRange().
-  private RowRange rowRangeFromByteStringRange(ByteStringRange byteStringRange) {
+  private RowRange rowRangeFromPartition(ByteStringRange partition) {
     return RowRange.newBuilder()
-        .setStartKeyClosed(byteStringRange.getStart())
-        .setEndKeyOpen(byteStringRange.getEnd())
+        .setStartKeyClosed(partition.getStart())
+        .setEndKeyOpen(partition.getEnd())
         .build();
   }
 
@@ -53,8 +51,7 @@ public class ChangeStreamContinuationTokenTest {
     ByteStringRange byteStringRange = createFakeByteStringRange();
     ChangeStreamContinuationToken changeStreamContinuationToken =
         new ChangeStreamContinuationToken(byteStringRange, TOKEN);
-    Assert.assertEquals(
-        changeStreamContinuationToken.getRowRange(), rowRangeFromByteStringRange(byteStringRange));
+    Assert.assertEquals(changeStreamContinuationToken.getPartition(), byteStringRange);
     Assert.assertEquals(changeStreamContinuationToken.getToken(), TOKEN);
 
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -69,15 +66,17 @@ public class ChangeStreamContinuationTokenTest {
   @Test
   public void fromProtoTest() {
     ByteStringRange byteStringRange = createFakeByteStringRange();
-    RowRange fakeRowRange = rowRangeFromByteStringRange(byteStringRange);
     StreamContinuationToken proto =
         StreamContinuationToken.newBuilder()
-            .setPartition(StreamPartition.newBuilder().setRowRange(fakeRowRange).build())
+            .setPartition(
+                StreamPartition.newBuilder()
+                    .setRowRange(rowRangeFromPartition(byteStringRange))
+                    .build())
             .setToken(TOKEN)
             .build();
     ChangeStreamContinuationToken changeStreamContinuationToken =
         ChangeStreamContinuationToken.fromProto(proto);
-    Assert.assertEquals(changeStreamContinuationToken.getRowRange(), fakeRowRange);
+    Assert.assertEquals(changeStreamContinuationToken.getPartition(), byteStringRange);
     Assert.assertEquals(changeStreamContinuationToken.getToken(), TOKEN);
     Assert.assertEquals(
         changeStreamContinuationToken,
@@ -89,8 +88,7 @@ public class ChangeStreamContinuationTokenTest {
     ByteStringRange byteStringRange = createFakeByteStringRange();
     ChangeStreamContinuationToken changeStreamContinuationToken =
         new ChangeStreamContinuationToken(byteStringRange, TOKEN);
-    Assert.assertEquals(
-        changeStreamContinuationToken.getRowRange(), rowRangeFromByteStringRange(byteStringRange));
+    Assert.assertEquals(changeStreamContinuationToken.getPartition(), byteStringRange);
     Assert.assertEquals(changeStreamContinuationToken.getToken(), TOKEN);
     Assert.assertEquals(
         changeStreamContinuationToken,

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamRecordTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamRecordTest.java
@@ -21,6 +21,7 @@ import com.google.bigtable.v2.ReadChangeStreamResponse;
 import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.StreamContinuationToken;
 import com.google.bigtable.v2.StreamPartition;
+import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import com.google.rpc.Status;
@@ -119,7 +120,9 @@ public class ChangeStreamRecordTest {
     Heartbeat actualHeartbeat = Heartbeat.fromProto(heartbeatProto);
 
     Assert.assertEquals(actualHeartbeat.getLowWatermark(), lowWatermark);
-    Assert.assertEquals(actualHeartbeat.getChangeStreamContinuationToken().getRowRange(), rowRange);
+    Assert.assertEquals(
+        actualHeartbeat.getChangeStreamContinuationToken().getPartition(),
+        ByteStringRange.create(rowRange.getStartKeyClosed(), rowRange.getEndKeyOpen()));
     Assert.assertEquals(actualHeartbeat.getChangeStreamContinuationToken().getToken(), token);
   }
 
@@ -156,11 +159,13 @@ public class ChangeStreamRecordTest {
 
     Assert.assertEquals(status, actualCloseStream.getStatus());
     Assert.assertEquals(
-        rowRange1, actualCloseStream.getChangeStreamContinuationTokens().get(0).getRowRange());
+        actualCloseStream.getChangeStreamContinuationTokens().get(0).getPartition(),
+        ByteStringRange.create(rowRange1.getStartKeyClosed(), rowRange1.getEndKeyOpen()));
     Assert.assertEquals(
         token1, actualCloseStream.getChangeStreamContinuationTokens().get(0).getToken());
     Assert.assertEquals(
-        rowRange2, actualCloseStream.getChangeStreamContinuationTokens().get(1).getRowRange());
+        actualCloseStream.getChangeStreamContinuationTokens().get(1).getPartition(),
+        ByteStringRange.create(rowRange2.getStartKeyClosed(), rowRange2.getEndKeyOpen()));
     Assert.assertEquals(
         token2, actualCloseStream.getChangeStreamContinuationTokens().get(1).getToken());
   }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/RangeTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/RangeTest.java
@@ -21,6 +21,7 @@ import com.google.cloud.bigtable.data.v2.models.Range.BoundType;
 import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.cloud.bigtable.data.v2.models.Range.TimestampRange;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -305,5 +306,15 @@ public class RangeTest {
 
     ByteStringRange actual = (ByteStringRange) ois.readObject();
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void byteStringRangeToByteStringTest() throws InvalidProtocolBufferException {
+    ByteStringRange expected = ByteStringRange.create("a", "z");
+
+    ByteString serialized = ByteStringRange.serializeByteStringRange(expected);
+    ByteStringRange deserialized = ByteStringRange.deserializeByteStringRange(serialized);
+
+    assertThat(expected).isEqualTo(deserialized);
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/RangeTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/RangeTest.java
@@ -312,8 +312,8 @@ public class RangeTest {
   public void byteStringRangeToByteStringTest() throws InvalidProtocolBufferException {
     ByteStringRange expected = ByteStringRange.create("a", "z");
 
-    ByteString serialized = ByteStringRange.serializeByteStringRange(expected);
-    ByteStringRange deserialized = ByteStringRange.deserializeByteStringRange(serialized);
+    ByteString serialized = ByteStringRange.toByteString(expected);
+    ByteStringRange deserialized = ByteStringRange.toByteStringRange(serialized);
 
     assertThat(expected).isEqualTo(deserialized);
   }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/GenerateInitialChangeStreamPartitionsUserCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/GenerateInitialChangeStreamPartitionsUserCallableTest.java
@@ -23,6 +23,7 @@ import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.StreamPartition;
 import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.cloud.bigtable.gaxx.testing.FakeStreamingApi;
 import com.google.common.collect.Lists;
 import com.google.common.truth.Truth;
@@ -80,13 +81,8 @@ public class GenerateInitialChangeStreamPartitionsUserCallableTest {
         generateInitialChangeStreamPartitionsUserCallable =
             new GenerateInitialChangeStreamPartitionsUserCallable(inner, requestContext);
 
-    List<RowRange> results =
+    List<ByteStringRange> results =
         generateInitialChangeStreamPartitionsUserCallable.all().call("my-table");
-    Truth.assertThat(results)
-        .containsExactly(
-            RowRange.newBuilder()
-                .setStartKeyClosed(ByteString.copyFromUtf8("apple"))
-                .setEndKeyOpen(ByteString.copyFromUtf8("banana"))
-                .build());
+    Truth.assertThat(results).containsExactly(ByteStringRange.create("apple", "banana"));
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/GenerateInitialChangeStreamPartitionsUserCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/GenerateInitialChangeStreamPartitionsUserCallableTest.java
@@ -27,7 +27,6 @@ import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.cloud.bigtable.gaxx.testing.FakeStreamingApi;
 import com.google.common.collect.Lists;
 import com.google.common.truth.Truth;
-import com.google.protobuf.ByteString;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -70,11 +69,7 @@ public class GenerateInitialChangeStreamPartitionsUserCallableTest {
                     GenerateInitialChangeStreamPartitionsResponse.newBuilder()
                         .setPartition(
                             StreamPartition.newBuilder()
-                                .setRowRange(
-                                    RowRange.newBuilder()
-                                        .setStartKeyClosed(ByteString.copyFromUtf8("apple"))
-                                        .setEndKeyOpen(ByteString.copyFromUtf8("banana"))
-                                        .build())
+                                .setRowRange(RowRange.newBuilder().getDefaultInstanceForType())
                                 .build())
                         .build()));
     GenerateInitialChangeStreamPartitionsUserCallable
@@ -83,6 +78,6 @@ public class GenerateInitialChangeStreamPartitionsUserCallableTest {
 
     List<ByteStringRange> results =
         generateInitialChangeStreamPartitionsUserCallable.all().call("my-table");
-    Truth.assertThat(results).containsExactly(ByteStringRange.create("apple", "banana"));
+    Truth.assertThat(results).containsExactly(ByteStringRange.create("", ""));
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/ReadChangeStreamMergingAcceptanceTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/ReadChangeStreamMergingAcceptanceTest.java
@@ -24,6 +24,7 @@ import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.ReadChangeStreamRequest;
 import com.google.bigtable.v2.ReadChangeStreamResponse;
+import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.StreamContinuationToken;
 import com.google.bigtable.v2.StreamPartition;
 import com.google.bigtable.v2.TimestampRange;
@@ -36,6 +37,7 @@ import com.google.cloud.bigtable.data.v2.models.DeleteCells;
 import com.google.cloud.bigtable.data.v2.models.DeleteFamily;
 import com.google.cloud.bigtable.data.v2.models.Entry;
 import com.google.cloud.bigtable.data.v2.models.Heartbeat;
+import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.cloud.bigtable.data.v2.models.SetCell;
 import com.google.cloud.bigtable.gaxx.testing.FakeStreamingApi;
 import com.google.cloud.conformance.bigtable.v2.ChangeStreamTestDefinition.ChangeStreamTestFile;
@@ -130,7 +132,10 @@ public class ReadChangeStreamMergingAcceptanceTest {
                           .setPartition(
                               StreamPartition.newBuilder()
                                   .setRowRange(
-                                      heartbeat.getChangeStreamContinuationToken().getRowRange())
+                                      toRowRange(
+                                          heartbeat
+                                              .getChangeStreamContinuationToken()
+                                              .getRowRange()))
                                   .build())
                           .setToken(heartbeat.getChangeStreamContinuationToken().getToken())
                           .build())
@@ -152,7 +157,9 @@ public class ReadChangeStreamMergingAcceptanceTest {
             builder.addContinuationTokens(
                 StreamContinuationToken.newBuilder()
                     .setPartition(
-                        StreamPartition.newBuilder().setRowRange(token.getRowRange()).build())
+                        StreamPartition.newBuilder()
+                            .setRowRange(toRowRange(token.getRowRange()))
+                            .build())
                     .setToken(token.getToken())
                     .build());
           }
@@ -259,5 +266,12 @@ public class ReadChangeStreamMergingAcceptanceTest {
       }
     }
     return response;
+  }
+
+  private static RowRange toRowRange(ByteStringRange byteStringRange) {
+    return RowRange.newBuilder()
+        .setStartKeyClosed(byteStringRange.getStart())
+        .setEndKeyOpen(byteStringRange.getEnd())
+        .build();
   }
 }


### PR DESCRIPTION
…wRange

1. Make GenerateInitialChangeStreamPartitions return ByteStringRange
2. Make ChangeStreamContinuationToken::GetRowRange() return ByteStringRange

Also add serializeByteStringRange() & deserializeByteStringRange() methods for ByteStringRange so that they can be used by the CDC beam connector to write to bigtable.