### PR TITLE
chore: include recommended_package in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,5 +13,6 @@
   "api_id": "bigtable.googleapis.com",
   "library_type": "GAPIC_COMBO",
   "extra_versioned_modules": "google-cloud-bigtable-emulator,google-cloud-bigtable-emulator-core",
-  "excluded_poms": "google-cloud-bigtable-bom"
+  "excluded_poms": "google-cloud-bigtable-bom",
+  "recommended_package": "com.google.cloud.bigtable"
 }

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-bigtable'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigtable:2.37.0'
+implementation 'com.google.cloud:google-cloud-bigtable:2.38.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.37.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.38.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -541,7 +541,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigtable/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigtable.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigtable/2.37.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigtable/2.38.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles


### PR DESCRIPTION
Adds a field for recommended_package as part of the revamped Library Overviews.
See go/cloud-rad-overviews-handwritten-repos for more details