### PR TITLE
test: attempt to fix flaky test

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.3.0')
+implementation platform('com.google.cloud:libraries-bom:26.4.0')
 
 implementation 'com.google.cloud:google-cloud-bigtable'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigtable:2.18.0'
+implementation 'com.google.cloud:google-cloud-bigtable:2.18.1'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.18.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.18.1"
 ```
 
 ## Authentication

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/BuiltinMetricsIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/BuiltinMetricsIT.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.TruthJUnit.assume;
 
 import com.google.api.client.util.Lists;
+import com.google.api.core.ApiFuture;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.Row;
@@ -34,6 +35,8 @@ import com.google.protobuf.util.Timestamps;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -76,27 +79,42 @@ public class BuiltinMetricsIT {
 
   @Test
   public void testBuiltinMetrics() throws Exception {
-    // Send a MutateRow and ReadRows request
-    testEnvRule
-        .env()
-        .getDataClient()
-        .mutateRow(
-            RowMutation.create(testEnvRule.env().getTableId(), "a-new-key")
-                .setCell(testEnvRule.env().getFamilyId(), "q", "abc"));
-    ArrayList<Row> rows =
-        Lists.newArrayList(
-            testEnvRule
-                .env()
-                .getDataClient()
-                .readRows(Query.create(testEnvRule.env().getTableId()).limit(10)));
+    List<ApiFuture> futures = new ArrayList<>();
+    // Send a few MutateRow and ReadRows requests
+    for (int i = 0; i < 5; i++) {
+      ApiFuture<Void> future =
+          testEnvRule
+              .env()
+              .getDataClient()
+              .mutateRowAsync(
+                  RowMutation.create(testEnvRule.env().getTableId(), "a-new-key" + i)
+                      .setCell(testEnvRule.env().getFamilyId(), "q", "abc"));
+      futures.add(future);
+    }
+    for (int i = 0; i < 5; i++) {
+      ArrayList<Row> rows =
+          Lists.newArrayList(
+              testEnvRule
+                  .env()
+                  .getDataClient()
+                  .readRows(Query.create(testEnvRule.env().getTableId()).limit(10)));
+    }
+
+    futures.forEach(
+        f -> {
+          try {
+            f.get(1, TimeUnit.MINUTES);
+          } catch (Exception e) {
+          }
+        });
 
     // Sleep 5 minutes so the metrics could be published and precomputation is done
     Thread.sleep(Duration.ofMinutes(5).toMillis());
 
     ProjectName name = ProjectName.of(testEnvRule.env().getProjectId());
 
-    // Restrict time to last 10 minutes
-    long startMillis = System.currentTimeMillis() - Duration.ofMinutes(10).toMillis();
+    // Restrict time to last 15 minutes
+    long startMillis = System.currentTimeMillis() - Duration.ofMinutes(15).toMillis();
     TimeInterval interval =
         TimeInterval.newBuilder()
             .setStartTime(Timestamps.fromMillis(startMillis))

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/UnaryMetricsMetadataIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/UnaryMetricsMetadataIT.java
@@ -70,7 +70,13 @@ public class UnaryMetricsMetadataIT {
     List<Cluster> clusters = clustersFuture.get(1, TimeUnit.MINUTES);
 
     // give opencensus some time to populate view data
-    Thread.sleep(1000);
+    for (int i = 0; i < 10; i++) {
+      if (StatsWrapper.getOperationLatencyViewTagValueStrings()
+          .contains(clusters.get(0).getZone())) {
+        break;
+      }
+      Thread.sleep(100);
+    }
 
     List<String> tagValueStrings = StatsWrapper.getOperationLatencyViewTagValueStrings();
     assertThat(tagValueStrings).contains(clusters.get(0).getZone());
@@ -99,7 +105,12 @@ public class UnaryMetricsMetadataIT {
     }
 
     // give opencensus some time to populate view data
-    Thread.sleep(1000);
+    for (int i = 0; i < 10; i++) {
+      if (StatsWrapper.getOperationLatencyViewTagValueStrings().contains("unspecified")) {
+        break;
+      }
+      Thread.sleep(100);
+    }
 
     List<String> tagValueStrings = StatsWrapper.getOperationLatencyViewTagValueStrings();
     assertThat(tagValueStrings).contains("unspecified");

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/UnaryMetricsMetadataIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/UnaryMetricsMetadataIT.java
@@ -28,7 +28,10 @@ import com.google.cloud.bigtable.test_helpers.env.EmulatorEnv;
 import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -69,7 +72,7 @@ public class UnaryMetricsMetadataIT {
     List<Cluster> clusters = clustersFuture.get(1, TimeUnit.MINUTES);
 
     // give opencensus some time to populate view data
-    Thread.sleep(100);
+    Thread.sleep(1000);
 
     List<String> tagValueStrings = StatsWrapper.getOperationLatencyViewTagValueStrings();
     assertThat(tagValueStrings).contains(clusters.get(0).getZone());
@@ -77,21 +80,26 @@ public class UnaryMetricsMetadataIT {
   }
 
   @Test
-  public void testFailure() throws InterruptedException {
+  public void testFailure() throws Exception {
     String rowKey = UUID.randomUUID().toString();
     String familyId = testEnvRule.env().getFamilyId();
 
-    try {
-      testEnvRule
+    ApiFuture<Void> future = testEnvRule
           .env()
           .getDataClient()
           .mutateRowCallable()
-          .call(RowMutation.create("non-exist-table", rowKey).setCell(familyId, "q", "myVal"));
-    } catch (NotFoundException e) {
+          .futureCall(RowMutation.create("non-exist-table", rowKey).setCell(familyId, "q", "myVal"));
+
+    try {
+      future.get(1, TimeUnit.MINUTES);
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof NotFoundException) {
+        // ignore NotFoundException
+      }
     }
 
     // give opencensus some time to populate view data
-    Thread.sleep(100);
+    Thread.sleep(1000);
 
     List<String> tagValueStrings = StatsWrapper.getOperationLatencyViewTagValueStrings();
     assertThat(tagValueStrings).contains("unspecified");

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/UnaryMetricsMetadataIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/UnaryMetricsMetadataIT.java
@@ -101,6 +101,8 @@ public class UnaryMetricsMetadataIT {
     } catch (ExecutionException e) {
       if (e.getCause() instanceof NotFoundException) {
         // ignore NotFoundException
+      } else {
+        throw e;
       }
     }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/UnaryMetricsMetadataIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/UnaryMetricsMetadataIT.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -84,11 +82,13 @@ public class UnaryMetricsMetadataIT {
     String rowKey = UUID.randomUUID().toString();
     String familyId = testEnvRule.env().getFamilyId();
 
-    ApiFuture<Void> future = testEnvRule
-          .env()
-          .getDataClient()
-          .mutateRowCallable()
-          .futureCall(RowMutation.create("non-exist-table", rowKey).setCell(familyId, "q", "myVal"));
+    ApiFuture<Void> future =
+        testEnvRule
+            .env()
+            .getDataClient()
+            .mutateRowCallable()
+            .futureCall(
+                RowMutation.create("non-exist-table", rowKey).setCell(familyId, "q", "myVal"));
 
     try {
       future.get(1, TimeUnit.MINUTES);

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/DynamicFlowControlCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/DynamicFlowControlCallableTest.java
@@ -100,6 +100,10 @@ public class DynamicFlowControlCallableTest {
 
   @Test
   public void testLatenciesAreRecorded() throws Exception {
+    DynamicFlowControlStats stats = new DynamicFlowControlStats();
+    DynamicFlowControlCallable callableToTest =
+        new DynamicFlowControlCallable(
+            innerCallable, flowController, stats, TARGET_LATENCY_MS, ADJUSTING_INTERVAL_MS);
     Map<String, List<String>> extraHeaders = new HashMap<>();
     extraHeaders.put(LATENCY_HEADER, Arrays.asList("5"));
     ApiCallContext newContext = context.withExtraHeaders(extraHeaders);


### PR DESCRIPTION
UnaryMetricsMetadataIT: testFailure sometimes fails with:
```
expected to contain: unspecified
but was            : []
```
Setting a longer wait time before checking opencensus stats. Also assign the returned value to a future. 


DynamicFlowControlCallableTest sometimes fails with:
```
value of: getLastAdjustedTimestampMs()
expected: 0
but was : 1669306507692
	at com.google.cloud.bigtable.data.v2.stub.DynamicFlowControlCallableTest.testLatenciesAreRecorded(DynamicFlowControlCallableTest.java:105)
```
Cleanup DyanmicFlowControlStats after each test, and create a new Stats instance and callable inside the testLatenciesAreRecorded test.