### PR TITLE
fix: remove javadoc external link configuration (#1815)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,12 +286,6 @@
                         <sourceFileExclude>**/com/google/cloud/bigtable/data/v2/stub/readrows/**</sourceFileExclude>
                         <sourceFileExclude>**/com/google/cloud/bigtable/data/v2/stub/metrics/**</sourceFileExclude>
                     </sourceFileExcludes>
-
-                    <!-- Enable external linking -->
-                    <links>
-                        <link>https://googleapis.dev/java/gax/${gax.version}/</link>
-                        <link>https://googleapis.github.io/api-common-java/${google.api-common.version}/apidocs/</link>
-                    </links>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The undefined variable in the external link configuration fails JDK 17 builds.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
