### PR TITLE
ci: automatic kokoro label in addition to /gcbrun comment

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -5,3 +5,5 @@ trustedContributors:
 annotations:
 - type: comment
   text: "/gcbrun"
+- type: label
+  text: "kokoro:force-run"


### PR DESCRIPTION
From reading the configuration (https://github.com/googleapis/repo-automation-bots/pull/1682/files), it accepts multiple objects.