### PR TITLE
deps: update dependency com.google.cloud:google-cloud-shared-dependencies to v3.13.0

### DIFF
--- a/google-cloud-bigtable-deps-bom/pom.xml
+++ b/google-cloud-bigtable-deps-bom/pom.xml
@@ -66,7 +66,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>3.12.0</version>
+        <version>3.13.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -959,7 +959,6 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
     public EnhancedBigtableStubSettings build() {
       Preconditions.checkState(projectId != null, "Project id must be set");
       Preconditions.checkState(instanceId != null, "Instance id must be set");
-
       if (isRefreshingChannel) {
         Preconditions.checkArgument(
             getTransportChannelProvider() instanceof InstantiatingGrpcChannelProvider,

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableBatchingCallSettingsTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableBatchingCallSettingsTest.java
@@ -176,8 +176,8 @@ public class BigtableBatchingCallSettingsTest {
             BatchingSettings.newBuilder()
                 .setFlowControlSettings(
                     FlowControlSettings.newBuilder()
-                        .setMaxOutstandingElementCount(10L)
-                        .setMaxOutstandingRequestBytes(10L)
+                        .setMaxOutstandingElementCount(11L)
+                        .setMaxOutstandingRequestBytes(11L)
                         .build())
                 .setElementCountThreshold(10L)
                 .setRequestByteThreshold(10L)

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
@@ -207,8 +207,8 @@ public class BuiltinMetricsTracerTest {
                 .setDelayThreshold(Duration.ofHours(1))
                 .setFlowControlSettings(
                     FlowControlSettings.newBuilder()
-                        .setMaxOutstandingElementCount((long) batchElementCount)
-                        .setMaxOutstandingRequestBytes(1000L)
+                        .setMaxOutstandingElementCount((long) batchElementCount + 1)
+                        .setMaxOutstandingRequestBytes(1001L)
                         .build())
                 .build());
     stubSettingsBuilder.setTracerFactory(mockFactory);
@@ -477,6 +477,9 @@ public class BuiltinMetricsTracerTest {
       for (int i = 0; i < 6; i++) {
         batcher.add(RowMutationEntry.create("key").setCell("f", "q", "v"));
       }
+
+      // closing the batcher to trigger the third flush
+      batcher.close();
 
       int expectedNumRequests = 6 / batchElementCount;
       ArgumentCaptor<Long> throttledTime = ArgumentCaptor.forClass(Long.class);

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
+import com.google.api.gax.batching.BatchResource;
 import com.google.api.gax.batching.Batcher;
 import com.google.api.gax.batching.BatcherImpl;
 import com.google.api.gax.batching.BatchingDescriptor;
@@ -422,6 +423,8 @@ public class MetricsTracerTest {
   public void testBatchMutateRowsThrottledTime() throws Exception {
     FlowController flowController = Mockito.mock(FlowController.class);
     BatchingDescriptor batchingDescriptor = Mockito.mock(MutateRowsBatchingDescriptor.class);
+    when(batchingDescriptor.createResource(any())).thenReturn(new FakeBatchResource());
+    when(batchingDescriptor.createEmptyResource()).thenReturn(new FakeBatchResource());
     // Mock throttling
     final long throttled = 50;
     doAnswer(
@@ -485,5 +488,30 @@ public class MetricsTracerTest {
   @SuppressWarnings("unchecked")
   private static <T> StreamObserver<T> anyObserver(Class<T> returnType) {
     return (StreamObserver<T>) any(returnType);
+  }
+
+  private class FakeBatchResource implements BatchResource {
+
+    FakeBatchResource() {}
+
+    @Override
+    public BatchResource add(BatchResource resource) {
+      return new FakeBatchResource();
+    }
+
+    @Override
+    public long getElementCount() {
+      return 1;
+    }
+
+    @Override
+    public long getByteCount() {
+      return 1;
+    }
+
+    @Override
+    public boolean shouldFlush(long maxElementThreshold, long maxBytesThreshold) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
Update dependency to v3.13.0 and fix the tests since we changed the logic in BatcherImpl: https://github.com/googleapis/sdk-platform-java/pull/1790.

The shouldFlush logic changed from element >= maxElement to element > maxElement. This means if flow controller has the same element count threshold as the batch element threshold, the resource is going to get locked up. Fixing the condition when we build BatchCallSettings and the tests. 