### PR TITLE
feat: allow non default service account in DirectPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.43.0')
+implementation platform('com.google.cloud:libraries-bom:26.44.0')
 
 implementation 'com.google.cloud:google-cloud-bigtable'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigtable:2.41.0'
+implementation 'com.google.cloud:google-cloud-bigtable:2.42.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.41.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.42.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -542,7 +542,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigtable/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigtable.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigtable/2.41.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigtable/2.42.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -370,7 +370,11 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
     if (isDirectpathEnabled) {
       // Attempts direct access to CBT service over gRPC to improve throughput,
       // whether the attempt is allowed is totally controlled by service owner.
-      grpcTransportProviderBuilder.setAttemptDirectPathXds().setAttemptDirectPath(true);
+      grpcTransportProviderBuilder
+          .setAttemptDirectPathXds()
+          .setAttemptDirectPath(true)
+          // Allow using non-default service account in DirectPath.
+          .setAllowNonDefaultServiceAccount(true);
     }
     return grpcTransportProviderBuilder
         .setChannelPoolSettings(


### PR DESCRIPTION
Copying over from: https://github.com/googleapis/java-bigtable/pull/2012

Bigtable already sets the flag to allow non-default SA in DirectPath on the service side, we also need to set the option on the client side to make this feature work.
Related Spanner PR: https://github.com/googleapis/java-spanner/pull/2635.