### PR TITLE
fix: Add known conformance test failures

### DIFF
--- a/.kokoro/conformance.sh
+++ b/.kokoro/conformance.sh
@@ -67,9 +67,7 @@ do
 
   pushd .
   cd cloud-bigtable-clients-test/tests
-  # If there is known failures, please add
-  # "-skip `cat ../../test-proxy/known_failures.txt`" to the command below.
-  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip '`cat ../../test-proxy/known_failures.txt`'"
+  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `tr -d '\n' < ../../test-proxy/known_failures.txt`"
   returnCode=$?
   popd
 

--- a/.kokoro/conformance.sh
+++ b/.kokoro/conformance.sh
@@ -67,7 +67,7 @@ do
 
   pushd .
   cd cloud-bigtable-clients-test/tests
-  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `tr -d '\n' < ../../test-proxy/known_failures.txt`"
+  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip '`cat ../../test-proxy/known_failures.txt`'"
   returnCode=$?
   popd
 

--- a/.kokoro/conformance.sh
+++ b/.kokoro/conformance.sh
@@ -71,7 +71,7 @@ do
   # "-skip `cat ../../java-bigtable/test-proxy/known_failures.txt`" to the command below.
   # working dir when running this is (...)/cloud-bigtable-client-tests/tests/
   # known_failures.txt is in (...)/java-bigtable/test-proxy/
-  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `tr -d '\n' < ../../java-bigtable/testproxy/known_failures.txt`"
+  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `cat ../../java-bigtable/testproxy/known_failures.txt`"
   returnCode=$?
   popd
 

--- a/.kokoro/conformance.sh
+++ b/.kokoro/conformance.sh
@@ -69,7 +69,7 @@ do
   cd cloud-bigtable-clients-test/tests
   # If there is known failures, please add
   # "-skip `cat ../../test-proxy/known_failures.txt`" to the command below.
-  eval "go test -v -proxy_addr=:9999 ${configFlag}"
+  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `cat ../../test-proxy/known_failures.txt`"
   returnCode=$?
   popd
 

--- a/.kokoro/conformance.sh
+++ b/.kokoro/conformance.sh
@@ -69,7 +69,7 @@ do
   cd cloud-bigtable-clients-test/tests
   # If there is known failures, please add
   # "-skip `cat ../../test-proxy/known_failures.txt`" to the command below.
-  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `tr -d '\n' < ../testproxy/known_failures.txt`"
+  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `tr -d '\n' < ./testproxy/known_failures.txt`"
   returnCode=$?
   popd
 

--- a/.kokoro/conformance.sh
+++ b/.kokoro/conformance.sh
@@ -69,7 +69,7 @@ do
   cd cloud-bigtable-clients-test/tests
   # If there is known failures, please add
   # "-skip `cat ../../test-proxy/known_failures.txt`" to the command below.
-  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `cat ../../test-proxy/known_failures.txt`"
+  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `tr -d '\n' < ../../testproxy/known_failures.txt`"
   returnCode=$?
   popd
 

--- a/.kokoro/conformance.sh
+++ b/.kokoro/conformance.sh
@@ -68,10 +68,8 @@ do
   pushd .
   cd cloud-bigtable-clients-test/tests
   # If there is known failures, please add
-  # "-skip `cat ../../java-bigtable/test-proxy/known_failures.txt`" to the command below.
-  # working dir when running this is (...)/cloud-bigtable-client-tests/tests/
-  # known_failures.txt is in (...)/java-bigtable/test-proxy/
-  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `cat ../../java-bigtable/test-proxy/known_failures.txt`"
+  # "-skip `cat ../../test-proxy/known_failures.txt`" to the command below.
+  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip '`cat ../../test-proxy/known_failures.txt`'"
   returnCode=$?
   popd
 

--- a/.kokoro/conformance.sh
+++ b/.kokoro/conformance.sh
@@ -68,8 +68,10 @@ do
   pushd .
   cd cloud-bigtable-clients-test/tests
   # If there is known failures, please add
-  # "-skip `cat ../../test-proxy/known_failures.txt`" to the command below.
-  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `tr -d '\n' < ./testproxy/known_failures.txt`"
+  # "-skip `cat ../../java-bigtable/test-proxy/known_failures.txt`" to the command below.
+  # working dir when running this is (...)/cloud-bigtable-client-tests/tests/
+  # known_failures.txt is in (...)/java-bigtable/test-proxy/
+  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `tr -d '\n' < ../../java-bigtable/testproxy/known_failures.txt`"
   returnCode=$?
   popd
 

--- a/.kokoro/conformance.sh
+++ b/.kokoro/conformance.sh
@@ -69,7 +69,7 @@ do
   cd cloud-bigtable-clients-test/tests
   # If there is known failures, please add
   # "-skip `cat ../../test-proxy/known_failures.txt`" to the command below.
-  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `tr -d '\n' < ../../testproxy/known_failures.txt`"
+  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `tr -d '\n' < ../testproxy/known_failures.txt`"
   returnCode=$?
   popd
 

--- a/.kokoro/conformance.sh
+++ b/.kokoro/conformance.sh
@@ -71,7 +71,7 @@ do
   # "-skip `cat ../../java-bigtable/test-proxy/known_failures.txt`" to the command below.
   # working dir when running this is (...)/cloud-bigtable-client-tests/tests/
   # known_failures.txt is in (...)/java-bigtable/test-proxy/
-  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `cat ../../java-bigtable/testproxy/known_failures.txt`"
+  eval "go test -v -proxy_addr=:9999 ${configFlag} -skip `cat ../../java-bigtable/test-proxy/known_failures.txt`"
   returnCode=$?
   popd
 

--- a/test-proxy/known_failures.txt
+++ b/test-proxy/known_failures.txt
@@ -1,2 +1,1 @@
-TestFeatureGap/traffic_director_enabled|
-TestFeatureGap/direct_access_requested
+TestFeatureGap/(traffic_director_enabled|direct_access_requested)

--- a/test-proxy/known_failures.txt
+++ b/test-proxy/known_failures.txt
@@ -1,1 +1,1 @@
-
+TestFeatureGap/(traffic_director_enabled|direct_access_requested)

--- a/test-proxy/known_failures.txt
+++ b/test-proxy/known_failures.txt
@@ -1,1 +1,2 @@
-TestFeatureGap/(traffic_director_enabled|direct_access_requested)
+TestFeatureGap/traffic_director_enabled|
+TestFeatureGap/direct_access_requested


### PR DESCRIPTION
2 new flags were added to `[cloud-bigtable-clients-test](https://github.com/googleapis/cloud-bigtable-clients-test)` when it upgraded `cloud.google.com/go/bigtable` from 1.33 to 1.34: https://github.com/googleapis/googleapis/commit/ab2ad69473e17b813f5555a44b89691f67b66297

This change skips the tests for those 2 flags