### PR TITLE
Update logging.properties for test to be fine

### DIFF
--- a/google-cloud-bigtable/src/test/resources/logging.properties
+++ b/google-cloud-bigtable/src/test/resources/logging.properties
@@ -1,5 +1,9 @@
 handlers= java.util.logging.ConsoleHandler
-.level= INFO
+.level= FINE
+
+io.grpc.level=FINE
+io.grpc.xds.level=FINE
+io.grpc.ChannelLogger.level=FINE
 
 java.util.logging.ConsoleHandler.level = INFO
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter


### PR DESCRIPTION
Increase test logging level from INFO to FINE. This will add a large number of logs but will help with features related to grpc and xds changes.