### PR TITLE
test: fix samples test that was broken by a test harness change

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.42.0')
+implementation platform('com.google.cloud:libraries-bom:26.43.0')
 
 implementation 'com.google.cloud:google-cloud-bigtable'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigtable:2.39.5'
+implementation 'com.google.cloud:google-cloud-bigtable:2.40.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.39.5"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.40.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -542,7 +542,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigtable/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigtable.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigtable/2.39.5
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigtable/2.40.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/samples/snippets/src/test/java/com/example/bigtable/deletes/DeletesTest.java
+++ b/samples/snippets/src/test/java/com/example/bigtable/deletes/DeletesTest.java
@@ -19,11 +19,13 @@ package com.example.bigtable.deletes;
 import com.example.bigtable.MobileTimeSeriesBaseTest;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.models.ColumnFamily;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowCell;
 import com.google.cloud.bigtable.data.v2.models.TableId;
+import com.google.common.truth.Correspondence;
 import com.google.common.truth.Truth;
 import java.io.IOException;
 import java.util.List;
@@ -39,6 +41,8 @@ import org.junit.runners.MethodSorters;
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DeletesTest extends MobileTimeSeriesBaseTest {
+  private static final Correspondence<ColumnFamily, String> COLUMN_FAMILY_ID_CORRESPONDENCE =
+      Correspondence.transforming(ColumnFamily::getId, "ColumnFamily id");
   public static BigtableDataClient bigtableDataClient;
 
   @BeforeClass
@@ -164,13 +168,17 @@ public class DeletesTest extends MobileTimeSeriesBaseTest {
   public void test7_testDeleteColumnFamily() throws IOException {
     try (BigtableTableAdminClient tableAdminClient =
         BigtableTableAdminClient.create(projectId, instanceId)) {
-      Truth.assertThat(tableAdminClient.getTable(TABLE_ID).getColumnFamilies().size()).isEqualTo(2);
+      Truth.assertThat(tableAdminClient.getTable(TABLE_ID).getColumnFamilies())
+          .comparingElementsUsing(COLUMN_FAMILY_ID_CORRESPONDENCE)
+          .contains(COLUMN_FAMILY_NAME_STATS);
 
       DeleteColumnFamilyExample deleteColumnFamilyExample = new DeleteColumnFamilyExample();
       deleteColumnFamilyExample.deleteColumnFamily(
           projectId, instanceId, TABLE_ID, COLUMN_FAMILY_NAME_STATS);
 
-      Truth.assertThat(tableAdminClient.getTable(TABLE_ID).getColumnFamilies().size()).isEqualTo(1);
+      Truth.assertThat(tableAdminClient.getTable(TABLE_ID).getColumnFamilies())
+          .comparingElementsUsing(COLUMN_FAMILY_ID_CORRESPONDENCE)
+          .doesNotContain(COLUMN_FAMILY_NAME_STATS);
     }
   }
 


### PR DESCRIPTION
The test was broken in #2170 which added a new column family. The test was relient on the abolute column family count of the schema. This PR fixes the test by making it focus on the family its trying to delete instead of the entire schema

Change-Id: I0df90e68c0b25c4e66ed7d8ae1c19ae53577443b

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed
- [ ] All new data plane features have a completed end to end testing plan

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
