### PR TITLE
feat: add an experimental feature to skip waiting for trailers for unary ops

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
@@ -563,7 +563,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
    * </ul>
    */
   public <RowT> UnaryCallable<Query, RowT> createReadRowCallable(RowAdapter<RowT> rowAdapter) {
-    if (!EnhancedBigtableStubSettings.SKIP_TRAILERS) {
+    if (!settings.getEnableSkipTrailers()) {
       ServerStreamingCallable<ReadRowsRequest, RowT> readRowsCallable =
           createReadRowsBaseCallable(
               ServerStreamingCallSettings.<ReadRowsRequest, Row>newBuilder()
@@ -1296,7 +1296,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
       UnaryCallSettings<ReqT, RespT> callSettings,
       Function<ReqT, BaseReqT> requestTransformer,
       Function<BaseRespT, RespT> responseTranformer) {
-    if (EnhancedBigtableStubSettings.SKIP_TRAILERS) {
+    if (settings.getEnableSkipTrailers()) {
       return createUnaryCallableNew(
           methodDescriptor, headerParamsFn, callSettings, requestTransformer, responseTranformer);
     } else {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -109,7 +109,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   private static final boolean DIRECT_PATH_ENABLED =
       Boolean.parseBoolean(System.getenv("CBT_ENABLE_DIRECTPATH"));
 
-  static final boolean SKIP_TRAILERS =
+  private static final boolean SKIP_TRAILERS =
       Optional.ofNullable(System.getenv("CBT_SKIP_HEADERS"))
           .map(Boolean::parseBoolean)
           .orElse(DIRECT_PATH_ENABLED);
@@ -240,6 +240,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   private final Map<String, String> jwtAudienceMapping;
   private final boolean enableRoutingCookie;
   private final boolean enableRetryInfo;
+  private final boolean enableSkipTrailers;
 
   private final ServerStreamingCallSettings<Query, Row> readRowsSettings;
   private final UnaryCallSettings<Query, Row> readRowSettings;
@@ -287,6 +288,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
     jwtAudienceMapping = builder.jwtAudienceMapping;
     enableRoutingCookie = builder.enableRoutingCookie;
     enableRetryInfo = builder.enableRetryInfo;
+    enableSkipTrailers = builder.enableSkipTrailers;
     metricsProvider = builder.metricsProvider;
     metricsEndpoint = builder.metricsEndpoint;
 
@@ -371,6 +373,10 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   @BetaApi("RetryInfo is not currently stable and may change in the future")
   public boolean getEnableRetryInfo() {
     return enableRetryInfo;
+  }
+
+  boolean getEnableSkipTrailers() {
+    return enableSkipTrailers;
   }
 
   /**
@@ -683,6 +689,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
     private Map<String, String> jwtAudienceMapping;
     private boolean enableRoutingCookie;
     private boolean enableRetryInfo;
+    private boolean enableSkipTrailers;
 
     private final ServerStreamingCallSettings.Builder<Query, Row> readRowsSettings;
     private final UnaryCallSettings.Builder<Query, Row> readRowSettings;
@@ -721,6 +728,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
       setCredentialsProvider(defaultCredentialsProviderBuilder().build());
       this.enableRoutingCookie = true;
       this.enableRetryInfo = true;
+      this.enableSkipTrailers = SKIP_TRAILERS;
       metricsProvider = DefaultMetricsProvider.INSTANCE;
 
       // Defaults provider
@@ -1085,6 +1093,11 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
       return enableRetryInfo;
     }
 
+    Builder setEnableSkipTrailers(boolean enabled) {
+      this.enableSkipTrailers = enabled;
+      return this;
+    }
+
     /** Returns the builder for the settings used for calls to readRows. */
     public ServerStreamingCallSettings.Builder<Query, Row> readRowsSettings() {
       return readRowsSettings;
@@ -1212,6 +1225,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
         .add("jwtAudienceMapping", jwtAudienceMapping)
         .add("enableRoutingCookie", enableRoutingCookie)
         .add("enableRetryInfo", enableRetryInfo)
+        .add("enableSkipTrailers", enableSkipTrailers)
         .add("readRowsSettings", readRowsSettings)
         .add("readRowSettings", readRowSettings)
         .add("sampleRowKeysSettings", sampleRowKeysSettings)

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracer.java
@@ -52,6 +52,11 @@ public class BigtableTracer extends BaseApiTracer {
     // noop
   }
 
+  /**
+   * Used by BigtableUnaryOperationCallable to signal that the user visible portion of the RPC is
+   * complete and that metrics should freeze the timers and then publish the frozen values when the
+   * internal portion of the operation completes.
+   */
   public void operationFinishEarly() {}
 
   /**

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracer.java
@@ -52,6 +52,8 @@ public class BigtableTracer extends BaseApiTracer {
     // noop
   }
 
+  public void operationFinishEarly() {}
+
   /**
    * Get the attempt number of the current call. Attempt number for the current call is passed in
    * and should be recorded in {@link #attemptStarted(int)}. With the getter we can access it from

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracer.java
@@ -299,9 +299,7 @@ class BuiltinMetricsTracer extends BigtableTracer {
     if (!opFinished.compareAndSet(false, true)) {
       return;
     }
-    if (operationTimer.isRunning()) {
-      operationTimer.stop();
-    }
+    long operationLatencyNano = operationTimer.elapsed(TimeUnit.NANOSECONDS);
 
     boolean isStreaming = operationType == OperationType.ServerStreaming;
     String statusStr = Util.extractStatus(status);
@@ -319,8 +317,6 @@ class BuiltinMetricsTracer extends BigtableTracer {
             .put(STREAMING_KEY, isStreaming)
             .put(STATUS_KEY, statusStr)
             .build();
-
-    long operationLatencyNano = operationTimer.elapsed(TimeUnit.NANOSECONDS);
 
     // Only record when retry count is greater than 0 so the retry
     // graph will be less confusing

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/CompositeTracer.java
@@ -63,6 +63,13 @@ class CompositeTracer extends BigtableTracer {
   }
 
   @Override
+  public void operationFinishEarly() {
+    for (BigtableTracer tracer : bigtableTracers) {
+      tracer.operationFinishEarly();
+    }
+  }
+
+  @Override
   public void operationSucceeded() {
     for (ApiTracer child : children) {
       child.operationSucceeded();

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
@@ -110,11 +110,6 @@ class MetricsTracer extends BigtableTracer {
       return;
     }
 
-    // Mightve stopped in operationFinishEarly()
-    if (operationTimer.isRunning()) {
-      operationTimer.stop();
-    }
-
     long elapsed = operationTimer.elapsed(TimeUnit.MILLISECONDS);
 
     MeasureMap measures =

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracer.java
@@ -85,6 +85,12 @@ class MetricsTracer extends BigtableTracer {
   }
 
   @Override
+  public void operationFinishEarly() {
+    attemptTimer.stop();
+    operationTimer.stop();
+  }
+
+  @Override
   public void operationSucceeded() {
     recordOperationCompletion(null);
   }
@@ -103,7 +109,11 @@ class MetricsTracer extends BigtableTracer {
     if (!opFinished.compareAndSet(false, true)) {
       return;
     }
-    operationTimer.stop();
+
+    // Mightve stopped in operationFinishEarly()
+    if (operationTimer.isRunning()) {
+      operationTimer.stop();
+    }
 
     long elapsed = operationTimer.elapsed(TimeUnit.MILLISECONDS);
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableUnaryOperationCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableUnaryOperationCallableTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.verify;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.grpc.GrpcCallContext;
-import com.google.api.gax.rpc.InternalException;
 import com.google.api.gax.tracing.ApiTracerFactory;
 import com.google.api.gax.tracing.SpanName;
 import com.google.cloud.bigtable.data.v2.stub.metrics.BigtableTracer;
@@ -88,18 +87,11 @@ public class BigtableUnaryOperationCallableTest {
     call.getController().getObserver().onResponse("first");
     call.getController().getObserver().onResponse("second");
 
-    Throwable e = Assert.assertThrows(ExecutionException.class, f::get).getCause();
-    assertThat(e).isInstanceOf(InternalException.class);
-    assertThat(e)
-        .hasMessageThat()
-        .contains(
-            "Received multiple responses for a Fake.method unary operation. Previous: first, New: second");
-
     ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
     verify(callable.logger).log(Mockito.any(), msgCaptor.capture());
     assertThat(msgCaptor.getValue())
         .isEqualTo(
-            "Received multiple responses for a Fake.method unary operation. Previous: first, New: second");
+            "Received response after future is resolved for a Fake.method unary operation. previous: first, New response: second");
 
     assertThat(call.getController().isCancelled()).isTrue();
   }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettingsTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettingsTest.java
@@ -961,6 +961,7 @@ public class EnhancedBigtableStubSettingsTest {
     "jwtAudienceMapping",
     "enableRoutingCookie",
     "enableRetryInfo",
+    "enableSkipTrailers",
     "readRowsSettings",
     "readRowSettings",
     "sampleRowKeysSettings",

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/SkipTrailersTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/SkipTrailersTest.java
@@ -195,6 +195,10 @@ public class SkipTrailersTest {
     }
   }
 
+  /**
+   * Hack the srvice definition to allow grpc server to simulate delayed trailers. This will augment
+   * the bigtable service definition to promote unary rpcs to server streaming
+   */
   class HackedBigtableService implements BindableService {
     private final LinkedBlockingDeque<ServerRpc<?, ?>> rpcs = new LinkedBlockingDeque<>();
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/SkipTrailersTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/SkipTrailersTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.data.v2.stub;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.tracing.ApiTracer;
+import com.google.api.gax.tracing.ApiTracerFactory;
+import com.google.auto.value.AutoValue;
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.v2.CheckAndMutateRowResponse;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.PingAndWarmResponse;
+import com.google.bigtable.v2.ReadModifyWriteRowResponse;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.Row;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.data.v2.FakeServiceBuilder;
+import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
+import com.google.cloud.bigtable.data.v2.models.Filters;
+import com.google.cloud.bigtable.data.v2.models.Mutation;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.data.v2.models.TableId;
+import com.google.cloud.bigtable.data.v2.models.TargetId;
+import com.google.cloud.bigtable.data.v2.stub.metrics.BigtableTracer;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.StringValue;
+import io.grpc.BindableService;
+import io.grpc.MethodDescriptor;
+import io.grpc.Server;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.stub.ServerCalls;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.exceptions.verification.WantedButNotInvoked;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class SkipTrailersTest {
+  @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private static final String PROJECT_ID = "fake-project";
+  private static final String INSTANCE_ID = "fake-instance";
+  private static final TargetId TABLE_ID = TableId.of("fake-table");
+
+  private HackedBigtableService hackedService;
+  private Server server;
+
+  @Mock private ApiTracerFactory tracerFactory;
+  @Mock private BigtableTracer tracer;
+
+  private BigtableDataClient client;
+
+  @Before
+  public void setUp() throws Exception {
+    hackedService = new HackedBigtableService();
+    server = FakeServiceBuilder.create(hackedService).start();
+
+    when(tracerFactory.newTracer(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(tracer);
+    when(tracer.inScope()).thenReturn(Mockito.mock(ApiTracer.Scope.class));
+
+    BigtableDataSettings.Builder clientBuilder =
+        BigtableDataSettings.newBuilderForEmulator(server.getPort())
+            .setProjectId(PROJECT_ID)
+            .setInstanceId(INSTANCE_ID)
+            .setCredentialsProvider(NoCredentialsProvider.create());
+    clientBuilder.stubSettings().setEnableSkipTrailers(true).setTracerFactory(tracerFactory);
+
+    client = BigtableDataClient.create(clientBuilder.build());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    client.close();
+    server.shutdown();
+  }
+
+  @Test
+  public void testReadRow() throws InterruptedException, ExecutionException {
+    ReadRowsResponse fakeResponse =
+        ReadRowsResponse.newBuilder()
+            .addChunks(
+                ReadRowsResponse.CellChunk.newBuilder()
+                    .setRowKey(ByteString.copyFromUtf8("fake-key"))
+                    .setFamilyName(StringValue.newBuilder().setValue("cf"))
+                    .setQualifier(BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("q")))
+                    .setTimestampMicros(0)
+                    .setValue(ByteString.copyFromUtf8("value"))
+                    .setCommitRow(true))
+            .build();
+    test(() -> client.readRowAsync(TABLE_ID, "fake-key"), fakeResponse);
+  }
+
+  @Test
+  public void testMutateRow() throws ExecutionException, InterruptedException {
+    test(
+        () -> client.mutateRowAsync(RowMutation.create(TABLE_ID, "fake-key")),
+        MutateRowResponse.getDefaultInstance());
+  }
+
+  @Test
+  public void testCheckAndMutateRow() throws ExecutionException, InterruptedException {
+    ConditionalRowMutation req =
+        ConditionalRowMutation.create(TABLE_ID, "fake-key")
+            .condition(Filters.FILTERS.pass())
+            .then(Mutation.create().deleteRow());
+    test(() -> client.checkAndMutateRowAsync(req), CheckAndMutateRowResponse.getDefaultInstance());
+  }
+
+  @Test
+  public void testRMW() throws ExecutionException, InterruptedException {
+    ReadModifyWriteRow req = ReadModifyWriteRow.create(TABLE_ID, "fake-key").append("cf", "q", "A");
+    test(
+        () -> client.readModifyWriteRowAsync(req),
+        ReadModifyWriteRowResponse.newBuilder().setRow(Row.getDefaultInstance()).build());
+  }
+
+  private <T> void test(Supplier<ApiFuture<?>> invoker, T fakeResponse)
+      throws InterruptedException, ExecutionException {
+    ApiFuture<?> future = invoker.get();
+
+    // Wait for the call to start on the server
+    @SuppressWarnings("unchecked")
+    ServerRpc<?, T> rpc = (ServerRpc<?, T>) hackedService.rpcs.poll(10, TimeUnit.SECONDS);
+    Preconditions.checkNotNull(
+        rpc, "Timed out waiting for the call to be received by the mock server");
+
+    // Send the only row
+    rpc.getResponseStream().onNext(fakeResponse);
+
+    // Ensure that the future resolves and does not throw an error
+    try {
+      future.get(1, TimeUnit.MINUTES);
+    } catch (TimeoutException e) {
+      Assert.fail("timed out waiting for the trailer optimization future to resolve");
+    }
+
+    verify(tracer, times(1)).operationFinishEarly();
+    verify(tracer, never()).operationSucceeded();
+
+    // clean up
+    rpc.getResponseStream().onCompleted();
+
+    // Ensure that the tracer is invoked after the internal operation is complete
+    // Since we dont have a way to know exactly when this happens, we poll
+    for (int i = 10; i > 0; i--) {
+      try {
+        verify(tracer, times(1)).operationSucceeded();
+        break;
+      } catch (WantedButNotInvoked e) {
+        if (i > 1) {
+          Thread.sleep(100);
+        } else {
+          throw e;
+        }
+      }
+    }
+  }
+
+  class HackedBigtableService implements BindableService {
+    private final LinkedBlockingDeque<ServerRpc<?, ?>> rpcs = new LinkedBlockingDeque<>();
+
+    @Override
+    public ServerServiceDefinition bindService() {
+      ServerServiceDefinition.Builder builder =
+          ServerServiceDefinition.builder(BigtableGrpc.SERVICE_NAME)
+              .addMethod(
+                  BigtableGrpc.getPingAndWarmMethod(),
+                  ServerCalls.asyncUnaryCall(
+                      (ignored, observer) -> {
+                        observer.onNext(PingAndWarmResponse.getDefaultInstance());
+                        observer.onCompleted();
+                      }))
+              .addMethod(
+                  BigtableGrpc.getReadRowsMethod(),
+                  ServerCalls.asyncServerStreamingCall(
+                      (req, observer) -> rpcs.add(ServerRpc.create(req, observer))));
+      ImmutableList<MethodDescriptor<? extends GeneratedMessageV3, ? extends GeneratedMessageV3>>
+          unaryDescriptors =
+              ImmutableList.of(
+                  BigtableGrpc.getMutateRowMethod(),
+                  BigtableGrpc.getCheckAndMutateRowMethod(),
+                  BigtableGrpc.getReadModifyWriteRowMethod());
+
+      for (MethodDescriptor<? extends GeneratedMessageV3, ? extends GeneratedMessageV3> desc :
+          unaryDescriptors) {
+        builder.addMethod(
+            desc.toBuilder().setType(MethodDescriptor.MethodType.SERVER_STREAMING).build(),
+            ServerCalls.asyncServerStreamingCall(
+                (req, observer) -> rpcs.add(ServerRpc.create(req, observer))));
+      }
+      return builder.build();
+    }
+  }
+
+  @AutoValue
+  abstract static class ServerRpc<ReqT, RespT> {
+    abstract ReqT getRequest();
+
+    abstract StreamObserver<RespT> getResponseStream();
+
+    static <ReqT, RespT> ServerRpc<ReqT, RespT> create(ReqT req, StreamObserver<RespT> resp) {
+      // return new AutoValue__(req, resp);
+      return new AutoValue_SkipTrailersTest_ServerRpc<>(req, resp);
+    }
+  }
+}


### PR DESCRIPTION
This is off by default and can be enabled using an environment variable.
When enabled, BigtableUnaryOperationCallable will resolve the user visible future immediately when a response is available and will tell metrics to freeze all timers. Metrics will still wait for the trailers in the background for necessary metadata to publish the frozen timer values.