### PR TITLE
deps: update shared deps to 3.3.0 and monitoring to 3.12.0

### DIFF
--- a/google-cloud-bigtable-deps-bom/pom.xml
+++ b/google-cloud-bigtable-deps-bom/pom.xml
@@ -66,14 +66,14 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-monitoring-bom</artifactId>
-        <version>3.11.0</version>
+        <version>3.12.0</version>
         <exclusions>
           <exclusion>
             <!-- using the perfmark version in opencensus -->

--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -39,7 +39,7 @@
 
     <!-- These are needed to compile the protobuf used by Changestream merging acceptance test. We have enforcer rule
      below to make sure that the versions here match the ones we pull in via the shared bom. -->
-    <grpc.version>1.52.1</grpc.version>
+    <grpc.version>1.53.0</grpc.version>
     <protobuf.version>3.21.12</protobuf.version>
     <protoc.version>${protobuf.version}</protoc.version>
   </properties>


### PR DESCRIPTION
This is a temporary manual update of dependencies until https://github.com/googleapis/java-bigtable/pull/1640 is merged
