### PR TITLE
fix: Make ChangeStreamRecord interface serializable

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamRecord.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamRecord.java
@@ -16,10 +16,11 @@
 package com.google.cloud.bigtable.data.v2.models;
 
 import com.google.api.core.InternalApi;
+import java.io.Serializable;
 
 /**
  * Default representation of a change stream record, which can be a Heartbeat, a CloseStream, or a
  * logical mutation.
  */
 @InternalApi("Intended for use by the BigtableIO in apache/beam only.")
-public interface ChangeStreamRecord {}
+public interface ChangeStreamRecord extends Serializable {}


### PR DESCRIPTION
Make ChangeStreamRecord interface Serializable so that beam can create Coders for it by default.  ChangeStreamMutation, CloseStream, and Heartbeat all already implement Serializable.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
