### PR TITLE
chore: add generator version to config

### DIFF
--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -17,31 +17,13 @@ name: Hermetic library generation upon generation config change through pull req
 on:
   pull_request:
 
-env:
-  HEAD_REF: ${{ github.head_ref }}
-  REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
-  GITHUB_REPOSITORY: ${{ github.repository }}
-
 jobs:
   library_generation:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
-    - name: Generate changed libraries
-      shell: bash
-      run: |
-        set -ex
-        if [[ "${GITHUB_REPOSITORY}" != "${REPO_FULL_NAME}" ]]; then
-          echo "This PR comes from a fork. Generation will be skipped"
-          exit 0
-        fi
-        [ -z "$(git config user.email)" ] && git config --global user.email "cloud-java-bot@google.com"
-        [ -z "$(git config user.name)" ] && git config --global user.name "cloud-java-bot"
-        bash .github/scripts/hermetic_library_generation.sh \
-          --target_branch ${{ github.base_ref }} \
-          --current_branch $HEAD_REF
-      env:
-        GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
+    uses: googleapis/google-cloud-java/.github/workflows/reusable_library_generation.yaml@chore/setup-reusable-workflow
+    with:
+      repo_full_name: ${{ github.event.pull_request.head.repo.full_name }}
+      repository: ${{ github.repository }}
+      base_ref: ${{ github.base_ref }}
+      head_ref: ${{ github.head_ref }}
+    secrets:
+      token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -1,5 +1,5 @@
 gapic_generator_version: 2.44.0
-googleapis_commitish: c93b54fa3060c7185f6dc724f0f9ec0c12bc44fc
+googleapis_commitish: eb4c1ec02412e65c453ef0bfc4347731e64dcc82
 libraries_bom_version: 26.44.0
 template_excludes:
   - .gitignore

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -1,3 +1,4 @@
+gapic_generator_version: 2.44.0
 googleapis_commitish: c93b54fa3060c7185f6dc724f0f9ec0c12bc44fc
 libraries_bom_version: 26.44.0
 template_excludes:


### PR DESCRIPTION
In this PR:
- Add generator version to generation config.

The library generation job failed due to config doesn't have a generator version, see https://github.com/googleapis/java-bigtable/actions/runs/10712723965/job/29703584291.