### PR TITLE
chore: remove release-please version increment in samples

### DIFF
--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -31,7 +31,7 @@
       <artifactId>google-cloud-bigtable</artifactId>
       <version>2.38.0</version>
     </dependency>
-    <!-- {x-version-update-end} -->
+    <!-- [END bigtable_install_without_bom] -->
 
     <dependency>
       <groupId>junit</groupId>

--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -25,14 +25,12 @@
 
 
   <dependencies>
-    <!-- {x-version-update-start:google-cloud-bigtable:released} -->
     <!-- [START bigtable_install_without_bom] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigtable</artifactId>
       <version>2.38.0</version>
     </dependency>
-    <!-- [END bigtable_install_without_bom] -->
     <!-- {x-version-update-end} -->
 
     <dependency>


### PR DESCRIPTION
This automatically gets incremented after the release is complete by a renovate bot PR (example https://github.com/googleapis/java-bigtable/pull/2173), so no need to increment it here.
