### PR TITLE
deps: downgrade grpc to 1.67.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-bigtable'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-bigtable:2.44.0'
+implementation 'com.google.cloud:google-cloud-bigtable:2.44.1'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.44.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-bigtable" % "2.44.1"
 ```
 <!-- {x-version-update-end} -->
 
@@ -545,7 +545,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-bigtable/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigtable.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigtable/2.44.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigtable/2.44.1
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-bigtable-deps-bom/pom.xml
+++ b/google-cloud-bigtable-deps-bom/pom.xml
@@ -63,6 +63,17 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Temporarily downgrade grpc version since 1.68.0 was a mistake:
+      https://github.com/grpc/grpc-java/releases/tag/v1.68.0 -->
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>1.67.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- google cloud boms -->
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>gapic-libraries-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,23 @@
     </dependencyManagement>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <!-- TODO: remove this next release -->
+                <!-- Temporarily disable requireUpperBoundDeps
+                    rule to downgrade bad grpc release:
+                     https://github.com/grpc/grpc-java/releases/tag/v1.68.0-->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <configuration>
+                        <rulesToSkip>requireUpperBoundDeps</rulesToSkip>
+                        <failIfNoRules>false</failIfNoRules>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <!-- Using maven site plugin only as a hook for javadoc:aggregate, don't need the reports -->
             <plugin>


### PR DESCRIPTION
grpc-java 1.68.0 was a mistake:
https://github.com/grpc/grpc-java/releases/tag/v1.68.0

This PR will temporarily rollback grpc version to 1.67.1 until the shared config is caught up