### PR TITLE
chore: remove unused image tag in .OwlBot-hermetic.yaml

### DIFF
--- a/.github/.OwlBot-hermetic.yaml
+++ b/.github/.OwlBot-hermetic.yaml
@@ -11,10 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-docker:
-  image: "gcr.io/cloud-devrel-public-resources/owlbot-java:latest"
-
 deep-remove-regex:
 - "/grpc-google-.*/src"
 - "/proto-google-.*/src"


### PR DESCRIPTION
This removes the unused image tag in this file. Part of the cleanup after enabling Hermetic Library generation in this repo.

Newline at EOF automatically added - see [this SO](https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline).