### PR TITLE
build: update docFX profile to enable overriding doclet path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,9 @@
     <profiles>
         <profile>
             <id>docFX</id>
+            <properties>
+                <docletPath>${env.KOKORO_GFILE_DIR}/java-docfx-doclet-1.9.0.jar</docletPath>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -316,7 +319,8 @@
                             <!-- This is the new way of publishing the doc to cloud.google.com -->
                             <doclet>com.microsoft.doclet.DocFxDoclet</doclet>
                             <useStandardDocletOptions>false</useStandardDocletOptions>
-                            <docletPath>${env.KOKORO_GFILE_DIR}/java-docfx-doclet-1.9.0.jar</docletPath>
+                            <!-- Enable overriding of default doclet path for testing -->
+                            <docletPath>${docletPath}</docletPath>
                             <additionalOptions>
                                 -outputpath ${project.build.directory}/docfx-yml
                                 -projectname ${artifactId}


### PR DESCRIPTION
As part of testing javadoc generation at time of libraries-bom publishing with a specific doclet version, we need a way to override the doclet path currently set in `docFX` profile. This update sets the default `docletPath` to the existing version, and enables an overridden path. 
