### PR TITLE
fix: Add getServiceName() to EnhancedBigTableStubSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-bigtable'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigtable:2.39.4'
+implementation 'com.google.cloud:google-cloud-bigtable:2.39.5'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.39.4"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.39.5"
 ```
 <!-- {x-version-update-end} -->
 
@@ -542,7 +542,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigtable/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigtable.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigtable/2.39.4
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigtable/2.39.5
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -373,6 +373,11 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
         .setJwtEnabledScopes(JWT_ENABLED_SCOPES);
   }
 
+  @Override
+  public String getServiceName() {
+    return "bigtable";
+  }
+
   /**
    * Returns the object with the settings used for calls to ReadRows.
    *


### PR DESCRIPTION
Adds a duplicate `getServiceName()` implementation to EnhancedBigTableStubSettings. This is similar to https://github.com/googleapis/java-bigtable/blob/de639bc7869dc5a25029367b8fc470fcd089667d/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java#L171-L174, but is re-implemented as EnhancedBigTableStubSettings does not implement BigtableStubSettings