### PR TITLE
fix: Change types for Cloud Bigtable Changestream methods

### DIFF
--- a/google-cloud-bigtable/clirr-ignored-differences.xml
+++ b/google-cloud-bigtable/clirr-ignored-differences.xml
@@ -91,6 +91,41 @@
         <differenceType>7006</differenceType>
         <className>com/google/cloud/bigtable/data/v2/models/Heartbeat</className>
         <method>*getEstimatedLowWatermark*</method>
-        <to>long</to>
+        <to>org.threeten.bp.Instant</to>
+    </difference>
+    <!-- change method return type is ok because CloseStream is InternalApi -->
+    <difference>
+        <differenceType>7006</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/models/CloseStream</className>
+        <method>*getStatus*</method>
+        <to>com.google.cloud.bigtable.common.Status</to>
+    </difference>
+    <!-- change method return type is ok because ChangeStreamMutation is InternalApi -->
+    <difference>
+        <differenceType>7006</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/models/ChangeStreamMutation</className>
+        <method>*getCommitTimestamp*</method>
+        <to>org.threeten.bp.Instant</to>
+    </difference>
+    <!-- change method return type is ok because ChangeStreamMutation is InternalApi -->
+    <difference>
+        <differenceType>7006</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/models/ChangeStreamMutation</className>
+        <method>*getEstimatedLowWatermark*</method>
+        <to>org.threeten.bp.Instant</to>
+    </difference>
+    <!-- change method argument type is ok because ChangeStreamRecordAdapter is InternalApi -->
+    <difference>
+        <differenceType>7005</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/models/ChangeStreamRecordAdapter$ChangeStreamRecordBuilder</className>
+        <method>*</method>
+        <to>*</to>
+    </difference>
+    <!-- change method argument type is ok because ReadChangeStreamQuery is InternalApi -->
+    <difference>
+        <differenceType>7005</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/models/ReadChangeStreamQuery</className>
+        <method>*</method>
+        <to>*</to>
     </difference>
 </differences>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/common/Status.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/common/Status.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.common;
 
 import com.google.common.base.Objects;
+import java.io.Serializable;
 
 /**
  * The `Status` type defines a logical error model. Each `Status` message contains an error code and
@@ -23,7 +24,9 @@ import com.google.common.base.Objects;
  *
  * <p>This primarily wraps the protobuf {@link com.google.rpc.Status}.
  */
-public final class Status {
+public final class Status implements Serializable {
+  private static final long serialVersionUID = -5512896228725308380L;
+
   public enum Code {
     OK(com.google.rpc.Code.OK),
     CANCELLED(com.google.rpc.Code.CANCELLED),

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamMutation.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamMutation.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import java.io.Serializable;
 import javax.annotation.Nonnull;
+import org.threeten.bp.Instant;
 
 /**
  * A ChangeStreamMutation represents a list of mods(represented by List<{@link Entry}>) targeted at
@@ -72,7 +73,7 @@ public abstract class ChangeStreamMutation implements ChangeStreamRecord, Serial
   static Builder createUserMutation(
       @Nonnull ByteString rowKey,
       @Nonnull String sourceClusterId,
-      long commitTimestamp,
+      Instant commitTimestamp,
       int tieBreaker) {
     return builder()
         .setRowKey(rowKey)
@@ -88,7 +89,7 @@ public abstract class ChangeStreamMutation implements ChangeStreamRecord, Serial
    * mutation.
    */
   static Builder createGcMutation(
-      @Nonnull ByteString rowKey, long commitTimestamp, int tieBreaker) {
+      @Nonnull ByteString rowKey, Instant commitTimestamp, int tieBreaker) {
     return builder()
         .setRowKey(rowKey)
         .setType(MutationType.GARBAGE_COLLECTION)
@@ -110,7 +111,7 @@ public abstract class ChangeStreamMutation implements ChangeStreamRecord, Serial
   public abstract String getSourceClusterId();
 
   /** Get the commit timestamp of the current mutation. */
-  public abstract long getCommitTimestamp();
+  public abstract Instant getCommitTimestamp();
 
   /**
    * Get the tie breaker of the current mutation. This is used to resolve conflicts when multiple
@@ -123,7 +124,7 @@ public abstract class ChangeStreamMutation implements ChangeStreamRecord, Serial
   public abstract String getToken();
 
   /** Get the low watermark of the current mutation. */
-  public abstract long getEstimatedLowWatermark();
+  public abstract Instant getEstimatedLowWatermark();
 
   /** Get the list of mods of the current mutation. */
   @Nonnull
@@ -144,7 +145,7 @@ public abstract class ChangeStreamMutation implements ChangeStreamRecord, Serial
 
     abstract Builder setSourceClusterId(@Nonnull String sourceClusterId);
 
-    abstract Builder setCommitTimestamp(long commitTimestamp);
+    abstract Builder setCommitTimestamp(Instant commitTimestamp);
 
     abstract Builder setTieBreaker(int tieBreaker);
 
@@ -152,7 +153,7 @@ public abstract class ChangeStreamMutation implements ChangeStreamRecord, Serial
 
     abstract Builder setToken(@Nonnull String token);
 
-    abstract Builder setEstimatedLowWatermark(long estimatedLowWatermark);
+    abstract Builder setEstimatedLowWatermark(Instant estimatedLowWatermark);
 
     Builder setCell(
         @Nonnull String familyName,

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamRecordAdapter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamRecordAdapter.java
@@ -20,6 +20,7 @@ import com.google.bigtable.v2.ReadChangeStreamResponse;
 import com.google.cloud.bigtable.data.v2.models.Range.TimestampRange;
 import com.google.protobuf.ByteString;
 import javax.annotation.Nonnull;
+import org.threeten.bp.Instant;
 
 /**
  * An extension point that allows end users to plug in a custom implementation of logical change
@@ -115,7 +116,7 @@ public interface ChangeStreamRecordAdapter<ChangeStreamRecordT> {
     void startUserMutation(
         @Nonnull ByteString rowKey,
         @Nonnull String sourceClusterId,
-        long commitTimestamp,
+        Instant commitTimestamp,
         int tieBreaker);
 
     /**
@@ -123,7 +124,7 @@ public interface ChangeStreamRecordAdapter<ChangeStreamRecordT> {
      * once. If called, the current change stream record must not include any close stream message
      * or heartbeat.
      */
-    void startGcMutation(@Nonnull ByteString rowKey, long commitTimestamp, int tieBreaker);
+    void startGcMutation(@Nonnull ByteString rowKey, Instant commitTimestamp, int tieBreaker);
 
     /** Called to add a DeleteFamily mod. */
     void deleteFamily(@Nonnull String familyName);
@@ -164,7 +165,7 @@ public interface ChangeStreamRecordAdapter<ChangeStreamRecordT> {
 
     /** Called once per stream record to signal that all mods have been processed (unless reset). */
     ChangeStreamRecordT finishChangeStreamMutation(
-        @Nonnull String token, long estimatedLowWatermark);
+        @Nonnull String token, Instant estimatedLowWatermark);
 
     /** Called when the current in progress change stream record should be dropped */
     void reset();

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/CloseStream.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/CloseStream.java
@@ -18,8 +18,8 @@ package com.google.cloud.bigtable.data.v2.models;
 import com.google.api.core.InternalApi;
 import com.google.auto.value.AutoValue;
 import com.google.bigtable.v2.ReadChangeStreamResponse;
+import com.google.cloud.bigtable.common.Status;
 import com.google.common.collect.ImmutableList;
-import com.google.rpc.Status;
 import java.io.Serializable;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -34,8 +34,9 @@ public abstract class CloseStream implements ChangeStreamRecord, Serializable {
   private static final long serialVersionUID = 7316215828353608505L;
 
   private static CloseStream create(
-      Status status, List<ChangeStreamContinuationToken> changeStreamContinuationTokens) {
-    return new AutoValue_CloseStream(status, changeStreamContinuationTokens);
+      com.google.rpc.Status status,
+      List<ChangeStreamContinuationToken> changeStreamContinuationTokens) {
+    return new AutoValue_CloseStream(Status.fromProto(status), changeStreamContinuationTokens);
   }
 
   /** Wraps the protobuf {@link ReadChangeStreamResponse.CloseStream}. */

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/DefaultChangeStreamRecordAdapter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/DefaultChangeStreamRecordAdapter.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.threeten.bp.Instant;
 
 /**
  * Default implementation of a {@link ChangeStreamRecordAdapter} that uses {@link
@@ -102,7 +103,7 @@ public class DefaultChangeStreamRecordAdapter
     public void startUserMutation(
         @Nonnull ByteString rowKey,
         @Nonnull String sourceClusterId,
-        long commitTimestamp,
+        Instant commitTimestamp,
         int tieBreaker) {
       this.changeStreamMutationBuilder =
           ChangeStreamMutation.createUserMutation(
@@ -111,7 +112,8 @@ public class DefaultChangeStreamRecordAdapter
 
     /** {@inheritDoc} */
     @Override
-    public void startGcMutation(@Nonnull ByteString rowKey, long commitTimestamp, int tieBreaker) {
+    public void startGcMutation(
+        @Nonnull ByteString rowKey, Instant commitTimestamp, int tieBreaker) {
       this.changeStreamMutationBuilder =
           ChangeStreamMutation.createGcMutation(rowKey, commitTimestamp, tieBreaker);
     }
@@ -156,7 +158,7 @@ public class DefaultChangeStreamRecordAdapter
     /** {@inheritDoc} */
     @Override
     public ChangeStreamRecord finishChangeStreamMutation(
-        @Nonnull String token, long estimatedLowWatermark) {
+        @Nonnull String token, Instant estimatedLowWatermark) {
       this.changeStreamMutationBuilder.setToken(token);
       this.changeStreamMutationBuilder.setEstimatedLowWatermark(estimatedLowWatermark);
       return this.changeStreamMutationBuilder.build();

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Heartbeat.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Heartbeat.java
@@ -18,9 +18,9 @@ package com.google.cloud.bigtable.data.v2.models;
 import com.google.api.core.InternalApi;
 import com.google.auto.value.AutoValue;
 import com.google.bigtable.v2.ReadChangeStreamResponse;
-import com.google.protobuf.util.Timestamps;
 import java.io.Serializable;
 import javax.annotation.Nonnull;
+import org.threeten.bp.Instant;
 
 /** A simple wrapper for {@link ReadChangeStreamResponse.Heartbeat}. */
 @InternalApi("Intended for use by the BigtableIO in apache/beam only.")
@@ -29,7 +29,7 @@ public abstract class Heartbeat implements ChangeStreamRecord, Serializable {
   private static final long serialVersionUID = 7316215828353608504L;
 
   private static Heartbeat create(
-      ChangeStreamContinuationToken changeStreamContinuationToken, long estimatedLowWatermark) {
+      ChangeStreamContinuationToken changeStreamContinuationToken, Instant estimatedLowWatermark) {
     return new AutoValue_Heartbeat(changeStreamContinuationToken, estimatedLowWatermark);
   }
 
@@ -37,12 +37,14 @@ public abstract class Heartbeat implements ChangeStreamRecord, Serializable {
   static Heartbeat fromProto(@Nonnull ReadChangeStreamResponse.Heartbeat heartbeat) {
     return create(
         ChangeStreamContinuationToken.fromProto(heartbeat.getContinuationToken()),
-        Timestamps.toNanos(heartbeat.getEstimatedLowWatermark()));
+        Instant.ofEpochSecond(
+            heartbeat.getEstimatedLowWatermark().getSeconds(),
+            heartbeat.getEstimatedLowWatermark().getNanos()));
   }
 
   @InternalApi("Intended for use by the BigtableIO in apache/beam only.")
   public abstract ChangeStreamContinuationToken getChangeStreamContinuationToken();
 
   @InternalApi("Intended for use by the BigtableIO in apache/beam only.")
-  public abstract long getEstimatedLowWatermark();
+  public abstract Instant getEstimatedLowWatermark();
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ReadChangeStreamQuery.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ReadChangeStreamQuery.java
@@ -28,7 +28,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
-import com.google.protobuf.util.Timestamps;
+import com.google.protobuf.Timestamp;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -36,6 +36,7 @@ import java.io.Serializable;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.threeten.bp.Instant;
 
 /** A simple wrapper to construct a query for the ReadChangeStream RPC. */
 @InternalApi("Intended for use by the BigtableIO in apache/beam only.")
@@ -142,18 +143,26 @@ public final class ReadChangeStreamQuery implements Serializable, Cloneable {
     return streamPartition(rangeBuilder.build());
   }
 
-  /** Sets the startTime(Nanosecond) to read the change stream. */
-  public ReadChangeStreamQuery startTime(long value) {
+  /** Sets the startTime to read the change stream. */
+  public ReadChangeStreamQuery startTime(Instant value) {
     Preconditions.checkState(
         !builder.hasContinuationTokens(),
         "startTime and continuationTokens can't be specified together");
-    builder.setStartTime(Timestamps.fromNanos(value));
+    builder.setStartTime(
+        Timestamp.newBuilder()
+            .setSeconds(value.getEpochSecond())
+            .setNanos(value.getNano())
+            .build());
     return this;
   }
 
-  /** Sets the endTime(Nanosecond) to read the change stream. */
-  public ReadChangeStreamQuery endTime(long value) {
-    builder.setEndTime(Timestamps.fromNanos(value));
+  /** Sets the endTime to read the change stream. */
+  public ReadChangeStreamQuery endTime(Instant value) {
+    builder.setEndTime(
+        Timestamp.newBuilder()
+            .setSeconds(value.getEpochSecond())
+            .setNanos(value.getNano())
+            .build());
     return this;
   }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/common/StatusTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/common/StatusTest.java
@@ -19,6 +19,11 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.rpc.Code;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -88,5 +93,24 @@ public class StatusTest {
     assertThat(model.toProto()).isEqualTo(proto);
 
     assertThat(model.toString()).isEqualTo(proto.toString());
+  }
+
+  @Test
+  public void testSerialization() throws IOException, ClassNotFoundException {
+    com.google.rpc.Status proto =
+        com.google.rpc.Status.newBuilder()
+            .setCode(Code.UNAVAILABLE.getNumber())
+            .setMessage("some message")
+            .build();
+
+    Status model = Status.fromProto(proto);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(bos);
+    oos.writeObject(model);
+    oos.close();
+    ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bos.toByteArray()));
+    Status actual = (Status) ois.readObject();
+    assertThat(actual).isEqualTo(model);
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamMutationTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamMutationTest.java
@@ -32,6 +32,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.threeten.bp.Instant;
 
 @RunWith(JUnit4.class)
 public class ChangeStreamMutationTest {
@@ -41,8 +42,8 @@ public class ChangeStreamMutationTest {
   private static final String APP_PROFILE_ID = "fake-profile";
   private static final RequestContext REQUEST_CONTEXT =
       RequestContext.create(PROJECT_ID, INSTANCE_ID, APP_PROFILE_ID);
-  private static final long FAKE_COMMIT_TIMESTAMP = 1000L;
-  private static final long FAKE_LOW_WATERMARK = 2000L;
+  private static final Instant FAKE_COMMIT_TIMESTAMP = Instant.ofEpochSecond(0, 1000L);
+  private static final Instant FAKE_LOW_WATERMARK = Instant.ofEpochSecond(0, 2000L);
 
   @Test
   public void userInitiatedMutationTest() throws IOException, ClassNotFoundException {

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamRecordTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamRecordTest.java
@@ -24,7 +24,6 @@ import com.google.bigtable.v2.StreamPartition;
 import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Timestamps;
 import com.google.rpc.Status;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -34,6 +33,7 @@ import java.io.ObjectOutputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.threeten.bp.Instant;
 
 @RunWith(JUnit4.class)
 public class ChangeStreamRecordTest {
@@ -121,7 +121,7 @@ public class ChangeStreamRecordTest {
     Heartbeat actualHeartbeat = Heartbeat.fromProto(heartbeatProto);
 
     assertThat(actualHeartbeat.getEstimatedLowWatermark())
-        .isEqualTo(Timestamps.toNanos(lowWatermark));
+        .isEqualTo(Instant.ofEpochSecond(lowWatermark.getSeconds(), lowWatermark.getNanos()));
     assertThat(actualHeartbeat.getChangeStreamContinuationToken().getPartition())
         .isEqualTo(ByteStringRange.create(rowRange.getStartKeyClosed(), rowRange.getEndKeyOpen()));
     assertThat(actualHeartbeat.getChangeStreamContinuationToken().getToken()).isEqualTo(token);
@@ -158,7 +158,7 @@ public class ChangeStreamRecordTest {
             .build();
     CloseStream actualCloseStream = CloseStream.fromProto(closeStreamProto);
 
-    assertThat(status).isEqualTo(actualCloseStream.getStatus());
+    assertThat(status).isEqualTo(actualCloseStream.getStatus().toProto());
     assertThat(actualCloseStream.getChangeStreamContinuationTokens().get(0).getPartition())
         .isEqualTo(
             ByteStringRange.create(rowRange1.getStartKeyClosed(), rowRange1.getEndKeyOpen()));

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/DefaultChangeStreamRecordAdapterTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/DefaultChangeStreamRecordAdapterTest.java
@@ -23,7 +23,7 @@ import com.google.bigtable.v2.StreamContinuationToken;
 import com.google.bigtable.v2.TimestampRange;
 import com.google.cloud.bigtable.data.v2.models.ChangeStreamRecordAdapter.ChangeStreamRecordBuilder;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.util.Timestamps;
+import com.google.protobuf.Timestamp;
 import com.google.rpc.Status;
 import org.junit.Assert;
 import org.junit.Before;
@@ -32,14 +32,15 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.threeten.bp.Instant;
 
 @RunWith(JUnit4.class)
 public class DefaultChangeStreamRecordAdapterTest {
 
   private final DefaultChangeStreamRecordAdapter adapter = new DefaultChangeStreamRecordAdapter();
   private ChangeStreamRecordBuilder<ChangeStreamRecord> changeStreamRecordBuilder;
-  private static final long FAKE_COMMIT_TIMESTAMP = 1000L;
-  private static final long FAKE_LOW_WATERMARK = 2000L;
+  private static final Instant FAKE_COMMIT_TIMESTAMP = Instant.ofEpochSecond(0L, 1000L);
+  private static final Instant FAKE_LOW_WATERMARK = Instant.ofEpochSecond(0L, 2000L);
 
   @Rule public ExpectedException expect = ExpectedException.none();
 
@@ -70,7 +71,10 @@ public class DefaultChangeStreamRecordAdapterTest {
     ChangeStreamRecord heartbeatRecord =
         Heartbeat.fromProto(
             ReadChangeStreamResponse.Heartbeat.newBuilder()
-                .setEstimatedLowWatermark(Timestamps.fromNanos(FAKE_LOW_WATERMARK))
+                .setEstimatedLowWatermark(
+                    Timestamp.newBuilder()
+                        .setSeconds(FAKE_LOW_WATERMARK.getEpochSecond())
+                        .setNanos(FAKE_LOW_WATERMARK.getNano()))
                 .setContinuationToken(
                     StreamContinuationToken.newBuilder().setToken("heartbeat-token").build())
                 .build());
@@ -127,7 +131,11 @@ public class DefaultChangeStreamRecordAdapterTest {
   public void heartbeatTest() {
     ReadChangeStreamResponse.Heartbeat expectedHeartbeat =
         ReadChangeStreamResponse.Heartbeat.newBuilder()
-            .setEstimatedLowWatermark(Timestamps.fromNanos(FAKE_LOW_WATERMARK))
+            .setEstimatedLowWatermark(
+                Timestamp.newBuilder()
+                    .setSeconds(FAKE_LOW_WATERMARK.getEpochSecond())
+                    .setNanos(FAKE_LOW_WATERMARK.getNano())
+                    .build())
             .setContinuationToken(
                 StreamContinuationToken.newBuilder().setToken("random-token").build())
             .build();

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ReadChangeStreamQueryTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ReadChangeStreamQueryTest.java
@@ -28,7 +28,7 @@ import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
-import com.google.protobuf.util.Timestamps;
+import com.google.protobuf.Timestamp;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.threeten.bp.Instant;
 
 @RunWith(JUnit4.class)
 public class ReadChangeStreamQueryTest {
@@ -49,8 +50,8 @@ public class ReadChangeStreamQueryTest {
   private static final String TABLE_ID = "fake-table";
   private static final String APP_PROFILE_ID = "fake-profile-id";
   private RequestContext requestContext;
-  private static final long FAKE_START_TIME = 1000L;
-  private static final long FAKE_END_TIME = 2000L;
+  private static final Instant FAKE_START_TIME = Instant.ofEpochSecond(1L, 1000L);
+  private static final Instant FAKE_END_TIME = Instant.ofEpochSecond(1L, 2000L);
 
   @Rule public ExpectedException expect = ExpectedException.none();
 
@@ -123,7 +124,11 @@ public class ReadChangeStreamQueryTest {
     ReadChangeStreamQuery query = ReadChangeStreamQuery.create(TABLE_ID).startTime(FAKE_START_TIME);
 
     Builder expectedProto =
-        expectedProtoBuilder().setStartTime(Timestamps.fromNanos(FAKE_START_TIME));
+        expectedProtoBuilder()
+            .setStartTime(
+                Timestamp.newBuilder()
+                    .setSeconds(FAKE_START_TIME.getEpochSecond())
+                    .setNanos(FAKE_START_TIME.getNano()));
 
     ReadChangeStreamRequest actualProto = query.toProto(requestContext);
     assertThat(actualProto).isEqualTo(expectedProto.build());
@@ -133,7 +138,12 @@ public class ReadChangeStreamQueryTest {
   public void endTimeTest() {
     ReadChangeStreamQuery query = ReadChangeStreamQuery.create(TABLE_ID).endTime(FAKE_END_TIME);
 
-    Builder expectedProto = expectedProtoBuilder().setEndTime(Timestamps.fromNanos(FAKE_END_TIME));
+    Builder expectedProto =
+        expectedProtoBuilder()
+            .setEndTime(
+                Timestamp.newBuilder()
+                    .setSeconds(FAKE_END_TIME.getEpochSecond())
+                    .setNanos(FAKE_END_TIME.getNano()));
 
     ReadChangeStreamRequest actualProto = query.toProto(requestContext);
     assertThat(actualProto).isEqualTo(expectedProto.build());
@@ -267,7 +277,10 @@ public class ReadChangeStreamQueryTest {
                             .setEndKeyClosed(ByteString.copyFromUtf8(""))
                             .build()))
             .setContinuationTokens(StreamContinuationTokens.newBuilder().addTokens(token).build())
-            .setEndTime(Timestamps.fromNanos(FAKE_END_TIME))
+            .setEndTime(
+                Timestamp.newBuilder()
+                    .setSeconds(FAKE_END_TIME.getEpochSecond())
+                    .setNanos(FAKE_END_TIME.getNano()))
             .setHeartbeatDuration(Duration.newBuilder().setSeconds(5).build())
             .build();
     ReadChangeStreamQuery query = ReadChangeStreamQuery.fromProto(request);
@@ -304,9 +317,11 @@ public class ReadChangeStreamQueryTest {
     assertThat(ReadChangeStreamQuery.create(TABLE_ID).streamPartition("begin-1", "end-1"))
         .isNotEqualTo(ReadChangeStreamQuery.create(TABLE_ID).streamPartition("begin-2", "end-1"));
     assertThat(ReadChangeStreamQuery.create(TABLE_ID).startTime(FAKE_START_TIME))
-        .isNotEqualTo(ReadChangeStreamQuery.create(TABLE_ID).startTime(1001L));
+        .isNotEqualTo(
+            ReadChangeStreamQuery.create(TABLE_ID).startTime(Instant.ofEpochSecond(1L, 1001L)));
     assertThat(ReadChangeStreamQuery.create(TABLE_ID).endTime(FAKE_END_TIME))
-        .isNotEqualTo(ReadChangeStreamQuery.create(TABLE_ID).endTime(1001L));
+        .isNotEqualTo(
+            ReadChangeStreamQuery.create(TABLE_ID).endTime(Instant.ofEpochSecond(1L, 1001L)));
     assertThat(
             ReadChangeStreamQuery.create(TABLE_ID)
                 .heartbeatDuration(java.time.Duration.ofSeconds(5)))
@@ -349,7 +364,10 @@ public class ReadChangeStreamQueryTest {
                             .build()))
             .setContinuationTokens(
                 StreamContinuationTokens.newBuilder().addTokens(tokenProto).build())
-            .setEndTime(Timestamps.fromNanos(FAKE_END_TIME))
+            .setEndTime(
+                Timestamp.newBuilder()
+                    .setSeconds(FAKE_END_TIME.getEpochSecond())
+                    .setNanos(FAKE_END_TIME.getNano()))
             .setHeartbeatDuration(Duration.newBuilder().setSeconds(5).build())
             .build();
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/ChangeStreamRecordMergingCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/ChangeStreamRecordMergingCallableTest.java
@@ -32,7 +32,6 @@ import com.google.cloud.bigtable.gaxx.testing.FakeStreamingApi;
 import com.google.cloud.bigtable.gaxx.testing.FakeStreamingApi.ServerStreamingStashCallable;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Timestamps;
 import com.google.rpc.Status;
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +39,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.threeten.bp.Instant;
 
 /**
  * Additional tests in addition to {@link ReadChangeStreamMergingAcceptanceTest}.
@@ -81,7 +81,10 @@ public class ChangeStreamRecordMergingCallableTest {
     assertThat(heartbeat.getChangeStreamContinuationToken().getToken())
         .isEqualTo(heartbeatProto.getContinuationToken().getToken());
     assertThat(heartbeat.getEstimatedLowWatermark())
-        .isEqualTo(Timestamps.toNanos(heartbeatProto.getEstimatedLowWatermark()));
+        .isEqualTo(
+            Instant.ofEpochSecond(
+                heartbeatProto.getEstimatedLowWatermark().getSeconds(),
+                heartbeatProto.getEstimatedLowWatermark().getNanos()));
   }
 
   @Test
@@ -116,7 +119,7 @@ public class ChangeStreamRecordMergingCallableTest {
     ChangeStreamRecord record = results.get(0);
     Assert.assertTrue(record instanceof CloseStream);
     CloseStream closeStream = (CloseStream) record;
-    assertThat(closeStream.getStatus()).isEqualTo(closeStreamProto.getStatus());
+    assertThat(closeStream.getStatus().toProto()).isEqualTo(closeStreamProto.getStatus());
     assertThat(closeStream.getChangeStreamContinuationTokens().size()).isEqualTo(1);
     ChangeStreamContinuationToken changeStreamContinuationToken =
         closeStream.getChangeStreamContinuationTokens().get(0);

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/ReadChangeStreamMergingAcceptanceTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/ReadChangeStreamMergingAcceptanceTest.java
@@ -43,8 +43,8 @@ import com.google.cloud.bigtable.gaxx.testing.FakeStreamingApi;
 import com.google.cloud.conformance.bigtable.v2.ChangeStreamTestDefinition.ChangeStreamTestFile;
 import com.google.cloud.conformance.bigtable.v2.ChangeStreamTestDefinition.ReadChangeStreamTest;
 import com.google.common.base.CaseFormat;
+import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.JsonFormat;
-import com.google.protobuf.util.Timestamps;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -142,7 +142,10 @@ public class ReadChangeStreamMergingAcceptanceTest {
                           .setToken(heartbeat.getChangeStreamContinuationToken().getToken())
                           .build())
                   .setEstimatedLowWatermark(
-                      Timestamps.fromNanos(heartbeat.getEstimatedLowWatermark()))
+                      Timestamp.newBuilder()
+                          .setSeconds(heartbeat.getEstimatedLowWatermark().getEpochSecond())
+                          .setNanos(heartbeat.getEstimatedLowWatermark().getNano())
+                          .build())
                   .build();
           actualResults.add(
               ReadChangeStreamTest.Result.newBuilder()
@@ -154,7 +157,8 @@ public class ReadChangeStreamMergingAcceptanceTest {
         } else if (record instanceof CloseStream) {
           CloseStream closeStream = (CloseStream) record;
           ReadChangeStreamResponse.CloseStream.Builder builder =
-              ReadChangeStreamResponse.CloseStream.newBuilder().setStatus(closeStream.getStatus());
+              ReadChangeStreamResponse.CloseStream.newBuilder()
+                  .setStatus(closeStream.getStatus().toProto());
           for (ChangeStreamContinuationToken token :
               closeStream.getChangeStreamContinuationTokens()) {
             builder.addContinuationTokens(
@@ -194,11 +198,17 @@ public class ReadChangeStreamMergingAcceptanceTest {
             builder.setSourceClusterId(changeStreamMutation.getSourceClusterId());
           }
           builder.setCommitTimestamp(
-              Timestamps.fromNanos(changeStreamMutation.getCommitTimestamp()));
+              Timestamp.newBuilder()
+                  .setSeconds(changeStreamMutation.getCommitTimestamp().getEpochSecond())
+                  .setNanos(changeStreamMutation.getCommitTimestamp().getNano())
+                  .build());
           builder.setTiebreaker(changeStreamMutation.getTieBreaker());
           builder.setToken(changeStreamMutation.getToken());
           builder.setEstimatedLowWatermark(
-              Timestamps.fromNanos(changeStreamMutation.getEstimatedLowWatermark()));
+              Timestamp.newBuilder()
+                  .setSeconds(changeStreamMutation.getEstimatedLowWatermark().getEpochSecond())
+                  .setNanos(changeStreamMutation.getEstimatedLowWatermark().getNano())
+                  .build());
           for (Entry entry : changeStreamMutation.getEntries()) {
             if (entry instanceof DeleteFamily) {
               DeleteFamily deleteFamily = (DeleteFamily) entry;

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/ReadChangeStreamRetryTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/ReadChangeStreamRetryTest.java
@@ -45,7 +45,6 @@ import com.google.common.collect.Queues;
 import com.google.common.truth.Truth;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Timestamps;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
@@ -63,6 +62,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.threeten.bp.Instant;
 
 @RunWith(JUnit4.class)
 public class ReadChangeStreamRetryTest {
@@ -74,7 +74,7 @@ public class ReadChangeStreamRetryTest {
   private static final String HEARTBEAT_TOKEN = "heartbeat-token";
   private static final String CLOSE_STREAM_TOKEN = "close-stream-token";
   private static final String DATA_CHANGE_TOKEN = "data-change-token";
-  private static final long REQUEST_START_TIME = 1000L;
+  private static final Instant REQUEST_START_TIME = Instant.ofEpochSecond(0L, 1000L);
 
   @Rule public GrpcServerRule serverRule = new GrpcServerRule();
   private TestBigtableService service;
@@ -446,7 +446,10 @@ public class ReadChangeStreamRetryTest {
     }
 
     RpcExpectation expectInitialRequest() {
-      requestBuilder.setStartTime(Timestamps.fromNanos(REQUEST_START_TIME));
+      requestBuilder.setStartTime(
+          Timestamp.newBuilder()
+              .setSeconds(REQUEST_START_TIME.getEpochSecond())
+              .setNanos(REQUEST_START_TIME.getNano()));
       return this;
     }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/ReadChangeStreamUserCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/changestream/ReadChangeStreamUserCallableTest.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.threeten.bp.Instant;
 
 @RunWith(JUnit4.class)
 public class ReadChangeStreamUserCallableTest {
@@ -40,8 +41,8 @@ public class ReadChangeStreamUserCallableTest {
     ReadChangeStreamQuery query =
         ReadChangeStreamQuery.create("fake-table")
             .streamPartition("begin", "end")
-            .startTime(1000L)
-            .endTime(2000L)
+            .startTime(Instant.ofEpochSecond(0L, 1000L))
+            .endTime(Instant.ofEpochSecond(0L, 2000L))
             .heartbeatDuration(Duration.ofSeconds(1));
     callable.call(query);
     Truth.assertThat(innerCallable.getActualRequest()).isEqualTo(query.toProto(REQUEST_CONTEXT));


### PR DESCRIPTION
Use org.threeten.bp.Instant for below fields:
- startTime
- endTime
- commitTimestamp
- estimatedLowWatermark

Use bigtable.common.Status for CloseStream::getStatus()

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
