### PR TITLE
ci: adding gcbrun for trusted bots

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,3 +1,7 @@
 trustedContributors:
 - renovate-bot
 - gcf-owl-bot[bot]
+
+annotations:
+- type: comment
+  text: "/gcbrun"

--- a/owlbot.py
+++ b/owlbot.py
@@ -105,6 +105,7 @@ java.common_templates(excludes=[
     # todo remove once template is updated
     '.github/ISSUE_TEMPLATE/bug_report.md',
     '.github/PULL_REQUEST_TEMPLATE.md',
+    '.github/trusted-contribution.yml',
     'CONTRIBUTING.md',
     # exclude autogen
     'codecov.yaml',


### PR DESCRIPTION
A pull request in trusted-contribution bot: https://github.com/googleapis/repo-automation-bots/pull/1682

This is an experiment to try the capability of trusted-contribution bot. This may turn the kokoro labels off. In that case, I'll update another CL to remove the lines. 