### PR TITLE
fix: per-connection metrics issue when using a different Bigtable project

### DIFF
--- a/google-cloud-bigtable-stats/src/main/java/com/google/cloud/bigtable/stats/BigtableCreateTimeSeriesExporter.java
+++ b/google-cloud-bigtable-stats/src/main/java/com/google/cloud/bigtable/stats/BigtableCreateTimeSeriesExporter.java
@@ -58,7 +58,7 @@ final class BigtableCreateTimeSeriesExporter extends MetricExporter {
                   Collectors.groupingBy(
                       timeSeries ->
                           BigtableStackdriverExportUtils.getProjectId(
-                              metric.getMetricDescriptor(), timeSeries),
+                              metric.getMetricDescriptor(), timeSeries, gceOrGkeMonitoredResource),
                       Collectors.mapping(
                           timeSeries ->
                               BigtableStackdriverExportUtils.convertTimeSeries(

--- a/google-cloud-bigtable-stats/src/main/java/com/google/cloud/bigtable/stats/BigtableStackdriverExportUtils.java
+++ b/google-cloud-bigtable-stats/src/main/java/com/google/cloud/bigtable/stats/BigtableStackdriverExportUtils.java
@@ -22,6 +22,7 @@ import com.google.api.Distribution.BucketOptions.Explicit;
 import com.google.api.Metric;
 import com.google.api.MetricDescriptor.MetricKind;
 import com.google.api.MonitoredResource;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.monitoring.v3.TimeInterval;
@@ -56,10 +57,9 @@ import javax.annotation.Nullable;
 class BigtableStackdriverExportUtils {
   private static final String BIGTABLE_RESOURCE_TYPE = "bigtable_client_raw";
 
-  // Defined package private to access in tests.
-  static final String GCE_RESOURCE_TYPE = "gce_instance";
-  static final String GKE_RESOURCE_TYPE = "k8s_container";
-  static final String GCE_OR_GKE_PROJECT_ID_KEY = "project_id";
+  @VisibleForTesting static final String GCE_RESOURCE_TYPE = "gce_instance";
+  @VisibleForTesting static final String GKE_RESOURCE_TYPE = "k8s_container";
+  @VisibleForTesting static final String GCE_OR_GKE_PROJECT_ID_KEY = "project_id";
   private static final Logger logger =
       Logger.getLogger(BigtableStackdriverExportUtils.class.getName());
 

--- a/google-cloud-bigtable-stats/src/test/java/com/google/cloud/bigtable/stats/BigtableCreateTimeSeriesExporterTest.java
+++ b/google-cloud-bigtable-stats/src/test/java/com/google/cloud/bigtable/stats/BigtableCreateTimeSeriesExporterTest.java
@@ -61,6 +61,8 @@ public class BigtableCreateTimeSeriesExporterTest {
   private static final String bigtableZone = "us-east-1";
   private static final String bigtableCluster = "cluster-1";
   private static final String clientName = "client-name";
+  private static final String gceProjectId = "fake-gce-project";
+  private static final String gkeProjectId = "fake-gke-project";
 
   @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
@@ -121,6 +123,7 @@ public class BigtableCreateTimeSeriesExporterTest {
 
     CreateTimeSeriesRequest request = argumentCaptor.getValue();
 
+    assertThat(request.getName()).isEqualTo("projects/" + bigtableProjectId);
     assertThat(request.getTimeSeriesList()).hasSize(1);
 
     com.google.monitoring.v3.TimeSeries timeSeries = request.getTimeSeriesList().get(0);
@@ -148,8 +151,9 @@ public class BigtableCreateTimeSeriesExporterTest {
         new BigtableCreateTimeSeriesExporter(
             fakeMetricServiceClient,
             MonitoredResource.newBuilder()
-                .setType("gce-instance")
-                .putLabels("some-gce-key", "some-gce-value")
+                .setType(BigtableStackdriverExportUtils.GCE_RESOURCE_TYPE)
+                .putLabels(BigtableStackdriverExportUtils.GCE_OR_GKE_PROJECT_ID_KEY, gceProjectId)
+                .putLabels("another-gce-key", "another-gce-value")
                 .build());
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
@@ -197,12 +201,17 @@ public class BigtableCreateTimeSeriesExporterTest {
 
     CreateTimeSeriesRequest request = argumentCaptor.getValue();
 
+    assertThat(request.getName()).isEqualTo("projects/" + gceProjectId);
     assertThat(request.getTimeSeriesList()).hasSize(1);
 
     com.google.monitoring.v3.TimeSeries timeSeries = request.getTimeSeriesList().get(0);
 
     assertThat(timeSeries.getResource().getLabelsMap())
-        .containsExactly("some-gce-key", "some-gce-value");
+        .containsExactly(
+            BigtableStackdriverExportUtils.GCE_OR_GKE_PROJECT_ID_KEY,
+            gceProjectId,
+            "another-gce-key",
+            "another-gce-value");
 
     assertThat(timeSeries.getMetric().getLabelsMap()).hasSize(5);
     assertThat(timeSeries.getMetric().getLabelsMap())
@@ -225,8 +234,9 @@ public class BigtableCreateTimeSeriesExporterTest {
         new BigtableCreateTimeSeriesExporter(
             fakeMetricServiceClient,
             MonitoredResource.newBuilder()
-                .setType("gke-container")
-                .putLabels("some-gke-key", "some-gke-value")
+                .setType(BigtableStackdriverExportUtils.GKE_RESOURCE_TYPE)
+                .putLabels(BigtableStackdriverExportUtils.GCE_OR_GKE_PROJECT_ID_KEY, gkeProjectId)
+                .putLabels("another-gke-key", "another-gke-value")
                 .build());
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
@@ -275,12 +285,17 @@ public class BigtableCreateTimeSeriesExporterTest {
 
     CreateTimeSeriesRequest request = argumentCaptor.getValue();
 
+    assertThat(request.getName()).isEqualTo("projects/" + gkeProjectId);
     assertThat(request.getTimeSeriesList()).hasSize(1);
 
     com.google.monitoring.v3.TimeSeries timeSeries = request.getTimeSeriesList().get(0);
 
     assertThat(timeSeries.getResource().getLabelsMap())
-        .containsExactly("some-gke-key", "some-gke-value");
+        .containsExactly(
+            BigtableStackdriverExportUtils.GCE_OR_GKE_PROJECT_ID_KEY,
+            gkeProjectId,
+            "another-gke-key",
+            "another-gke-value");
 
     assertThat(timeSeries.getMetric().getLabelsMap()).hasSize(5);
     assertThat(timeSeries.getMetric().getLabelsMap())


### PR DESCRIPTION
Fix an issue in exporting per-connection metrics when using a different Bigtable project.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed
- [ ] All new data plane features have a completed end to end testing plan

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
