### PR TITLE
feat: add experimental support for reverse scans public preview

### DIFF
--- a/google-cloud-bigtable/clirr-ignored-differences.xml
+++ b/google-cloud-bigtable/clirr-ignored-differences.xml
@@ -134,4 +134,15 @@
         <method>*</method>
         <to>*</to>
     </difference>
+    <!-- Removed methods in an internal class -->
+    <difference>
+        <differenceType>7002</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/internal/RowSetUtil</className>
+        <method>*</method>
+    </difference>
+    <difference>
+        <differenceType>7004</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/stub/readrows/RowMerger</className>
+        <method>*</method>
+    </difference>
 </differences>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/RowMergerUtil.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/RowMergerUtil.java
@@ -30,7 +30,7 @@ public class RowMergerUtil implements AutoCloseable {
 
   public RowMergerUtil() {
     RowBuilder<Row> rowBuilder = new DefaultRowAdapter().createRowBuilder();
-    merger = new RowMerger<>(rowBuilder);
+    merger = new RowMerger<>(rowBuilder, false);
   }
 
   @Override

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/readrows/ReadRowsResumptionStrategy.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/readrows/ReadRowsResumptionStrategy.java
@@ -85,7 +85,8 @@ public class ReadRowsResumptionStrategy<RowT>
       return originalRequest;
     }
 
-    RowSet remaining = RowSetUtil.split(originalRequest.getRows(), lastKey).getRight();
+    RowSet remaining =
+        RowSetUtil.erase(originalRequest.getRows(), lastKey, !originalRequest.getReversed());
 
     // Edge case: retrying a fulfilled request.
     // A fulfilled request is one that has had all of its row keys and ranges fulfilled, or if it

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/readrows/RowMerger.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/readrows/RowMerger.java
@@ -61,8 +61,8 @@ public class RowMerger<RowT> implements Reframer<RowT, ReadRowsResponse> {
   private final StateMachine<RowT> stateMachine;
   private Queue<RowT> mergedRows;
 
-  public RowMerger(RowBuilder<RowT> rowBuilder) {
-    stateMachine = new StateMachine<>(rowBuilder);
+  public RowMerger(RowBuilder<RowT> rowBuilder, boolean reversed) {
+    stateMachine = new StateMachine<>(rowBuilder, reversed);
     mergedRows = new ArrayDeque<>();
   }
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/readrows/RowMergingCallable.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/readrows/RowMergingCallable.java
@@ -49,7 +49,7 @@ public class RowMergingCallable<RowT> extends ServerStreamingCallable<ReadRowsRe
   public void call(
       ReadRowsRequest request, ResponseObserver<RowT> responseObserver, ApiCallContext context) {
     RowBuilder<RowT> rowBuilder = rowAdapter.createRowBuilder();
-    RowMerger<RowT> merger = new RowMerger<>(rowBuilder);
+    RowMerger<RowT> merger = new RowMerger<>(rowBuilder, request.getReversed());
     ReframingResponseObserver<ReadRowsResponse, RowT> innerObserver =
         new ReframingResponseObserver<>(responseObserver, merger);
     inner.call(request, innerObserver, context);

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/readrows/StateMachine.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/readrows/StateMachine.java
@@ -76,6 +76,7 @@ import java.util.List;
  */
 final class StateMachine<RowT> {
   private final RowBuilder<RowT> adapter;
+  private boolean reversed;
   private State currentState;
   private ByteString lastCompleteRowKey;
 
@@ -102,9 +103,11 @@ final class StateMachine<RowT> {
    * Initialize a new state machine that's ready for a new row.
    *
    * @param adapter The adapter that will build the final row.
+   * @param reversed
    */
-  StateMachine(RowBuilder<RowT> adapter) {
+  StateMachine(RowBuilder<RowT> adapter, boolean reversed) {
     this.adapter = adapter;
+    this.reversed = reversed;
     reset();
   }
 
@@ -261,9 +264,18 @@ final class StateMachine<RowT> {
           validate(chunk.hasFamilyName(), "AWAITING_NEW_ROW: family missing");
           validate(chunk.hasQualifier(), "AWAITING_NEW_ROW: qualifier missing");
           if (lastCompleteRowKey != null) {
+
+            int cmp = ByteStringComparator.INSTANCE.compare(lastCompleteRowKey,
+                chunk.getRowKey());
+            String direction  = "increasing";
+            if (reversed) {
+              cmp *= -1;
+              direction = "decreasing";
+            }
+
             validate(
-                ByteStringComparator.INSTANCE.compare(lastCompleteRowKey, chunk.getRowKey()) < 0,
-                "AWAITING_NEW_ROW: key must be strictly increasing");
+                cmp < 0,
+                "AWAITING_NEW_ROW: key must be strictly " + direction);
           }
 
           rowKey = chunk.getRowKey();

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/RowSetUtilTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/RowSetUtilTest.java
@@ -36,37 +36,41 @@ public class RowSetUtilTest {
   @Test
   public void testSplitFullScan() {
     RowSet input = RowSet.getDefaultInstance();
-    RowSetUtil.Split split = RowSetUtil.split(input, ByteString.copyFromUtf8("g"));
 
-    assertThat(split.getLeft()).isEqualTo(parse("-g]"));
-    assertThat(split.getRight()).isEqualTo(parse("(g-"));
+    RowSet right = RowSetUtil.erase(input, ByteString.copyFromUtf8("g"), true);
+    assertThat(right).isEqualTo(parse("(g-"));
+
+    RowSet left = RowSetUtil.erase(input, ByteString.copyFromUtf8("g"), false);
+    assertThat(left).isEqualTo(parse("-g)"));
   }
 
   @Test
   public void testSplitAllLeft() {
-    RowSet input = parse("a,c,(a1-c],[a2-c],(a3-c),[a4-c)");
-    RowSetUtil.Split split = RowSetUtil.split(input, ByteString.copyFromUtf8("c"));
+    RowSet input = parse("a,(a1-c),[a2-c),(a3-c),[a4-c)");
+    RowSet left = RowSetUtil.erase(input, ByteString.copyFromUtf8("c"), false);
+    RowSet right = RowSetUtil.erase(input, ByteString.copyFromUtf8("c"), true);
 
-    assertThat(split.getLeft()).isEqualTo(input);
-    assertThat(split.getRight()).isNull();
+    assertThat(left).isEqualTo(input);
+    assertThat(right).isNull();
   }
 
   @Test
   public void testSplitAllRight() {
     RowSet input = parse("a1,c,(a-c],[a2-c],(a3-c),[a4-c)");
-    RowSetUtil.Split split = RowSetUtil.split(input, ByteString.copyFromUtf8("a"));
 
-    assertThat(split.getLeft()).isNull();
-    assertThat(split.getRight()).isEqualTo(input);
+    assertThat(RowSetUtil.erase(input, ByteString.copyFromUtf8("a"), true)).isEqualTo(input);
+    assertThat(RowSetUtil.erase(input, ByteString.copyFromUtf8("a"), false)).isNull();
   }
 
   @Test
   public void testSplit() {
-    RowSet input = parse("a1,c,(a1-c],[a2-c],(a3-c),[a4-c)");
-    RowSetUtil.Split split = RowSetUtil.split(input, ByteString.copyFromUtf8("b"));
+    RowSet input = parse("a1,c,(a1-c],[a2-c],(a3-c),[a4-c),[b-z],(b-y]");
 
-    assertThat(split.getLeft()).isEqualTo(parse("a1,(a1-b],[a2-b],(a3-b],[a4-b]"));
-    assertThat(split.getRight()).isEqualTo(parse("c,(b-c],(b-c],(b-c),(b-c)"));
+    RowSet before = RowSetUtil.erase(input, ByteString.copyFromUtf8("b"), false);
+    RowSet after = RowSetUtil.erase(input, ByteString.copyFromUtf8("b"), true);
+
+    assertThat(before).isEqualTo(parse("a1,(a1-b),[a2-b),(a3-b),[a4-b)"));
+    assertThat(after).isEqualTo(parse("c,(b-c],(b-c],(b-c),(b-c),(b-z],(b-y]"));
   }
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/ReadIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/ReadIT.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.data.v2.it;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
@@ -31,9 +32,11 @@ import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowCell;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.cloud.bigtable.test_helpers.env.EmulatorEnv;
 import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.truth.TruthJUnit;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
@@ -222,6 +225,87 @@ public class ReadIT {
                     Query.create(tableId)
                         .range(ByteStringRange.unbounded().startOpen(keyA).endOpen(keyZ)))))
         .isEmpty();
+  }
+
+  @Test
+  public void reversed() {
+    assume()
+        .withMessage("reverse scans are not supported in the emulator")
+        .that(testEnvRule.env())
+        .isNotInstanceOf(EmulatorEnv.class);
+    BigtableDataClient client = testEnvRule.env().getDataClient();
+    String tableId = testEnvRule.env().getTableId();
+    String familyId = testEnvRule.env().getFamilyId();
+    String uniqueKey = prefix + "-rev-queries";
+    String keyA = uniqueKey + "-" + "a";
+    String keyB = uniqueKey + "-" + "b";
+    String keyC = uniqueKey + "-" + "c";
+
+    long timestampMicros = System.currentTimeMillis() * 1_000;
+
+    client.bulkMutateRows(
+        BulkMutation.create(tableId)
+            .add(RowMutationEntry.create(keyA).setCell(familyId, "", timestampMicros, "A"))
+            .add(RowMutationEntry.create(keyB).setCell(familyId, "", timestampMicros, "A"))
+            .add(RowMutationEntry.create(keyC).setCell(familyId, "", timestampMicros, "Z")));
+
+    Row expectedRowA =
+        Row.create(
+            ByteString.copyFromUtf8(keyA),
+            ImmutableList.of(
+                RowCell.create(
+                    testEnvRule.env().getFamilyId(),
+                    ByteString.copyFromUtf8(""),
+                    timestampMicros,
+                    ImmutableList.<String>of(),
+                    ByteString.copyFromUtf8("A"))));
+
+    Row expectedRowB =
+        Row.create(
+            ByteString.copyFromUtf8(keyB),
+            ImmutableList.of(
+                RowCell.create(
+                    testEnvRule.env().getFamilyId(),
+                    ByteString.copyFromUtf8(""),
+                    timestampMicros,
+                    ImmutableList.<String>of(),
+                    ByteString.copyFromUtf8("B"))));
+    Row expectedRowC =
+        Row.create(
+            ByteString.copyFromUtf8(keyB),
+            ImmutableList.of(
+                RowCell.create(
+                    testEnvRule.env().getFamilyId(),
+                    ByteString.copyFromUtf8(""),
+                    timestampMicros,
+                    ImmutableList.<String>of(),
+                    ByteString.copyFromUtf8("C"))));
+
+    assertThat(
+        ImmutableList.copyOf(
+            client.readRows(
+                Query.create(tableId)
+                    .reversed(true)
+                    .range(ByteStringRange.prefix(uniqueKey))))
+    ).containsExactly(expectedRowC, expectedRowB, expectedRowA).inOrder();
+
+    assertThat(
+        ImmutableList.copyOf(
+            client.readRows(
+                Query.create(tableId)
+                    .reversed(true)
+                    .range(ByteStringRange.prefix(uniqueKey))
+                    .limit(2)))
+    ).containsExactly(expectedRowC, expectedRowB).inOrder();
+
+    assertThat(
+        ImmutableList.copyOf(
+            client.readRows(
+                Query.create(tableId)
+                    .reversed(true)
+                    .range(ByteStringRange.unbounded().endClosed(keyC))
+                    .limit(2)))
+    ).containsExactly(expectedRowC, expectedRowB).inOrder();
   }
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/QueryTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/QueryTest.java
@@ -505,4 +505,11 @@ public class QueryTest {
 
     assertThat(queryPaginator.advance(ByteString.EMPTY)).isFalse();
   }
+
+  @Test
+  public void testQueryReversed() {
+    Query query = Query.create(TABLE_ID).reversed(true);
+    assertThat(query.toProto(requestContext))
+        .isEqualTo(expectedProtoBuilder().setReversed(true).build());
+  }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/readrows/StateMachineTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/readrows/StateMachineTest.java
@@ -34,7 +34,7 @@ public class StateMachineTest {
 
   @Before
   public void setUp() throws Exception {
-    stateMachine = new StateMachine<>(new DefaultRowAdapter().createRowBuilder());
+    stateMachine = new StateMachine<>(new DefaultRowAdapter().createRowBuilder(), false);
   }
 
   @Test

--- a/samples/snippets/src/main/java/com/example/bigtable/Reads.java
+++ b/samples/snippets/src/main/java/com/example/bigtable/Reads.java
@@ -24,6 +24,7 @@ import com.google.api.gax.rpc.ServerStream;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowCell;
 import java.io.IOException;
@@ -199,6 +200,39 @@ public class Reads {
     }
   }
   // [END bigtable_reads_prefix]
+
+  // [START bigtable_reverse_scan]
+  public static void readRowsReversed() {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "my-project-id";
+    String instanceId = "my-instance-id";
+    String tableId = "mobile-time-series";
+    readPrefix(projectId, instanceId, tableId);
+  }
+
+  public static void readRowsReversed(String projectId, String instanceId, String tableId) {
+    // Initialize client that will be used to send requests. This client only needs to be created
+    // once, and can be reused for multiple requests. After completing all of your requests, call
+    // the "close" method on the client to safely clean up any remaining background resources.
+    try (BigtableDataClient dataClient = BigtableDataClient.create(projectId, instanceId)) {
+      Query query = Query.create(tableId)
+          .reversed(true)
+          .limit(2)
+          .prefix("phone#4c410523")
+          .range(ByteStringRange.unbounded()
+              .startClosed("phone#5c10102")
+              .endClosed("phone#5c10102")
+          );
+      ServerStream<Row> rows = dataClient.readRows(query);
+      for (Row row : rows) {
+        printRow(row);
+      }
+    } catch (IOException e) {
+      System.out.println(
+          "Unable to initialize service client, as a network error occurred: \n" + e.toString());
+    }
+  }
+  // [END bigtable_reverse_scan]
 
   // [START bigtable_reads_filter]
   public static void readFilter() {

--- a/samples/snippets/src/test/java/com/example/bigtable/ReadsTest.java
+++ b/samples/snippets/src/test/java/com/example/bigtable/ReadsTest.java
@@ -187,6 +187,37 @@ public class ReadsTest extends MobileTimeSeriesBaseTest {
   }
 
   @Test
+  public void testReadRowsReversed() {
+    Reads.readRowsReversed(projectId, instanceId, TABLE_ID);
+    String output = bout.toString();
+
+    assertThat(output)
+        .contains(
+            String.format(
+                "Reading data for phone#5c10102#20190502\n"
+                    + "Column Family stats_summary\n"
+                    + "\tconnected_cell: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001 @%1$s\n"
+                    + "\tconnected_wifi: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000 @%1$s\n"
+                    + "\tos_build: PQ2A.190406.000 @%1$s"
+                    + "Reading data for phone#5c10102#20190501\n"
+                    + "Column Family stats_summary\n"
+                    + "\tconnected_cell: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001 @%1$s\n"
+                    + "\tconnected_wifi: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001 @%1$s\n"
+                    + "\tos_build: PQ2A.190401.002 @%1$s\n\n"
+                    + "Reading data for phone#4c410523#20190505\n"
+                    + "Column Family stats_summary\n"
+                    + "\tconnected_cell: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000 @%1$s\n"
+                    + "\tconnected_wifi: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001 @%1$s\n"
+                    + "\tos_build: PQ2A.190406.000 @%1$s\n\n"
+                    + "Reading data for phone#4c410523#20190502\n"
+                    + "Column Family stats_summary\n"
+                    + "\tconnected_cell: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001 @%1$s\n"
+                    + "\tconnected_wifi: \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001 @%1$s\n"
+                    + "\tos_build: PQ2A.190405.004 @%1$s\n\n",
+                TIMESTAMP));
+  }
+
+  @Test
   public void testReadFilter() {
     Reads.readFilter(projectId, instanceId, TABLE_ID);
 


### PR DESCRIPTION
This adds a reversed boolean to Query, which will allow endusers to stream rows in reverse order.

Example:
```java
Query query = Query.create("alphabet").range("a", "z").limit(3);
ServerStream<Row> results = client.readRows(query);

for (Row row : results) {
  System.out.println(row.getKey().toStringUtf8());
}
// Prints z, y, x
```
This its currently blocked on generated protos which will be autogenerated soon