### PR TITLE
build: do not declare javadoc plugin version

### DIFF
--- a/grpc-google-cloud-bigtable-admin-v2/pom.xml
+++ b/grpc-google-cloud-bigtable-admin-v2/pom.xml
@@ -74,7 +74,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
         <configuration>
           <show>protected</show>
           <nohelp>true</nohelp>

--- a/grpc-google-cloud-bigtable-v2/pom.xml
+++ b/grpc-google-cloud-bigtable-v2/pom.xml
@@ -66,7 +66,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
         <configuration>
           <show>protected</show>
           <nohelp>true</nohelp>

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>aggregate</id>
@@ -314,7 +313,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.6.0</version>
                         <configuration>
                             <!-- This is the new way of publishing the doc to cloud.google.com -->
                             <doclet>com.microsoft.doclet.DocFxDoclet</doclet>


### PR DESCRIPTION
The maven-javadoc-plugin version is defined in the shared config pom.xml.
https://github.com/googleapis/java-shared-config/blob/778a547a09de71dbf9e5a42b155f12d15c319864/pom.xml#L472

The removal of the 4 lines corresponds to the lines touched by the recent RenovateBot: https://github.com/googleapis/java-bigtable/pull/1924/files
