### PR TITLE
fix: send priming requests on the channel directly

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -709,7 +709,6 @@
             grpc-auth is not directly used transitively, but is pulled to align with other grpc parts
             opencensus-impl-core is brought in transitively through opencensus-impl
             -->
-          <usedDependencies>io.grpc:grpc-auth</usedDependencies>
           <ignoredUsedUndeclaredDependencies>
             <ignoredUsedUndeclaredDependency>io.opencensus:opencensus-impl-core</ignoredUsedUndeclaredDependency>
           </ignoredUsedUndeclaredDependencies>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
@@ -137,7 +137,7 @@ class BigtableChannelPrimer implements ChannelPrimer {
       // TODO: Not sure if we should swallow the error here. We are pre-emptively swapping
       // channels if the new
       // channel is bad.
-      LOG.log(Level.WARNING, "failed to prime channel", e);
+      LOG.log(Level.WARNING, "Failed to prime channel", e);
     }
   }
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.data.v2.stub;
 import com.google.api.core.BetaApi;
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.grpc.ChannelPrimer;
-import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.auth.Credentials;
 import com.google.bigtable.v2.BigtableGrpc;
 import com.google.bigtable.v2.InstanceName;

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
@@ -81,11 +81,12 @@ class BigtableChannelPrimer implements ChannelPrimer {
         .getHeaders()
         .forEach((k, v) -> metadata.put(Metadata.Key.of(k, Metadata.ASCII_STRING_MARSHALLER), v));
 
-    String escapedName = escaper.escape(request.getName());
-    String escapedAppProfile = escaper.escape(request.getAppProfileId());
     metadata.put(
         requestParams,
-        escaper.escape(String.format("name=%s&app_profile_id=%s", escapedName, escapedAppProfile)));
+        escaper.escape(
+            String.format(
+                "name=%s&app_profile_id=%s",
+                escaper.escape(request.getName()), escaper.escape(request.getAppProfileId()))));
   }
 
   @Override

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
@@ -25,6 +25,7 @@ import com.google.bigtable.v2.InstanceName;
 import com.google.bigtable.v2.PingAndWarmRequest;
 import com.google.bigtable.v2.PingAndWarmResponse;
 import io.grpc.CallCredentials;
+import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
@@ -104,8 +105,7 @@ class BigtableChannelPrimer implements ChannelPrimer {
       ClientCall<PingAndWarmRequest, PingAndWarmResponse> clientCall =
           managedChannel.newCall(
               BigtableGrpc.getPingAndWarmMethod(),
-              GrpcCallContext.createDefault()
-                  .getCallOptions()
+              CallOptions.DEFAULT
                   .withCallCredentials(callCredentials)
                   .withDeadline(Deadline.after(1, TimeUnit.MINUTES)));
 
@@ -138,11 +138,11 @@ class BigtableChannelPrimer implements ChannelPrimer {
       // TODO: Not sure if we should swallow the error here. We are pre-emptively swapping
       // channels if the new
       // channel is bad.
-      LOG.warning(String.format("Failed to prime channel: %s", e));
+      LOG.log(Level.WARNING, "failed to prime channel", e);
     }
   }
 
-  private Metadata createMetadata(Map<String, String> headers, PingAndWarmRequest request) {
+  private static Metadata createMetadata(Map<String, String> headers, PingAndWarmRequest request) {
     Metadata metadata = new Metadata();
 
     headers.forEach(

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
@@ -91,10 +91,9 @@ class BigtableChannelPrimer implements ChannelPrimer {
 
     metadata.put(
         requestParams,
-        escaper.escape(
-            String.format(
-                "name=%s&app_profile_id=%s",
-                escaper.escape(request.getName()), escaper.escape(request.getAppProfileId()))));
+        String.format(
+            "name=%s&app_profile_id=%s",
+            escaper.escape(request.getName()), escaper.escape(request.getAppProfileId())));
   }
 
   @Override

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
@@ -16,12 +16,11 @@
 package com.google.cloud.bigtable.data.v2.stub;
 
 import com.google.api.core.BetaApi;
-import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
 import com.google.api.gax.grpc.ChannelPrimer;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
-import com.google.auth.Credentials;
+import com.google.api.gax.rpc.InstantiatingWatchdogProvider;
 import com.google.bigtable.v2.PingAndWarmRequest;
 import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.common.base.Preconditions;
@@ -43,18 +42,13 @@ class BigtableChannelPrimer implements ChannelPrimer {
 
   private final EnhancedBigtableStubSettings settingsTemplate;
 
-  static BigtableChannelPrimer create(
-      Credentials credentials, String projectId, String instanceId, String appProfileId) {
-    EnhancedBigtableStubSettings.Builder builder =
-        EnhancedBigtableStubSettings.newBuilder()
-            .setProjectId(projectId)
-            .setInstanceId(instanceId)
-            .setAppProfileId(appProfileId)
-            .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
-            // Disable refreshing channel here to avoid creating settings in a loop
-            .setRefreshingChannel(false)
-            .setExecutorProvider(
-                InstantiatingExecutorProvider.newBuilder().setExecutorThreadCount(1).build());
+  static BigtableChannelPrimer create(EnhancedBigtableStubSettings settings) {
+    EnhancedBigtableStubSettings.Builder builder = settings.toBuilder();
+    builder
+        .setRefreshingChannel(false)
+        .setBackgroundExecutorProvider(
+            InstantiatingExecutorProvider.newBuilder().setExecutorThreadCount(1).build())
+        .setStreamWatchdogProvider(InstantiatingWatchdogProvider.create());
 
     return new BigtableChannelPrimer(builder.build());
   }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimer.java
@@ -36,6 +36,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -94,7 +95,7 @@ class BigtableChannelPrimer implements ChannelPrimer {
               URLEncoder.encode(request.getName(), "UTF-8"),
               URLEncoder.encode(request.getAppProfileId(), "UTF-8")));
     } catch (UnsupportedEncodingException e) {
-      LOG.warning(String.format("failed to encode request params %s", e));
+      LOG.log(Level.WARNING, "Failed to encode request params", e);
     }
   }
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
@@ -103,12 +103,7 @@ public class BigtableClientContext {
       }
       // Inject channel priming if enabled
       if (builder.isRefreshingChannel()) {
-        transportProvider.setChannelPrimer(
-            BigtableChannelPrimer.create(
-                credentials,
-                settings.getProjectId(),
-                settings.getInstanceId(),
-                settings.getAppProfileId()));
+        transportProvider.setChannelPrimer(BigtableChannelPrimer.create(builder.build()));
       }
 
       builder.setTransportChannelProvider(transportProvider.build());

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
@@ -103,7 +103,13 @@ public class BigtableClientContext {
       }
       // Inject channel priming if enabled
       if (builder.isRefreshingChannel()) {
-        transportProvider.setChannelPrimer(BigtableChannelPrimer.create(builder.build()));
+        transportProvider.setChannelPrimer(
+            BigtableChannelPrimer.create(
+                builder.getProjectId(),
+                builder.getInstanceId(),
+                builder.getAppProfileId(),
+                credentials,
+                builder.getHeaderProvider().getHeaders()));
       }
 
       builder.setTransportChannelProvider(transportProvider.build());

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
@@ -188,7 +188,6 @@ public class EnhancedBigtableStub implements AutoCloseable {
   private final UnaryCallable<BulkMutation, Void> externalBulkMutateRowsCallable;
   private final UnaryCallable<ConditionalRowMutation, Boolean> checkAndMutateRowCallable;
   private final UnaryCallable<ReadModifyWriteRow, Row> readModifyWriteRowCallable;
-  private final UnaryCallable<PingAndWarmRequest, PingAndWarmResponse> pingAndWarmCallable;
 
   private final ServerStreamingCallable<String, ByteStringRange>
       generateInitialChangeStreamPartitionsCallable;
@@ -321,7 +320,6 @@ public class EnhancedBigtableStub implements AutoCloseable {
         createGenerateInitialChangeStreamPartitionsCallable();
     readChangeStreamCallable =
         createReadChangeStreamCallable(new DefaultChangeStreamRecordAdapter());
-    pingAndWarmCallable = createPingAndWarmCallable();
     executeQueryCallable = createExecuteQueryCallable();
   }
 
@@ -1252,28 +1250,6 @@ public class EnhancedBigtableStub implements AutoCloseable {
         .build();
   }
 
-  private UnaryCallable<PingAndWarmRequest, PingAndWarmResponse> createPingAndWarmCallable() {
-    UnaryCallable<PingAndWarmRequest, PingAndWarmResponse> pingAndWarm =
-        GrpcRawCallableFactory.createUnaryCallable(
-            GrpcCallSettings.<PingAndWarmRequest, PingAndWarmResponse>newBuilder()
-                .setMethodDescriptor(BigtableGrpc.getPingAndWarmMethod())
-                .setParamsExtractor(
-                    new RequestParamsExtractor<PingAndWarmRequest>() {
-                      @Override
-                      public Map<String, String> extract(PingAndWarmRequest request) {
-                        return ImmutableMap.of(
-                            "name", request.getName(),
-                            "app_profile_id", request.getAppProfileId());
-                      }
-                    })
-                .build(),
-            Collections.emptySet());
-    return pingAndWarm.withDefaultCallContext(
-        clientContext
-            .getDefaultCallContext()
-            .withRetrySettings(settings.pingAndWarmSettings().getRetrySettings()));
-  }
-
   private <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> withRetries(
       UnaryCallable<RequestT, ResponseT> innerCallable, UnaryCallSettings<?, ?> unaryCallSettings) {
     UnaryCallable<RequestT, ResponseT> retrying;
@@ -1379,10 +1355,6 @@ public class EnhancedBigtableStub implements AutoCloseable {
   /** Returns an {@link com.google.cloud.bigtable.data.v2.stub.sql.ExecuteQueryCallable} */
   public ExecuteQueryCallable executeQueryCallable() {
     return executeQueryCallable;
-  }
-
-  UnaryCallable<PingAndWarmRequest, PingAndWarmResponse> pingAndWarmCallable() {
-    return pingAndWarmCallable;
   }
 
   // </editor-fold>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
@@ -61,8 +61,6 @@ import com.google.bigtable.v2.GenerateInitialChangeStreamPartitionsRequest;
 import com.google.bigtable.v2.GenerateInitialChangeStreamPartitionsResponse;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.MutateRowsResponse;
-import com.google.bigtable.v2.PingAndWarmRequest;
-import com.google.bigtable.v2.PingAndWarmResponse;
 import com.google.bigtable.v2.ReadChangeStreamRequest;
 import com.google.bigtable.v2.ReadChangeStreamResponse;
 import com.google.bigtable.v2.ReadRowsRequest;

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimerTest.java
@@ -74,7 +74,7 @@ public class BigtableChannelPrimerTest {
             "fake-instance",
             "fake-app-profile",
             OAuth2Credentials.create(new AccessToken(TOKEN_VALUE, null)),
-            ImmutableMap.of());
+            ImmutableMap.of("bigtable-feature", "fake-feature"));
 
     channel =
         ManagedChannelBuilder.forAddress("localhost", server.getPort()).usePlaintext().build();
@@ -149,6 +149,20 @@ public class BigtableChannelPrimerTest {
     assertThat(logHandler.logs).hasSize(1);
     for (LogRecord log : logHandler.logs) {
       assertThat(log.getMessage()).contains("UnsupportedOperationException");
+    }
+  }
+
+  @Test
+  public void testHeadersAreSent() {
+    primer.primeChannel(channel);
+
+    for (Metadata metadata : metadataInterceptor.metadataList) {
+      assertThat(metadata.get(BigtableChannelPrimer.REQUEST_PARAMS))
+          .isEqualTo(
+              "name=projects%2Ffake-project%2Finstances%2Ffake-instance&app_profile_id=fake-app-profile");
+      assertThat(
+              metadata.get(Metadata.Key.of("bigtable-feature", Metadata.ASCII_STRING_MARSHALLER)))
+          .isEqualTo("fake-feature");
     }
   }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimerTest.java
@@ -135,7 +135,7 @@ public class BigtableChannelPrimerTest {
 
     assertThat(logHandler.logs).hasSize(1);
     for (LogRecord log : logHandler.logs) {
-      assertThat(log.getMessage()).contains("FAILED_PRECONDITION");
+      assertThat(log.getThrown().getMessage()).contains("FAILED_PRECONDITION");
     }
   }
 
@@ -148,7 +148,7 @@ public class BigtableChannelPrimerTest {
 
     assertThat(logHandler.logs).hasSize(1);
     for (LogRecord log : logHandler.logs) {
-      assertThat(log.getMessage()).contains("UnsupportedOperationException");
+      assertThat(log.getThrown()).isInstanceOf(UnsupportedOperationException.class);
     }
   }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimerTest.java
@@ -18,13 +18,13 @@ package com.google.cloud.bigtable.data.v2.stub;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.core.ApiFunction;
-import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.bigtable.v2.BigtableGrpc.BigtableImplBase;
 import com.google.bigtable.v2.PingAndWarmRequest;
 import com.google.bigtable.v2.PingAndWarmResponse;
 import com.google.cloud.bigtable.data.v2.FakeServiceBuilder;
+import com.google.common.collect.ImmutableMap;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
@@ -68,16 +68,13 @@ public class BigtableChannelPrimerTest {
 
     server = FakeServiceBuilder.create(fakeService).intercept(metadataInterceptor).start();
 
-    EnhancedBigtableStubSettings settings =
-        EnhancedBigtableStubSettings.newBuilder()
-            .setProjectId("fake-project")
-            .setInstanceId("fake-instance")
-            .setAppProfileId("fake-app-profile")
-            .setCredentialsProvider(
-                FixedCredentialsProvider.create(
-                    OAuth2Credentials.create(new AccessToken(TOKEN_VALUE, null))))
-            .build();
-    primer = BigtableChannelPrimer.create(settings);
+    primer =
+        BigtableChannelPrimer.create(
+            "fake-project",
+            "fake-instance",
+            "fake-app-profile",
+            OAuth2Credentials.create(new AccessToken(TOKEN_VALUE, null)),
+            ImmutableMap.of());
 
     channel =
         ManagedChannelBuilder.forAddress("localhost", server.getPort()).usePlaintext().build();

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/BigtableChannelPrimerTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.data.v2.stub;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.core.ApiFunction;
+import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.bigtable.v2.BigtableGrpc.BigtableImplBase;
@@ -67,12 +68,16 @@ public class BigtableChannelPrimerTest {
 
     server = FakeServiceBuilder.create(fakeService).intercept(metadataInterceptor).start();
 
-    primer =
-        BigtableChannelPrimer.create(
-            OAuth2Credentials.create(new AccessToken(TOKEN_VALUE, null)),
-            "fake-project",
-            "fake-instance",
-            "fake-app-profile");
+    EnhancedBigtableStubSettings settings =
+        EnhancedBigtableStubSettings.newBuilder()
+            .setProjectId("fake-project")
+            .setInstanceId("fake-instance")
+            .setAppProfileId("fake-app-profile")
+            .setCredentialsProvider(
+                FixedCredentialsProvider.create(
+                    OAuth2Credentials.create(new AccessToken(TOKEN_VALUE, null))))
+            .build();
+    primer = BigtableChannelPrimer.create(settings);
 
     channel =
         ManagedChannelBuilder.forAddress("localhost", server.getPort()).usePlaintext().build();


### PR DESCRIPTION
Send priming requests on the channel instead of using the stub. This means that we'll not collect metrics on ping and warm requests.

Fixes #2371 ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
