### PR TITLE
feat: allow non default service account in DirectPath

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -656,7 +656,8 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
       sampleRowKeysSettings
           .setRetryableCodes(IDEMPOTENT_RETRY_CODES)
           .setRetrySettings(
-              IDEMPOTENT_RETRY_SETTINGS.toBuilder()
+              IDEMPOTENT_RETRY_SETTINGS
+                  .toBuilder()
                   .setInitialRpcTimeout(Duration.ofMinutes(5))
                   .setMaxRpcTimeout(Duration.ofMinutes(5))
                   .build());

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -329,7 +329,10 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
             Duration.ofSeconds(10)) // wait this long before considering the connection dead
         // Attempts direct access to CBT service over gRPC to improve throughput,
         // whether the attempt is allowed is totally controlled by service owner.
-        .setAttemptDirectPath(true);
+        .setAttemptDirectPath(true)
+        // Allow using non-default service account in DirectPath.
+        .setAllowNonDefaultServiceAccount(true);
+
   }
 
   @SuppressWarnings("WeakerAccess")

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -332,7 +332,6 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
         .setAttemptDirectPath(true)
         // Allow using non-default service account in DirectPath.
         .setAllowNonDefaultServiceAccount(true);
-
   }
 
   @SuppressWarnings("WeakerAccess")
@@ -657,8 +656,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
       sampleRowKeysSettings
           .setRetryableCodes(IDEMPOTENT_RETRY_CODES)
           .setRetrySettings(
-              IDEMPOTENT_RETRY_SETTINGS
-                  .toBuilder()
+              IDEMPOTENT_RETRY_SETTINGS.toBuilder()
                   .setInitialRpcTimeout(Duration.ofMinutes(5))
                   .setMaxRpcTimeout(Duration.ofMinutes(5))
                   .build());


### PR DESCRIPTION
Bigtable already sets the flag to allow non-default SA in DirectPath on the service side, we also need to set the option on the client side to make this feature work. 
Related Spanner PR: https://github.com/googleapis/java-spanner/pull/2635.