### PR TITLE
chore: add an unmanaged dependency check

### DIFF
--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -23,4 +23,4 @@ jobs:
     - name: Unmanaged dependency check
       uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@feat/unmanaged-dependency-check
       with:
-        bom-path: google-cloud-bigtable/pom.xml
+        bom-path: google-cloud-bigtable-bom/pom.xml

--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -22,3 +22,4 @@ jobs:
       uses: googleapis/sdk-platform-java@feat/unmanaged-dependency-check
       with:
         bom-path: google-cloud-bigtable-bom/pom.xml
+      working-directory: java-shared-dependencies/unmanaged-dependency-check

--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -23,4 +23,4 @@ jobs:
     - name: Unmanaged dependency check
       uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@feat/unmanaged-dependency-check
       with:
-        bom-path: google-cloud-bigtable-bom/pom.xml
+        bom-path: google-cloud-bigtable-deps-bom/pom.xml

--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -11,13 +11,14 @@ jobs:
         distribution: temurin
         java-version: 11
     - name: Install modules
-      run: mvn install -B -V -ntp \
-            -DskipTests=true \
-            -Dclirr.skip=true \
-            -Denforcer.skip=true \
-            -Dmaven.javadoc.skip=true \
-            -Dgcloud.download.skip=true \
-            -T 1C
+      run: |
+        mvn -B -V -ntp -DskipTests=true \
+        -Dclirr.skip=true \
+        -Denforcer.skip=true \
+        -Dmaven.javadoc.skip=true \
+        -Dgcloud.download.skip=true \
+        -T 1C \
+        clean install
     - name: Unmanaged dependency check
       uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@feat/unmanaged-dependency-check
       with:

--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -1,0 +1,24 @@
+on:
+  pull_request:
+name: Unmanaged dependency check
+jobs:
+  checkstyle:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 11
+    - name: Install modules
+      run: mvn install -B -V -ntp \
+            -DskipTests=true \
+            -Dclirr.skip=true \
+            -Denforcer.skip=true \
+            -Dmaven.javadoc.skip=true \
+            -Dgcloud.download.skip=true \
+            -T 1C
+    - name: Unmanaged dependency check
+      uses: googleapis/sdk-platform-java@feat/unmanaged-dependency-check
+      with:
+        bom-path: google-cloud-bigtable-bom/pom.xml

--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -11,6 +11,7 @@ jobs:
         distribution: temurin
         java-version: 11
     - name: Install modules
+      shell: bash
       run: |
         mvn -B -V -ntp -DskipTests=true \
         -Dclirr.skip=true \

--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -2,7 +2,7 @@ on:
   pull_request:
 name: Unmanaged dependency check
 jobs:
-  checkstyle:
+  unmanaged_dependency_check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -23,4 +23,4 @@ jobs:
     - name: Unmanaged dependency check
       uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@feat/unmanaged-dependency-check
       with:
-        bom-path: google-cloud-bigtable-deps-bom/pom.xml
+        bom-path: google-cloud-bigtable/pom.xml

--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -19,7 +19,6 @@ jobs:
             -Dgcloud.download.skip=true \
             -T 1C
     - name: Unmanaged dependency check
-      uses: googleapis/sdk-platform-java@feat/unmanaged-dependency-check
+      uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@feat/unmanaged-dependency-check
       with:
         bom-path: google-cloud-bigtable-bom/pom.xml
-      working-directory: java-shared-dependencies/unmanaged-dependency-check

--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -21,6 +21,6 @@ jobs:
         -T 1C \
         clean install
     - name: Unmanaged dependency check
-      uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@feat/unmanaged-dependency-check
+      uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@unmanaged-dependencies-check-latest
       with:
         bom-path: google-cloud-bigtable-bom/pom.xml

--- a/proto-google-cloud-bigtable-v2/pom.xml
+++ b/proto-google-cloud-bigtable-v2/pom.xml
@@ -56,7 +56,6 @@
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <version>2.2.224</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/proto-google-cloud-bigtable-v2/pom.xml
+++ b/proto-google-cloud-bigtable-v2/pom.xml
@@ -52,6 +52,12 @@
       <artifactId>proto-google-common-protos</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>2.2.224</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/proto-google-cloud-bigtable-v2/pom.xml
+++ b/proto-google-cloud-bigtable-v2/pom.xml
@@ -52,11 +52,6 @@
       <artifactId>proto-google-common-protos</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>2.2.224</version>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
In this PR:

- Add an unmanaged dependency check to verify there's no dependency that is not covered by java shared dependencies (the latest [released](https://central.sonatype.com/artifact/com.google.cloud/google-cloud-shared-dependencies) version in Maven Central).

When it fails, this throws error:

```
This pull request seems to add new third-party dependency, [com.h2database:h2], among the artifacts listed in google-cloud-bigtable-bom/pom.xml.
Please see go/cloud-sdk-java-dependency-governance.
```