### PR TITLE
ci: javadoc on JDK 17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,18 @@ jobs:
     - run: .kokoro/build.sh
       env:
         JOB_TYPE: lint
+  javadoc:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: 17
+    - run: java -version
+    - run: .kokoro/build.sh
+      env:
+        JOB_TYPE: javadoc
   clirr:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{matrix.java}}
     - run: java -version
     - run: .kokoro/build.sh
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 8
-          distribution: zulu
+          distribution: temurin
       - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
         # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
         # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: zulu
+          distribution: temurin
       - run: .kokoro/build.sh
         env:
           JOB_TYPE: test
@@ -66,7 +66,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: 8
     - run: java -version
     - run: .kokoro/build.bat
@@ -81,7 +81,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: ${{matrix.java}}
     - run: java -version
     - run: .kokoro/dependencies.sh
@@ -91,7 +91,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: 11
     - run: java -version
     - run: .kokoro/build.sh
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: 17
     - run: java -version
     - run: .kokoro/build.sh
@@ -115,7 +115,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:
-        distribution: zulu
+        distribution: temurin
         java-version: 8
     - run: java -version
     - run: .kokoro/build.sh

--- a/pom.xml
+++ b/pom.xml
@@ -286,12 +286,6 @@
                         <sourceFileExclude>**/com/google/cloud/bigtable/data/v2/stub/readrows/**</sourceFileExclude>
                         <sourceFileExclude>**/com/google/cloud/bigtable/data/v2/stub/metrics/**</sourceFileExclude>
                     </sourceFileExcludes>
-
-                    <!-- Enable external linking -->
-                    <links>
-                        <link>https://googleapis.dev/java/gax/${gax.version}/</link>
-                        <link>https://googleapis.github.io/api-common-java/${google.api-common.version}/apidocs/</link>
-                    </links>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Javadoc is not tested on JDK 17 and it caused a problem.

```
[INFO] <<< maven-javadoc-plugin:3.5.0:javadoc (default-cli) < generate-sources @ google-cloud-bigtable-stats <<<
[INFO] 
[INFO] 
[INFO] --- maven-javadoc-plugin:3.5.0:javadoc (default-cli) @ google-cloud-bigtable-stats ---
[INFO] No previous run data found, generating javadoc.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Google Cloud Bigtable Parent 2.24.0 ................ SUCCESS [  2.393 s]
[INFO] google-cloud-bigtable-stats 2.24.0 ................. FAILURE [  2.912 s]
[INFO] proto-google-cloud-bigtable-v2 2.24.0 .............. SKIPPED
[INFO] grpc-google-cloud-bigtable-v2 2.24.0 ............... SKIPPED
[INFO] proto-google-cloud-bigtable-admin-v2 2.24.0 ........ SKIPPED
[INFO] grpc-google-cloud-bigtable-admin-v2 2.24.0 ......... SKIPPED
[INFO] google-cloud-bigtable-emulator-core 0.161.0 ........ SKIPPED
[INFO] Google Cloud Java - Bigtable Emulator 0.161.0 ...... SKIPPED
[INFO] Google Cloud Bigtable 2.24.0 ....................... SKIPPED
[INFO] Google Cloud Bigtable BOM 2.24.0 ................... SKIPPED
[INFO] google-cloud-bigtable-deps-bom 2.24.0 .............. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.245 s
[INFO] Finished at: 2023-06-27T18:22:24Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.5.0:javadoc (default-cli) on project google-cloud-bigtable-stats: An error has occurred in Javadoc report generation: 
Error:  Exit code: 1
Error: [ERROR] error: Malformed URL: [https://googleapis.dev/java/gax/${gax.version}/](https://googleapis.dev/java/gax/$%7Bgax.version%7D/) (java.net.URISyntaxException: Illegal character in path at index 33: [https://googleapis.dev/java/gax/${gax.version}/)](https://googleapis.dev/java/gax/$%7Bgax.version%7D/))
Error: [ERROR] error: Malformed URL: [https://googleapis.github.io/api-common-java/${google.api-common.version}/apidocs/](https://googleapis.github.io/api-common-java/$%7Bgoogle.api-common.version%7D/apidocs/) (java.net.URISyntaxException: Illegal character in path at index 46: [https://googleapis.github.io/api-common-java/${google.api-common.version}/apidocs/)](https://googleapis.github.io/api-common-java/$%7Bgoogle.api-common.version%7D/apidocs/))
Error: [ERROR] 2 errors
```