### PR TITLE
chore: turn off fail-fast behavior to prevent cancellation of jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
           - 7
           - 8
           - 11
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: stCarolas/setup-maven@v4


### PR DESCRIPTION
As seen in https://github.com/googleapis/java-bigtable/pull/1497, unit tests (11) gets cancelled if unit tests (7) fails. This PR prevents workflows from getting cancelled at the first failed job. 