### PR TITLE
feat: Add support for type and aggregate APIs

### DIFF
--- a/google-cloud-bigtable/clirr-ignored-differences.xml
+++ b/google-cloud-bigtable/clirr-ignored-differences.xml
@@ -180,4 +180,16 @@
         <className>com/google/cloud/bigtable/data/v2/models/MutateRowsException</className>
         <method>*</method>
     </difference>
+    <!-- InternalApi was updated -->
+    <difference>
+        <differenceType>7012</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/models/MutationApi</className>
+        <method>*</method>
+    </difference>
+    <!-- InternalApi was updated -->
+    <difference>
+        <differenceType>7012</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/models/ChangeStreamRecordAdapter$ChangeStreamRecordBuilder</className>
+        <method>*</method>
+    </difference>
 </differences>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/ColumnFamily.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/ColumnFamily.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.admin.v2.models;
 import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
 
 import com.google.api.core.InternalApi;
-import com.google.bigtable.admin.v2.GcRule;
 import com.google.bigtable.admin.v2.GcRule.RuleCase;
 import com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule;
 import com.google.common.base.MoreObjects;
@@ -28,18 +27,18 @@ import com.google.common.base.Objects;
 public final class ColumnFamily {
   private final String id;
   private final GCRule rule;
+  private final Type valueType;
 
   @InternalApi
   public static ColumnFamily fromProto(String id, com.google.bigtable.admin.v2.ColumnFamily proto) {
-    // TODO(igorbernstein): can getGcRule ever be null?
-    GcRule ruleProto = MoreObjects.firstNonNull(proto.getGcRule(), GcRule.getDefaultInstance());
-
-    return new ColumnFamily(id, GCRULES.fromProto(ruleProto));
+    return new ColumnFamily(
+        id, GCRULES.fromProto(proto.getGcRule()), Type.fromProto(proto.getValueType()));
   }
 
-  private ColumnFamily(String id, GCRule rule) {
+  private ColumnFamily(String id, GCRule rule, Type type) {
     this.id = id;
     this.rule = rule;
+    this.valueType = type;
   }
 
   /** Gets the column family's id. */
@@ -47,14 +46,23 @@ public final class ColumnFamily {
     return id;
   }
 
-  /** Get's the GCRule configured for the column family. */
+  /** Gets the GCRule configured for the column family. */
   public GCRule getGCRule() {
     return rule;
+  }
+
+  /* Gets the valueType configured for the column family. */
+  public Type getValueType() {
+    return valueType;
   }
 
   /** Returns true if a GCRule has been configured for the family. */
   public boolean hasGCRule() {
     return !RuleCase.RULE_NOT_SET.equals(rule.toProto().getRuleCase());
+  }
+
+  public boolean hasValueType() {
+    return valueType.getClass() != Type.Raw.class;
   }
 
   @Override
@@ -66,16 +74,22 @@ public final class ColumnFamily {
       return false;
     }
     ColumnFamily that = (ColumnFamily) o;
-    return Objects.equal(id, that.id) && Objects.equal(rule, that.rule);
+    return Objects.equal(id, that.id)
+        && Objects.equal(rule, that.rule)
+        && Objects.equal(valueType, that.valueType);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(id, rule);
+    return Objects.hashCode(id, rule, valueType);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("id", id).add("GCRule", rule).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("id", id)
+        .add("GCRule", rule)
+        .add("valueType", valueType)
+        .toString();
   }
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateTableRequest.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateTableRequest.java
@@ -63,11 +63,40 @@ public final class CreateTableRequest {
    *
    * @see GCRule for available options.
    */
-  public CreateTableRequest addFamily(String familyId, GCRule gcRule) {
+  public CreateTableRequest addFamily(@Nonnull String familyId, @Nonnull GCRule gcRule) {
+    return addFamily(familyId, gcRule, Type.raw());
+  }
+
+  /**
+   * Adds a new columnFamily with a {@link Type} to the configuration. Please note that calling this
+   * method with the same familyId will overwrite the previous family.
+   *
+   * @see Type for available options.
+   */
+  public CreateTableRequest addFamily(@Nonnull String familyId, @Nonnull Type valueType) {
+    return addFamily(familyId, GCRules.GCRULES.defaultRule(), valueType);
+  }
+
+  /**
+   * Adds a new columnFamily with a {@link GCRule} and {@link Type} to the configuration. Please
+   * note that calling this method with the same familyId will overwrite the previous family.
+   *
+   * @see GCRule for available options.
+   * @see Type for available options.
+   */
+  public CreateTableRequest addFamily(
+      @Nonnull String familyId, @Nonnull GCRule gcRule, @Nonnull Type valueType) {
     Preconditions.checkNotNull(familyId);
-    requestBuilder
-        .getTableBuilder()
-        .putColumnFamilies(familyId, ColumnFamily.newBuilder().setGcRule(gcRule.toProto()).build());
+    Preconditions.checkNotNull(gcRule);
+    Preconditions.checkNotNull(valueType);
+
+    ColumnFamily.Builder builder = ColumnFamily.newBuilder().setGcRule(gcRule.toProto());
+
+    // Don't set the type if it's the default ("raw")
+    if (!valueType.equals(Type.raw())) {
+      builder.setValueType(valueType.toProto());
+    }
+    requestBuilder.getTableBuilder().putColumnFamilies(familyId, builder.build());
     return this;
   }
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/ModifyColumnFamiliesRequest.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/ModifyColumnFamiliesRequest.java
@@ -55,9 +55,31 @@ public final class ModifyColumnFamiliesRequest {
 
   /** Configures the name and {@link GCRule} of the new {@link ColumnFamily} to be created */
   public ModifyColumnFamiliesRequest addFamily(String familyId, GCRule gcRule) {
+    return addFamily(familyId, gcRule, Type.raw());
+  }
+
+  /** Configures the name and {@link Type} of the new {@link ColumnFamily} to be created */
+  public ModifyColumnFamiliesRequest addFamily(String familyId, Type valueType) {
+    return addFamily(familyId, GCRules.GCRULES.defaultRule(), valueType);
+  }
+
+  /**
+   * Configures the name, {@link GCRule}, and {@link Type} of the new {@link ColumnFamily} to be
+   * created
+   */
+  public ModifyColumnFamiliesRequest addFamily(
+      @Nonnull String familyId, @Nonnull GCRule gcRule, @Nonnull Type valueType) {
     Preconditions.checkNotNull(gcRule);
+    Preconditions.checkNotNull(valueType);
+
     Modification.Builder modification = Modification.newBuilder().setId(familyId);
-    modification.getCreateBuilder().setGcRule(gcRule.toProto());
+    com.google.bigtable.admin.v2.ColumnFamily.Builder createBuilder =
+        modification.getCreateBuilder().setGcRule(gcRule.toProto());
+
+    if (!valueType.equals(Type.raw())) {
+      createBuilder.setValueType(valueType.toProto());
+    }
+
     modFamilyRequest.addModifications(modification.build());
     return this;
   }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/Type.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/Type.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2.models;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.core.BetaApi;
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nonnull;
+
+/**
+ * Wrapper class for the {@link com.google.bigtable.admin.v2.Type} protobuf message.
+ *
+ * @see com.google.bigtable.admin.v2.Type
+ */
+@BetaApi
+public abstract class Type {
+  private Type() {}
+
+  /**
+   * This type is a marker type that allows types to be used as the input to the SUM aggregate
+   * function.
+   */
+  public abstract static class SumAggregateInput extends Type {}
+
+  abstract com.google.bigtable.admin.v2.Type toProto();
+
+  static Type fromProto(com.google.bigtable.admin.v2.Type source) {
+    switch (source.getKindCase()) {
+      case INT64_TYPE:
+        return Int64.fromProto(source.getInt64Type());
+      case BYTES_TYPE:
+        return Bytes.fromProto(source.getBytesType());
+      case AGGREGATE_TYPE:
+        return Aggregate.fromProto(source.getAggregateType());
+      case KIND_NOT_SET:
+        return Raw.create();
+    }
+    throw new UnsupportedOperationException();
+  }
+
+  /** The raw type denotes the absence of a type. */
+  public static Raw raw() {
+    return Raw.create();
+  }
+
+  /**
+   * Creates a Bytes type with a "raw" encoding, leaving the bytes encoded as they are passed in.
+   */
+  public static Bytes rawBytes() {
+    return Bytes.create(Bytes.Encoding.raw());
+  }
+
+  /** Creates a Bytes type with the specified encoding */
+  public static Bytes bytes(Bytes.Encoding encoding) {
+    return Bytes.create(encoding);
+  }
+
+  /**
+   * Creates an Int64 type with a big-endian encoding. The bytes are then encoded in "raw" format.
+   */
+  public static Int64 bigEndianInt64() {
+    return Int64.create(Int64.Encoding.BigEndianBytes.create(Bytes.rawBytes()));
+  }
+
+  /** Creates an Int64 type with the specified encoding. */
+  public static Int64 int64(Int64.Encoding encoding) {
+    return Int64.create(encoding);
+  }
+
+  /** Creates an Aggregate type with a SUM aggregator and Int64 input type. */
+  public static Aggregate int64Sum() {
+    return sum(bigEndianInt64());
+  }
+
+  /** Creates an Aggregate type with a SUM aggregator and specified input type. */
+  public static Aggregate sum(SumAggregateInput inputType) {
+    return Aggregate.create(inputType, Aggregate.Aggregator.Sum.create());
+  }
+
+  /** Represents a string of bytes with a specific encoding. */
+  @AutoValue
+  public abstract static class Bytes extends Type {
+    public static Bytes create(Encoding encoding) {
+      return new AutoValue_Type_Bytes(encoding);
+    }
+
+    @Nonnull
+    public abstract Encoding getEncoding();
+
+    @Override
+    com.google.bigtable.admin.v2.Type toProto() {
+      com.google.bigtable.admin.v2.Type.Builder builder =
+          com.google.bigtable.admin.v2.Type.newBuilder();
+      builder.getBytesTypeBuilder().setEncoding(getEncoding().toProto());
+      return builder.build();
+    }
+
+    static Bytes fromProto(com.google.bigtable.admin.v2.Type.Bytes source) {
+      return create(Encoding.fromProto(source.getEncoding()));
+    }
+
+    public abstract static class Encoding {
+
+      abstract com.google.bigtable.admin.v2.Type.Bytes.Encoding toProto();
+
+      static Encoding fromProto(com.google.bigtable.admin.v2.Type.Bytes.Encoding source) {
+        switch (source.getEncodingCase()) {
+          case RAW:
+          case ENCODING_NOT_SET:
+            return Raw.create();
+        }
+        throw new UnsupportedOperationException();
+      }
+
+      public static Encoding raw() {
+        return Raw.create();
+      }
+
+      @AutoValue
+      public abstract static class Raw extends Encoding {
+        public static Raw create() {
+          return new AutoValue_Type_Bytes_Encoding_Raw();
+        }
+
+        private static final com.google.bigtable.admin.v2.Type.Bytes.Encoding PROTO_INSTANCE =
+            com.google.bigtable.admin.v2.Type.Bytes.Encoding.newBuilder()
+                .setRaw(com.google.bigtable.admin.v2.Type.Bytes.Encoding.Raw.getDefaultInstance())
+                .build();
+
+        @Override
+        com.google.bigtable.admin.v2.Type.Bytes.Encoding toProto() {
+          return PROTO_INSTANCE;
+        }
+      }
+    }
+  }
+
+  /** Represents a 64-bit integer with a specific encoding. */
+  @AutoValue
+  public abstract static class Int64 extends SumAggregateInput {
+    public static Int64 create(Encoding encoding) {
+      return new AutoValue_Type_Int64(encoding);
+    }
+
+    @Nonnull
+    public abstract Encoding getEncoding();
+
+    public abstract static class Encoding {
+
+      abstract com.google.bigtable.admin.v2.Type.Int64.Encoding toProto();
+
+      static Encoding fromProto(com.google.bigtable.admin.v2.Type.Int64.Encoding source) {
+        switch (source.getEncodingCase()) {
+          case BIG_ENDIAN_BYTES:
+            return BigEndianBytes.create(
+                Bytes.fromProto(source.getBigEndianBytes().getBytesType()));
+          case ENCODING_NOT_SET:
+            return BigEndianBytes.create(Bytes.rawBytes());
+        }
+        throw new UnsupportedOperationException();
+      }
+
+      @AutoValue
+      public abstract static class BigEndianBytes extends Encoding {
+
+        public static BigEndianBytes create(Bytes bytes) {
+          return new AutoValue_Type_Int64_Encoding_BigEndianBytes(bytes);
+        }
+
+        @Nonnull
+        public abstract Bytes getBytes();
+
+        @Override
+        com.google.bigtable.admin.v2.Type.Int64.Encoding toProto() {
+          com.google.bigtable.admin.v2.Type.Int64.Encoding.Builder builder =
+              com.google.bigtable.admin.v2.Type.Int64.Encoding.newBuilder();
+          builder.getBigEndianBytesBuilder().setBytesType(getBytes().toProto().getBytesType());
+          return builder.build();
+        }
+      }
+    }
+
+    @Override
+    com.google.bigtable.admin.v2.Type toProto() {
+      com.google.bigtable.admin.v2.Type.Builder builder =
+          com.google.bigtable.admin.v2.Type.newBuilder();
+      builder.getInt64TypeBuilder().setEncoding(getEncoding().toProto());
+      return builder.build();
+    }
+
+    static Int64 fromProto(com.google.bigtable.admin.v2.Type.Int64 source) {
+      return Int64.create(Encoding.fromProto(source.getEncoding()));
+    }
+  }
+
+  @AutoValue
+  public abstract static class Raw extends Type {
+    public static Raw create() {
+      return new AutoValue_Type_Raw();
+    }
+
+    @Override
+    com.google.bigtable.admin.v2.Type toProto() {
+      return com.google.bigtable.admin.v2.Type.getDefaultInstance();
+    }
+  }
+
+  /**
+   * A value that combines incremental updates into a summarized value.
+   *
+   * <p>Data is never directly written or read using type `Aggregate`. Writes will provide either
+   * the `input_type` or `state_type`, and reads will always return the `state_type` .
+   */
+  @AutoValue
+  public abstract static class Aggregate extends Type {
+    public static Aggregate create(Type inputType, Aggregator aggregator) {
+      return new AutoValue_Type_Aggregate(inputType, aggregator);
+    }
+
+    @Nonnull
+    public abstract Type getInputType();
+
+    @Nonnull
+    public abstract Aggregator getAggregator();
+
+    public abstract static class Aggregator {
+      @AutoValue
+      public abstract static class Sum extends Aggregator {
+        public static Sum create() {
+          return new AutoValue_Type_Aggregate_Aggregator_Sum();
+        }
+
+        @Override
+        void buildTo(com.google.bigtable.admin.v2.Type.Aggregate.Builder builder) {
+          builder.setSum(com.google.bigtable.admin.v2.Type.Aggregate.Sum.getDefaultInstance());
+        }
+      }
+
+      abstract void buildTo(com.google.bigtable.admin.v2.Type.Aggregate.Builder builder);
+    }
+
+    @Override
+    com.google.bigtable.admin.v2.Type toProto() {
+      com.google.bigtable.admin.v2.Type.Builder typeBuilder =
+          com.google.bigtable.admin.v2.Type.newBuilder();
+      com.google.bigtable.admin.v2.Type.Aggregate.Builder aggregateBuilder =
+          typeBuilder.getAggregateTypeBuilder();
+      getAggregator().buildTo(aggregateBuilder);
+      aggregateBuilder.setInputType(getInputType().toProto());
+      return typeBuilder.build();
+    }
+
+    static Aggregate fromProto(com.google.bigtable.admin.v2.Type.Aggregate source) {
+      Type inputType = Type.fromProto(source.getInputType());
+      Aggregator aggregator = null;
+      switch (source.getAggregatorCase()) {
+        case SUM:
+          aggregator = Aggregator.Sum.create();
+          break;
+        case AGGREGATOR_NOT_SET:
+          throw new UnsupportedOperationException();
+      }
+      return Aggregate.create(inputType, checkNotNull(aggregator));
+    }
+  }
+}

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/AddToCell.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/AddToCell.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.data.v2.models;
+
+import com.google.api.core.InternalApi;
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+
+/** Representation of an AddToCell mod in a data change. */
+@InternalApi("Intended for use by the BigtableIO in apache/beam only.")
+@AutoValue
+public abstract class AddToCell implements Entry, Serializable {
+  public static AddToCell create(
+      @Nonnull String family,
+      @Nonnull Value qualifier,
+      @Nonnull Value timestamp,
+      @Nonnull Value input) {
+    return new AutoValue_AddToCell(family, qualifier, timestamp, input);
+  }
+
+  @Nonnull
+  public abstract String getFamily();
+
+  @Nonnull
+  public abstract Value getQualifier();
+
+  @Nonnull
+  public abstract Value getTimestamp();
+
+  @Nonnull
+  public abstract Value getInput();
+}

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamMutation.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamMutation.java
@@ -177,6 +177,11 @@ public abstract class ChangeStreamMutation implements ChangeStreamRecord, Serial
       return this;
     }
 
+    Builder addToCell(@Nonnull String familyName, Value qualifier, Value timestamp, Value input) {
+      this.entriesBuilder().add(AddToCell.create(familyName, qualifier, timestamp, input));
+      return this;
+    }
+
     abstract ChangeStreamMutation build();
   }
 
@@ -198,6 +203,13 @@ public abstract class ChangeStreamMutation implements ChangeStreamRecord, Serial
             setCell.getQualifier(),
             setCell.getTimestamp(),
             setCell.getValue());
+      } else if (entry instanceof AddToCell) {
+        AddToCell addToCell = (AddToCell) entry;
+        rowMutation.addToCell(
+            addToCell.getFamily(),
+            addToCell.getQualifier(),
+            addToCell.getTimestamp(),
+            addToCell.getInput());
       } else {
         throw new IllegalArgumentException("Unexpected Entry type.");
       }
@@ -223,6 +235,13 @@ public abstract class ChangeStreamMutation implements ChangeStreamRecord, Serial
             setCell.getQualifier(),
             setCell.getTimestamp(),
             setCell.getValue());
+      } else if (entry instanceof AddToCell) {
+        AddToCell addToCell = (AddToCell) entry;
+        rowMutationEntry.addToCell(
+            addToCell.getFamily(),
+            addToCell.getQualifier(),
+            addToCell.getTimestamp(),
+            addToCell.getInput());
       } else {
         throw new IllegalArgumentException("Unexpected Entry type.");
       }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamRecordAdapter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamRecordAdapter.java
@@ -135,6 +135,12 @@ public interface ChangeStreamRecordAdapter<ChangeStreamRecordT> {
         @Nonnull ByteString qualifier,
         @Nonnull TimestampRange timestampRange);
 
+    void addToCell(
+        @Nonnull String familyName,
+        @Nonnull Value qualifier,
+        @Nonnull Value timestamp,
+        @Nonnull Value value);
+
     /**
      * Called to start a SetCell.
      *

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/DefaultChangeStreamRecordAdapter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/DefaultChangeStreamRecordAdapter.java
@@ -133,6 +133,15 @@ public class DefaultChangeStreamRecordAdapter
       this.changeStreamMutationBuilder.deleteCells(familyName, qualifier, timestampRange);
     }
 
+    @Override
+    public void addToCell(
+        @Nonnull String familyName,
+        @Nonnull Value qualifier,
+        @Nonnull Value timestamp,
+        @Nonnull Value input) {
+      this.changeStreamMutationBuilder.addToCell(familyName, qualifier, timestamp, input);
+    }
+
     /** {@inheritDoc} */
     @Override
     public void startCell(String family, ByteString qualifier, long timestampMicros) {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Mutation.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Mutation.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.data.v2.models;
 
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
+import com.google.bigtable.v2.Mutation.AddToCell;
 import com.google.bigtable.v2.Mutation.DeleteFromColumn;
 import com.google.bigtable.v2.Mutation.DeleteFromFamily;
 import com.google.bigtable.v2.Mutation.DeleteFromRow;
@@ -286,6 +287,24 @@ public final class Mutation implements MutationApi<Mutation>, Serializable {
             .setDeleteFromRow(DeleteFromRow.getDefaultInstance())
             .build());
 
+    return this;
+  }
+
+  @Override
+  public Mutation addToCell(
+      @Nonnull String familyName,
+      @Nonnull Value qualifier,
+      @Nonnull Value timestamp,
+      @Nonnull Value value) {
+    com.google.bigtable.v2.Mutation.Builder builder = com.google.bigtable.v2.Mutation.newBuilder();
+    AddToCell.Builder addToCellBuilder = builder.getAddToCellBuilder();
+    addToCellBuilder.setFamilyName(familyName);
+
+    qualifier.buildTo(addToCellBuilder.getColumnQualifierBuilder());
+    timestamp.buildTo(addToCellBuilder.getTimestampBuilder());
+    value.buildTo(addToCellBuilder.getInputBuilder());
+
+    addMutation(builder.build());
     return this;
   }
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/MutationApi.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/MutationApi.java
@@ -122,4 +122,50 @@ public interface MutationApi<T extends MutationApi<T>> {
 
   /** Adds a mutation which deletes all cells from the containing row. */
   T deleteRow();
+
+  /**
+   * Adds an int64 value to an aggregate cell. The column family must be an aggregate family and
+   * have an "int64" input type or this mutation will be rejected.
+   *
+   * <p>This is a convenience override that converts Strings to ByteStrings.
+   *
+   * <p>Note: The timestamp values are in microseconds but must match the granularity of the
+   * table(defaults to `MILLIS`). Therefore, the given value must be a multiple of 1000 (millisecond
+   * granularity). For example: `1571902339435000`.
+   */
+  default T addToCell(
+      @Nonnull String familyName, @Nonnull String qualifier, long timestamp, long value) {
+    return addToCell(familyName, ByteString.copyFromUtf8(qualifier), timestamp, value);
+  }
+
+  /**
+   * Adds an int64 value to an aggregate cell. The column family must be an aggregate family and
+   * have an "int64" input type or this mutation will be rejected.
+   *
+   * <p>Note: The timestamp values are in microseconds but must match the granularity of the
+   * table(defaults to `MILLIS`). Therefore, the given value must be a multiple of 1000 (millisecond
+   * granularity). For example: `1571902339435000`.
+   */
+  default T addToCell(
+      @Nonnull String familyName, @Nonnull ByteString qualifier, long timestamp, long input) {
+    return addToCell(
+        familyName,
+        Value.RawValue.create(qualifier),
+        Value.RawTimestamp.create(timestamp),
+        Value.IntValue.create(input));
+  }
+
+  /**
+   * Adds a {@link Value} to an aggregate cell. The column family must be an aggregate family and
+   * have an input type matching the type of {@link Value} or this mutation will be rejected.
+   *
+   * <p>Note: The timestamp values are in microseconds but must match the granularity of the
+   * table(defaults to `MILLIS`). Therefore, the given value must be a multiple of 1000 (millisecond
+   * granularity). For example: `1571902339435000`.
+   */
+  T addToCell(
+      @Nonnull String familyName,
+      @Nonnull Value qualifier,
+      @Nonnull Value timestamp,
+      @Nonnull Value input);
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/RowMutation.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/RowMutation.java
@@ -184,6 +184,16 @@ public final class RowMutation implements MutationApi<RowMutation>, Serializable
     return this;
   }
 
+  @Override
+  public RowMutation addToCell(
+      @Nonnull String familyName,
+      @Nonnull Value qualifier,
+      @Nonnull Value timestamp,
+      @Nonnull Value input) {
+    mutation.addToCell(familyName, qualifier, timestamp, input);
+    return this;
+  }
+
   @InternalApi
   public MutateRowRequest toProto(RequestContext requestContext) {
     String tableName =

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/RowMutationEntry.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/RowMutationEntry.java
@@ -180,6 +180,16 @@ public class RowMutationEntry implements MutationApi<RowMutationEntry>, Serializ
     return this;
   }
 
+  @Override
+  public RowMutationEntry addToCell(
+      @Nonnull String familyName,
+      @Nonnull Value qualifier,
+      @Nonnull Value timestamp,
+      @Nonnull Value input) {
+    mutation.addToCell(familyName, qualifier, timestamp, input);
+    return this;
+  }
+
   @InternalApi
   public MutateRowsRequest.Entry toProto() {
     Preconditions.checkArgument(

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Value.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Value.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.data.v2.models;
+
+import com.google.api.core.BetaApi;
+import com.google.auto.value.AutoValue;
+import com.google.protobuf.ByteString;
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+
+/**
+ * Wrapper class for the {@link com.google.bigtable.v2.Value} protobuf message.
+ *
+ * @see com.google.bigtable.v2.Value
+ */
+@BetaApi
+public abstract class Value implements Serializable {
+  private Value() {}
+
+  public enum ValueType {
+    Int64,
+    RawTimestamp,
+    RawValue
+  }
+
+  /** Creates a "raw" value that simply passes through "value" as raw byres. */
+  public static Value rawValue(@Nonnull ByteString value) {
+    return RawValue.create(value);
+  }
+
+  /** Creates a "raw" timestamp value that simply passes through "timestamp" as a long. */
+  public static Value rawTimestamp(long timestamp) {
+    return RawTimestamp.create(timestamp);
+  }
+
+  /** Creates an int64 value. */
+  public static Value intValue(long value) {
+    return IntValue.create(value);
+  }
+
+  @AutoValue
+  public abstract static class IntValue extends Value {
+    public static IntValue create(long value) {
+      return new AutoValue_Value_IntValue(value);
+    }
+
+    public abstract long getValue();
+
+    @Override
+    public ValueType getValueType() {
+      return ValueType.Int64;
+    }
+
+    @Override
+    void buildTo(com.google.bigtable.v2.Value.Builder builder) {
+      builder.setIntValue(getValue());
+    }
+  }
+
+  @AutoValue
+  public abstract static class RawTimestamp extends Value {
+    public static RawTimestamp create(long value) {
+      return new AutoValue_Value_RawTimestamp(value);
+    }
+
+    public abstract long getValue();
+
+    @Override
+    public ValueType getValueType() {
+      return ValueType.RawTimestamp;
+    }
+
+    @Override
+    void buildTo(com.google.bigtable.v2.Value.Builder builder) {
+      builder.setRawTimestampMicros(getValue());
+    }
+  }
+
+  @AutoValue
+  public abstract static class RawValue extends Value {
+    public static RawValue create(@Nonnull ByteString value) {
+      return new AutoValue_Value_RawValue(value);
+    }
+
+    @Nonnull
+    public abstract ByteString getValue();
+
+    @Override
+    public ValueType getValueType() {
+      return ValueType.RawValue;
+    }
+
+    @Override
+    void buildTo(com.google.bigtable.v2.Value.Builder builder) {
+      builder.setRawValue(getValue());
+    }
+  }
+
+  com.google.bigtable.v2.Value toProto() {
+    com.google.bigtable.v2.Value.Builder builder = com.google.bigtable.v2.Value.newBuilder();
+    buildTo(builder);
+    return builder.build();
+  }
+
+  abstract void buildTo(com.google.bigtable.v2.Value.Builder builder);
+
+  public abstract ValueType getValueType();
+
+  public static Value fromProto(com.google.bigtable.v2.Value source) {
+    switch (source.getKindCase()) {
+      case INT_VALUE:
+        return IntValue.create(source.getIntValue());
+      case RAW_VALUE:
+        return RawValue.create(source.getRawValue());
+      case RAW_TIMESTAMP_MICROS:
+        return RawTimestamp.create(source.getRawTimestampMicros());
+    }
+    throw new UnsupportedOperationException();
+  }
+}

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/changestream/ChangeStreamStateMachine.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/changestream/ChangeStreamStateMachine.java
@@ -20,6 +20,7 @@ import com.google.bigtable.v2.ReadChangeStreamResponse;
 import com.google.bigtable.v2.ReadChangeStreamResponse.DataChange.Type;
 import com.google.cloud.bigtable.data.v2.models.ChangeStreamRecordAdapter.ChangeStreamRecordBuilder;
 import com.google.cloud.bigtable.data.v2.models.Range.TimestampRange;
+import com.google.cloud.bigtable.data.v2.models.Value;
 import com.google.common.base.Preconditions;
 import org.threeten.bp.Instant;
 
@@ -476,6 +477,14 @@ final class ChangeStreamStateMachine<ChangeStreamRecordT> {
                       mod.getDeleteFromColumn().getTimeRange().getStartTimestampMicros(),
                       mod.getDeleteFromColumn().getTimeRange().getEndTimestampMicros()));
               continue;
+            }
+            // Case 4: AddToCell
+            if (mod.hasAddToCell()) {
+              builder.addToCell(
+                  mod.getAddToCell().getFamilyName(),
+                  Value.fromProto(mod.getAddToCell().getColumnQualifier()),
+                  Value.fromProto(mod.getAddToCell().getTimestamp()),
+                  Value.fromProto(mod.getAddToCell().getInput()));
             }
             throw new IllegalStateException("AWAITING_NEW_DATA_CHANGE: Unexpected mod type");
           }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/TypeProtos.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/TypeProtos.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2;
+
+public class TypeProtos {
+  public static com.google.bigtable.admin.v2.Type.Bytes bytesType() {
+    return com.google.bigtable.admin.v2.Type.Bytes.newBuilder()
+        .setEncoding(
+            com.google.bigtable.admin.v2.Type.Bytes.Encoding.newBuilder()
+                .setRaw(com.google.bigtable.admin.v2.Type.Bytes.Encoding.Raw.getDefaultInstance())
+                .build())
+        .build();
+  }
+
+  public static com.google.bigtable.admin.v2.Type int64Type() {
+    return com.google.bigtable.admin.v2.Type.newBuilder()
+        .setInt64Type(
+            com.google.bigtable.admin.v2.Type.Int64.newBuilder()
+                .setEncoding(
+                    com.google.bigtable.admin.v2.Type.Int64.Encoding.newBuilder()
+                        .setBigEndianBytes(
+                            com.google.bigtable.admin.v2.Type.Int64.Encoding.BigEndianBytes
+                                .newBuilder()
+                                .setBytesType(bytesType())
+                                .build())
+                        .build()))
+        .build();
+  }
+
+  public static com.google.bigtable.admin.v2.Type intSumType() {
+    return com.google.bigtable.admin.v2.Type.newBuilder()
+        .setAggregateType(
+            com.google.bigtable.admin.v2.Type.Aggregate.newBuilder()
+                .setInputType(TypeProtos.int64Type())
+                .setSum(com.google.bigtable.admin.v2.Type.Aggregate.Sum.getDefaultInstance()))
+        .build();
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/TableAdminRequestsTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/TableAdminRequestsTest.java
@@ -78,6 +78,8 @@ public class TableAdminRequestsTest {
             .addFamily("cf1")
             .addFamily("cf2", GCRules.GCRULES.maxVersions(1))
             .addFamily("cf3")
+            .addFamily("cf4", Type.int64Sum())
+            .addFamily("cf5", GCRules.GCRULES.maxVersions(1), Type.int64Sum())
             .updateFamily("cf1", GCRules.GCRULES.maxVersions(5))
             .dropFamily("cf3")
             .toProto(PROJECT_ID, INSTANCE_ID);
@@ -103,6 +105,20 @@ public class TableAdminRequestsTest {
                     .setCreate(
                         com.google.bigtable.admin.v2.ColumnFamily.newBuilder()
                             .setGcRule(GcRule.getDefaultInstance())))
+            .addModifications(
+                com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification.newBuilder()
+                    .setId("cf4")
+                    .setCreate(
+                        com.google.bigtable.admin.v2.ColumnFamily.newBuilder()
+                            .setGcRule(GcRule.getDefaultInstance())
+                            .setValueType(Type.int64Sum().toProto())))
+            .addModifications(
+                com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification.newBuilder()
+                    .setId("cf5")
+                    .setCreate(
+                        com.google.bigtable.admin.v2.ColumnFamily.newBuilder()
+                            .setGcRule(GCRules.GCRULES.maxVersions(1).toProto())
+                            .setValueType(Type.int64Sum().toProto())))
             .addModifications(
                 com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification.newBuilder()
                     .setId("cf1")

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/TypeTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/TypeTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2.models;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.bigtable.admin.v2.TypeProtos;
+import com.google.cloud.bigtable.admin.v2.models.Type.Bytes;
+import com.google.cloud.bigtable.admin.v2.models.Type.Int64;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TypeTest {
+
+  @Test
+  public void rawBytes() {
+    Type type = Type.rawBytes();
+    assertThat(type.toProto())
+        .isEqualTo(
+            com.google.bigtable.admin.v2.Type.newBuilder()
+                .setBytesType(TypeProtos.bytesType())
+                .build());
+  }
+
+  @Test
+  public void bytes() {
+    Type type = Type.bytes(Bytes.Encoding.raw());
+    assertThat(type.toProto())
+        .isEqualTo(
+            com.google.bigtable.admin.v2.Type.newBuilder()
+                .setBytesType(TypeProtos.bytesType())
+                .build());
+  }
+
+  @Test
+  public void bigEndianInt64() {
+    Type type = Type.bigEndianInt64();
+    assertThat(type.toProto()).isEqualTo(TypeProtos.int64Type());
+  }
+
+  @Test
+  public void int64WithEncoding() {
+    Type type = Type.int64(Int64.Encoding.BigEndianBytes.create(Bytes.rawBytes()));
+    assertThat(type.toProto()).isEqualTo(TypeProtos.int64Type());
+  }
+
+  @Test
+  public void int64Sum() {
+    Type type = Type.int64Sum();
+    assertThat(type.toProto()).isEqualTo(TypeProtos.intSumType());
+  }
+
+  @Test
+  public void sum() {
+    Type type = Type.sum(Type.bigEndianInt64());
+    assertThat(type.toProto()).isEqualTo(TypeProtos.intSumType());
+  }
+
+  @Test
+  public void intSumFromProtoToProto() {
+    com.google.bigtable.admin.v2.Type proto = TypeProtos.intSumType();
+    assertThat(Type.fromProto(proto)).isEqualTo(Type.int64Sum());
+    assertThat(Type.fromProto(proto).toProto()).isEqualTo(proto);
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamMutationTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ChangeStreamMutationTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.bigtable.v2.MutateRowRequest;
 import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.Mutation;
 import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.common.primitives.Longs;
@@ -61,6 +62,11 @@ public class ChangeStreamMutationTest {
                 "fake-family",
                 ByteString.copyFromUtf8("fake-qualifier"),
                 Range.TimestampRange.create(1000L, 2000L))
+            .addToCell(
+                "agg-family",
+                Value.rawValue(ByteString.copyFromUtf8("col1")),
+                Value.rawTimestamp(1000),
+                Value.intValue(1234))
             .setToken("fake-token")
             .setEstimatedLowWatermark(FAKE_LOW_WATERMARK)
             .build();
@@ -139,6 +145,11 @@ public class ChangeStreamMutationTest {
                 "fake-family",
                 ByteString.copyFromUtf8("fake-qualifier"),
                 Range.TimestampRange.create(1000L, 2000L))
+            .addToCell(
+                "agg-family",
+                Value.rawValue(ByteString.copyFromUtf8("qual1")),
+                Value.rawTimestamp(1000),
+                Value.intValue(1234))
             .setToken("fake-token")
             .setEstimatedLowWatermark(FAKE_LOW_WATERMARK)
             .build();
@@ -150,7 +161,7 @@ public class ChangeStreamMutationTest {
         NameUtil.formatTableName(
             REQUEST_CONTEXT.getProjectId(), REQUEST_CONTEXT.getInstanceId(), TABLE_ID);
     assertThat(mutateRowRequest.getTableName()).isEqualTo(tableName);
-    assertThat(mutateRowRequest.getMutationsList()).hasSize(3);
+    assertThat(mutateRowRequest.getMutationsList()).hasSize(4);
     assertThat(mutateRowRequest.getMutations(0).getSetCell().getValue())
         .isEqualTo(ByteString.copyFromUtf8("fake-value"));
     assertThat(mutateRowRequest.getMutations(1).getDeleteFromFamily().getFamilyName())
@@ -159,6 +170,14 @@ public class ChangeStreamMutationTest {
         .isEqualTo("fake-family");
     assertThat(mutateRowRequest.getMutations(2).getDeleteFromColumn().getColumnQualifier())
         .isEqualTo(ByteString.copyFromUtf8("fake-qualifier"));
+    assertThat(mutateRowRequest.getMutations(3).getAddToCell())
+        .isEqualTo(
+            Mutation.AddToCell.newBuilder()
+                .setFamilyName("agg-family")
+                .setColumnQualifier(Value.rawValue(ByteString.copyFromUtf8("qual1")).toProto())
+                .setTimestamp(Value.rawTimestamp(1000).toProto())
+                .setInput(Value.intValue(1234).toProto())
+                .build());
   }
 
   @Test
@@ -196,6 +215,11 @@ public class ChangeStreamMutationTest {
                 "fake-family",
                 ByteString.copyFromUtf8("fake-qualifier"),
                 Range.TimestampRange.create(1000L, 2000L))
+            .addToCell(
+                "agg-family",
+                Value.rawValue(ByteString.copyFromUtf8("qual1")),
+                Value.rawTimestamp(1000),
+                Value.intValue(1234))
             .setToken("fake-token")
             .setEstimatedLowWatermark(FAKE_LOW_WATERMARK)
             .build();
@@ -204,7 +228,7 @@ public class ChangeStreamMutationTest {
     RowMutationEntry rowMutationEntry = changeStreamMutation.toRowMutationEntry();
     MutateRowsRequest.Entry mutateRowsRequestEntry = rowMutationEntry.toProto();
     assertThat(mutateRowsRequestEntry.getRowKey()).isEqualTo(ByteString.copyFromUtf8("key"));
-    assertThat(mutateRowsRequestEntry.getMutationsList()).hasSize(3);
+    assertThat(mutateRowsRequestEntry.getMutationsList()).hasSize(4);
     assertThat(mutateRowsRequestEntry.getMutations(0).getSetCell().getValue())
         .isEqualTo(ByteString.copyFromUtf8("fake-value"));
     assertThat(mutateRowsRequestEntry.getMutations(1).getDeleteFromFamily().getFamilyName())
@@ -213,6 +237,14 @@ public class ChangeStreamMutationTest {
         .isEqualTo("fake-family");
     assertThat(mutateRowsRequestEntry.getMutations(2).getDeleteFromColumn().getColumnQualifier())
         .isEqualTo(ByteString.copyFromUtf8("fake-qualifier"));
+    assertThat(mutateRowsRequestEntry.getMutations(3).getAddToCell())
+        .isEqualTo(
+            Mutation.AddToCell.newBuilder()
+                .setFamilyName("agg-family")
+                .setColumnQualifier(Value.rawValue(ByteString.copyFromUtf8("qual1")).toProto())
+                .setTimestamp(Value.rawTimestamp(1000).toProto())
+                .setInput(Value.intValue(1234).toProto())
+                .build());
   }
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/MutationTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/MutationTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.data.v2.models;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.bigtable.v2.Mutation.AddToCell;
 import com.google.bigtable.v2.Mutation.DeleteFromColumn;
 import com.google.bigtable.v2.Mutation.DeleteFromFamily;
 import com.google.bigtable.v2.Mutation.DeleteFromRow;
@@ -180,6 +181,21 @@ public class MutationTest {
   }
 
   @Test
+  public void addToCellTest() {
+    mutation.addToCell("cf1", "q", 10000, 1234);
+    List<com.google.bigtable.v2.Mutation> actual = mutation.getMutations();
+
+    com.google.bigtable.v2.Mutation.Builder builder = com.google.bigtable.v2.Mutation.newBuilder();
+    AddToCell.Builder addToCellBuilder = builder.getAddToCellBuilder();
+    addToCellBuilder.setFamilyName("cf1");
+    addToCellBuilder.getColumnQualifierBuilder().setRawValue(ByteString.copyFromUtf8("q"));
+    addToCellBuilder.getTimestampBuilder().setRawTimestampMicros(10000);
+    addToCellBuilder.getInputBuilder().setIntValue(1234);
+
+    assertThat(actual).containsExactly(builder.build());
+  }
+
+  @Test
   public void serializationTest() throws IOException, ClassNotFoundException {
     Mutation expected = Mutation.create().setCell("cf", "q", "val");
 
@@ -264,7 +280,8 @@ public class MutationTest {
             1_000,
             ByteString.copyFromUtf8("fake-value"))
         .deleteCells("fake-family", ByteString.copyFromUtf8("fake-qualifier"))
-        .deleteFamily("fake-family2");
+        .deleteFamily("fake-family2")
+        .addToCell("agg-family", "qual1", 1000, 1234);
 
     List<com.google.bigtable.v2.Mutation> protoMutation = mutation.getMutations();
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ValueTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/ValueTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.data.v2.models;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.protobuf.ByteString;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ValueTest {
+  @Test
+  public void rawValue() {
+    Value value = Value.rawValue(ByteString.copyFromUtf8("test"));
+    assertThat(Value.fromProto(value.toProto())).isEqualTo(value);
+  }
+
+  @Test
+  public void rawTimestamp() {
+    Value value = Value.rawTimestamp(1234);
+    assertThat(Value.fromProto(value.toProto())).isEqualTo(value);
+  }
+
+  @Test
+  public void int64() {
+    Value value = Value.intValue(1234);
+    assertThat(Value.fromProto(value.toProto())).isEqualTo(value);
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/MutateRowCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/MutateRowCallableTest.java
@@ -53,7 +53,8 @@ public class MutateRowCallableTest {
     MutateRowCallable callable = new MutateRowCallable(innerCallable, REQUEST_CONTEXT);
     RowMutation outerRequest =
         RowMutation.create("fake-table", "fake-key")
-            .setCell("fake-family", "fake-qualifier", 1_000, "fake-value");
+            .setCell("fake-family", "fake-qualifier", 1_000, "fake-value")
+            .addToCell("family-2", "qualifier", 1_000, 1234);
 
     innerResult.set(MutateRowResponse.getDefaultInstance());
     callable.call(outerRequest);


### PR DESCRIPTION
This PR adds support for type and aggregate APIs to the java client.  Bigtable aggregates will allow users to configure column families whose cells accumulate values via an aggregation function rather than simply overwrite them.

Change-Id: I5882459c862cc1deda11606e181cee38ac4d9099
