### PR TITLE
chore: remove renovate grouping for test protoc and grpc dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,14 +71,6 @@
       ],
       "groupName": "jackson dependencies"
     },
-    {
-      "packagePatterns": [
-        "^com.google.cloud:google-cloud-shared-dependencies",
-        "^com.google.protobuf:protoc",
-        "^io.grpc:protoc-gen-grpc-java"
-      ],
-      "groupName": "shared dependencies"
-    }
   ],
   "regexManagers": [
     {


### PR DESCRIPTION
This was done before we removed the enforcer check, so it is no longer required. Additionally, it's causing PRs which update shared dependencies to have a `test(deps)` prefix rather than `deps`. Example: https://github.com/googleapis/java-bigtable/pull/1755
