### PR TITLE
chore(deps): manually updating the Libraries BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>26.20.0</version>
+      <version>26.25.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -29,7 +29,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.20.0</version>
+        <version>26.25.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -30,7 +30,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.20.0</version>
+        <version>26.25.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Somehow the RenovateBot stopped working for libraries-bom
in this repository. Troubleshooting:
https://github.com/googleapis/synthtool/issues/1844

Followed https://github.com/googleapis/java-bigtable/pull/1868/files to locate the files.

