### PR TITLE
test: do not override status for mutate rows

### DIFF
--- a/test-proxy/src/main/java/com/google/cloud/bigtable/testproxy/CbtTestProxy.java
+++ b/test-proxy/src/main/java/com/google/cloud/bigtable/testproxy/CbtTestProxy.java
@@ -328,7 +328,13 @@ public class CbtTestProxy extends CloudBigtableV2TestProxyImplBase implements Cl
                     .build());
       }
       responseObserver.onNext(
-          resultBuilder.setStatus(com.google.rpc.Status.getDefaultInstance()).build());
+          resultBuilder
+              .setStatus(
+                  com.google.rpc.Status.newBuilder()
+                      .setCode(e.getStatusCode().getCode().ordinal())
+                      .setMessage(e.getMessage())
+                      .build())
+              .build());
       responseObserver.onCompleted();
       return;
     } catch (ApiException e) {


### PR DESCRIPTION
This is blocked on https://github.com/googleapis/cloud-bigtable-clients-test/pull/224.
