### PR TITLE
fix: if new_partitions is size 0, do not enforce size check

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/CloseStream.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/CloseStream.java
@@ -48,7 +48,8 @@ public abstract class CloseStream implements ChangeStreamRecord, Serializable {
           !changeStreamContinuationTokens.isEmpty(),
           "A non-OK CloseStream should have continuation token(s).");
       Preconditions.checkState(
-          changeStreamContinuationTokens.size() == newPartitions.size(),
+          newPartitions.size() == 0
+              || changeStreamContinuationTokens.size() == newPartitions.size(),
           "Number of continuation tokens does not match number of new partitions.");
     }
     return new AutoValue_CloseStream(


### PR DESCRIPTION
Do not enforce new_partitions and change_stream_continuation_tokens to be the same size if new_partitions has size of 0 because Cloud Bigtable backend may not be updated to serve new_partitions field yet.

`new_partitions` is a new field and the backend may not be serving this field.

Change-Id: Id21c293b92c304f05b905ca8e8b3988b9241866e

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
