### PR TITLE
test(fix): update the test proxy to set app profile id and connect to emulator correctly

### DIFF
--- a/test-proxy/src/main/java/com/google/cloud/bigtable/testproxy/CbtTestProxy.java
+++ b/test-proxy/src/main/java/com/google/cloud/bigtable/testproxy/CbtTestProxy.java
@@ -215,7 +215,11 @@ public class CbtTestProxy extends CloudBigtableV2TestProxyImplBase implements Cl
       return;
     }
 
-    BigtableDataSettings.Builder settingsBuilder = BigtableDataSettings.newBuilder();
+    BigtableDataSettings.Builder settingsBuilder = BigtableDataSettings.newBuilder()
+        .setProjectId(request.getProjectId())
+        .setInstanceId(request.getInstanceId())
+        .setAppProfileId(request.getAppProfileId());
+
     if (request.hasPerOperationTimeout()) {
       Duration newTimeout = Duration.ofMillis(Durations.toMillis(request.getPerOperationTimeout()));
       settingsBuilder = overrideTimeoutSetting(newTimeout, settingsBuilder);
@@ -227,13 +231,12 @@ public class CbtTestProxy extends CloudBigtableV2TestProxyImplBase implements Cl
 
     // Create and store CbtClient for later use
     try {
-      settingsBuilder
-          .setProjectId(request.getProjectId())
-          .setInstanceId(request.getInstanceId())
-          .stubSettings()
-          .setEndpoint(request.getDataTarget())
-          .setTransportChannelProvider(getTransportChannel())
-          .setCredentialsProvider(getCredentialsProvider());
+      if (!request.getDataTarget().equals("emulator")) {
+        settingsBuilder.stubSettings()
+            .setEndpoint(request.getDataTarget())
+            .setTransportChannelProvider(getTransportChannel())
+            .setCredentialsProvider(getCredentialsProvider());
+      }
       BigtableDataSettings settings = settingsBuilder.build();
       BigtableDataClient client = BigtableDataClient.create(settings);
       CbtClient cbtClient = CbtClient.create(settings, client);

--- a/test-proxy/src/main/java/com/google/cloud/bigtable/testproxy/CbtTestProxy.java
+++ b/test-proxy/src/main/java/com/google/cloud/bigtable/testproxy/CbtTestProxy.java
@@ -215,10 +215,11 @@ public class CbtTestProxy extends CloudBigtableV2TestProxyImplBase implements Cl
       return;
     }
 
-    BigtableDataSettings.Builder settingsBuilder = BigtableDataSettings.newBuilder()
-        .setProjectId(request.getProjectId())
-        .setInstanceId(request.getInstanceId())
-        .setAppProfileId(request.getAppProfileId());
+    BigtableDataSettings.Builder settingsBuilder =
+        BigtableDataSettings.newBuilder()
+            .setProjectId(request.getProjectId())
+            .setInstanceId(request.getInstanceId())
+            .setAppProfileId(request.getAppProfileId());
 
     if (request.hasPerOperationTimeout()) {
       Duration newTimeout = Duration.ofMillis(Durations.toMillis(request.getPerOperationTimeout()));
@@ -232,7 +233,8 @@ public class CbtTestProxy extends CloudBigtableV2TestProxyImplBase implements Cl
     // Create and store CbtClient for later use
     try {
       if (!request.getDataTarget().equals("emulator")) {
-        settingsBuilder.stubSettings()
+        settingsBuilder
+            .stubSettings()
             .setEndpoint(request.getDataTarget())
             .setTransportChannelProvider(getTransportChannel())
             .setCredentialsProvider(getCredentialsProvider());

--- a/test-proxy/src/main/proto/v2_test_proxy.proto
+++ b/test-proxy/src/main/proto/v2_test_proxy.proto
@@ -57,7 +57,9 @@ option go_package = "./testproxypb";
 message CreateClientRequest {
   string client_id = 1;
   // The "host:port" address of the data API endpoint (i.e. the backend being
-  // proxied to). Example: 127.0.0.1:38543
+  // proxied to). Example: 127.0.0.1:38543. If you want to connect to a local
+  // emulator via BIGTABLE_EMULATOR_HOST environment variable, you can use
+  // "emulator" instead of "host:port" for this field.
   string data_target = 2;
   // The project for all calls on this client.
   string project_id = 3;


### PR DESCRIPTION
This change makes the test proxy work with the hermetic testing that exercises app_profile_id and emulator (https://github.com/googleapis/cloud-bigtable-clients-test)
