### PR TITLE
chore(deps): update ghcr.io/graalvm/graalvm-ce docker tag to v22.3.2

### DIFF
--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.0"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.2"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.0"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.2"
 }
 
 env_vars: {


### PR DESCRIPTION
Update was made in synthtool but not propagated to bigtable because of an [owlbot exclusion](https://github.com/googleapis/java-bigtable/blob/722c6c58e42c51ac414a7e189c711e844447b9ce/owlbot.py#L100-L101). 