### PR TITLE
fix: batch time series data when exporting client-side metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.37.0')
+implementation platform('com.google.cloud:libraries-bom:26.38.0')
 
 implementation 'com.google.cloud:google-cloud-bigtable'
 ```

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
@@ -42,6 +42,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.monitoring.v3.CreateTimeSeriesRequest;
 import com.google.monitoring.v3.ProjectName;
@@ -53,6 +54,7 @@ import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -84,6 +86,8 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
           MetricServiceSettings.getDefaultEndpoint());
 
   private static final String APPLICATION_RESOURCE_PROJECT_ID = "project_id";
+
+  private static final int EXPORT_BATCH_SIZE_LIMIT = 200;
 
   private final MetricServiceClient client;
 
@@ -216,19 +220,12 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
     }
 
     ProjectName projectName = ProjectName.of(bigtableProjectId);
-    CreateTimeSeriesRequest bigtableRequest =
-        CreateTimeSeriesRequest.newBuilder()
-            .setName(projectName.toString())
-            .addAllTimeSeries(bigtableTimeSeries)
-            .build();
-
-    ApiFuture<Empty> future =
-        this.client.createServiceTimeSeriesCallable().futureCall(bigtableRequest);
+    ApiFuture<List<Empty>> future = exportTimeSeries(projectName.toString(), bigtableTimeSeries);
 
     CompletableResultCode bigtableExportCode = new CompletableResultCode();
     ApiFutures.addCallback(
         future,
-        new ApiFutureCallback<Empty>() {
+        new ApiFutureCallback<List<Empty>>() {
           @Override
           public void onFailure(Throwable throwable) {
             if (bigtableExportFailureLogged.compareAndSet(false, true)) {
@@ -245,7 +242,7 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
           }
 
           @Override
-          public void onSuccess(Empty empty) {
+          public void onSuccess(List<Empty> emptyList) {
             // When an export succeeded reset the export failure flag to false so if there's a
             // transient failure it'll be logged.
             bigtableExportFailureLogged.set(false);
@@ -290,22 +287,17 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
 
     // Construct the request. The project id will be the project id of the detected monitored
     // resource.
-    ApiFuture<Empty> gceOrGkeFuture;
+    ApiFuture<List<Empty>> gceOrGkeFuture;
     CompletableResultCode exportCode = new CompletableResultCode();
     try {
       ProjectName projectName =
           ProjectName.of(applicationResource.getLabelsOrThrow(APPLICATION_RESOURCE_PROJECT_ID));
-      CreateTimeSeriesRequest request =
-          CreateTimeSeriesRequest.newBuilder()
-              .setName(projectName.toString())
-              .addAllTimeSeries(timeSeries)
-              .build();
 
-      gceOrGkeFuture = this.client.createServiceTimeSeriesCallable().futureCall(request);
+      gceOrGkeFuture = exportTimeSeries(projectName.toString(), timeSeries);
 
       ApiFutures.addCallback(
           gceOrGkeFuture,
-          new ApiFutureCallback<Empty>() {
+          new ApiFutureCallback<List<Empty>>() {
             @Override
             public void onFailure(Throwable throwable) {
               if (applicationExportFailureLogged.compareAndSet(false, true)) {
@@ -322,7 +314,7 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
             }
 
             @Override
-            public void onSuccess(Empty empty) {
+            public void onSuccess(List<Empty> emptyList) {
               // When an export succeeded reset the export failure flag to false so if there's a
               // transient failure it'll be logged.
               applicationExportFailureLogged.set(false);
@@ -339,6 +331,19 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
     }
 
     return exportCode;
+  }
+
+  private ApiFuture<List<Empty>> exportTimeSeries(String name, List<TimeSeries> timeSeries) {
+    List<ApiFuture<Empty>> batchResults = new ArrayList<>();
+
+    for (List<TimeSeries> batch : Iterables.partition(timeSeries, EXPORT_BATCH_SIZE_LIMIT)) {
+      CreateTimeSeriesRequest req =
+          CreateTimeSeriesRequest.newBuilder().setName(name).addAllTimeSeries(batch).build();
+      ApiFuture<Empty> f = this.client.createServiceTimeSeriesCallable().futureCall(req);
+      batchResults.add(f);
+    }
+
+    return ApiFutures.allAsList(batchResults);
   }
 
   @Override


### PR DESCRIPTION
This fixes and issue with exporting client-side metrics when having too many distinct resources, resulting in batch sizes higher than 200.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed
- [ ] All new data plane features have a completed end to end testing plan

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
