### PR TITLE
ci: javadoc as a required check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -18,6 +18,7 @@ branchProtectionRules:
       - OwlBot Post Processor
       - 'Kokoro - Test: Java GraalVM Native Image'
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
+      - javadoc
   - pattern: 1.22.0-sp
     isAdminEnforced: true
     requiredApprovingReviewCount: 1


### PR DESCRIPTION
Manual configuration has been removed. Adding that back via sync-repo-settings.yaml.

