### PR TITLE
fix: fix attempt status tag for metrics

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracer.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.data.v2.stub.metrics;
 
 import static com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 
+import com.google.api.gax.retrying.ServerStreamingAttemptException;
 import com.google.api.gax.tracing.SpanName;
 import com.google.cloud.bigtable.stats.StatsRecorderWrapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -256,6 +257,14 @@ class BuiltinMetricsTracer extends BigtableTracer {
         serverLatencyTimerIsRunning = false;
       }
     }
+
+    // Patch the status until it's fixed in gax. When an attempt failed,
+    // it'll throw a ServerStreamingAttemptException. Unwrap the exception
+    // so it could get processed by extractStatus
+    if (status instanceof ServerStreamingAttemptException) {
+      status = status.getCause();
+    }
+
     recorder.putAttemptLatencies(attemptTimer.elapsed(TimeUnit.MILLISECONDS));
     recorder.recordAttempt(Util.extractStatus(status), tableId, zone, cluster);
   }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.data.v2.stub.metrics;
 
+import com.google.api.gax.retrying.ServerStreamingAttemptException;
 import com.google.api.gax.tracing.ApiTracerFactory.OperationType;
 import com.google.api.gax.tracing.SpanName;
 import com.google.common.base.Stopwatch;
@@ -165,6 +166,13 @@ class MetricsTracer extends BigtableTracer {
             .put(
                 RpcMeasureConstants.BIGTABLE_ATTEMPT_LATENCY,
                 attemptTimer.elapsed(TimeUnit.MILLISECONDS));
+
+    // Patch the throwable until it's fixed in gax. When an attempt failed,
+    // it'll throw a ServerStreamingAttemptException. Unwrap the exception
+    // so it could get processed by extractStatus
+    if (throwable instanceof ServerStreamingAttemptException) {
+      throwable = throwable.getCause();
+    }
 
     TagContextBuilder tagCtx =
         newTagCtxBuilder()


### PR DESCRIPTION
We need to fix: https://github.com/googleapis/gax-java/blob/11c4a7caf31de256f29678de829f11f9558adcfd/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java#L379