### PR TITLE
deps: update shared dependencies to 3.12.0, monitoring to 3.21.0, update renovate config

### DIFF
--- a/google-cloud-bigtable-deps-bom/pom.xml
+++ b/google-cloud-bigtable-deps-bom/pom.xml
@@ -66,14 +66,14 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.11.0</version>
+        <version>3.12.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-monitoring-bom</artifactId>
-        <version>3.20.0</version>
+        <version>3.21.0</version>
         <exclusions>
           <exclusion>
             <!-- using the perfmark version in opencensus -->

--- a/renovate.json
+++ b/renovate.json
@@ -71,6 +71,13 @@
       ],
       "groupName": "jackson dependencies"
     },
+    {
+      "packagePatterns": [
+        "^com.google.cloud:google-cloud-shared-dependencies",
+        "^com.google.cloud:google-cloud-monitoring-bom"
+      ],
+      "groupName": "shared dependencies"
+    }
   ],
   "regexManagers": [
     {


### PR DESCRIPTION
Opening in favor of #1805 and #1806 which need to be updated together (otherwise the dependency check will fail). Adding this to the renovate config so it will be combined in one PR going forward.
