### PR TITLE
docs: fix javadoc code example for awaitOptimizeRestoredTableAsync

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
@@ -1240,7 +1240,7 @@ public final class BigtableTableAdminClient implements AutoCloseable {
    *     }
    *   },
    *   MoreExecutors.directExecutor()
-   * );
+   * );}</pre>
    * */
   public ApiFuture<Void> awaitOptimizeRestoredTableAsync(
       OptimizeRestoredTableOperationToken token) {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
@@ -1218,7 +1218,8 @@ public final class BigtableTableAdminClient implements AutoCloseable {
     awaitOptimizeRestoredTableAsync(token).get();
   }
 
-  /** Awaits a restored table is fully optimized asynchronously.
+  /**
+   * Awaits a restored table is fully optimized asynchronously.
    *
    * <p>Sample code
    *
@@ -1240,8 +1241,9 @@ public final class BigtableTableAdminClient implements AutoCloseable {
    *     }
    *   },
    *   MoreExecutors.directExecutor()
-   * );}</pre>
-   * */
+   * );
+   * }</pre>
+   */
   public ApiFuture<Void> awaitOptimizeRestoredTableAsync(
       OptimizeRestoredTableOperationToken token) {
     return transformToVoid(


### PR DESCRIPTION
Fixes rendering of https://cloud.google.com/java/docs/reference/google-cloud-bigtable/latest/com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient#com_google_cloud_bigtable_admin_v2_BigtableTableAdminClient_awaitOptimizeRestoredTableAsync_com_google_cloud_bigtable_admin_v2_models_OptimizeRestoredTableOperationToken_
