### PR TITLE
Revert "feat: next release from main branch is 2.54.0 (#2498)"

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -65,12 +65,5 @@ branches:
       - >-
         google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/Version.java
     branch: 2.39.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    extraFiles:
-      - >-
-        google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/Version.java
-    branch: 2.53.x
 extraFiles:
   - google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/Version.java

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -157,25 +157,6 @@ branchProtectionRules:
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
       - javadoc
       - conformance
-  - pattern: 2.53.x
-    isAdminEnforced: true
-    requiredApprovingReviewCount: 1
-    requiresCodeOwnerReviews: true
-    requiresStrictStatusChecks: false
-    requiredStatusCheckContexts:
-      - dependencies (17)
-      - lint
-      - clirr
-      - units (8)
-      - units (11)
-      - 'Kokoro - Test: Integration'
-      - cla/google
-      - 'Kokoro - Test: Java GraalVM Native Image'
-      - 'Kokoro - Test: Java 17 GraalVM Native Image'
-      - javadoc
-      - conformance
-      - library_generation
-      - unmanaged_dependency_check
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
This reverts commit f967deda8b68091dcc417b6c51f451abd36696f1.

Bigtable needed to do another release for LTS 8, so will revert this an open a new one
