### PR TITLE
chore: decouple internal metrics from application metrics [WIP]

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -224,9 +224,23 @@
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-common</artifactId>
     </dependency>
+    <!-- TODO: remove this -->
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.opentelemetry</groupId>
+      <artifactId>detector-resources</artifactId>
+      <version>0.27.0-alpha</version>
+    </dependency>
     <dependency>
       <groupId>com.google.cloud.opentelemetry</groupId>
       <artifactId>detector-resources-support</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.opentelemetry</groupId>
+      <artifactId>exporter-metrics</artifactId>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
@@ -128,6 +128,7 @@ public final class BigtableDataSettings {
         // disable channel refreshing when creating an emulator
         .setRefreshingChannel(false)
         .setMetricsProvider(NoopMetricsProvider.INSTANCE) // disable exporting metrics for emulator
+        .disableInternalMetrics()
         .setTransportChannelProvider(
             InstantiatingGrpcChannelProvider.newBuilder()
                 .setMaxInboundMessageSize(256 * 1024 * 1024)

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettingsTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettingsTest.java
@@ -976,6 +976,7 @@ public class EnhancedBigtableStubSettingsTest {
     "executeQuerySettings",
     "metricsProvider",
     "metricsEndpoint",
+    "enableInternalMetrics"
   };
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/ErrorCountPerConnectionTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/ErrorCountPerConnectionTest.java
@@ -103,7 +103,7 @@ public class ErrorCountPerConnectionTest {
             .setBackgroundExecutorProvider(FixedExecutorProvider.create(executors))
             .setProjectId("fake-project")
             .setInstanceId("fake-instance")
-            .setMetricsProvider(CustomOpenTelemetryMetricsProvider.create(otel));
+            .setInternalMetricsProvider((ignored1, ignored2) -> otel);
 
     runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
     when(executors.scheduleAtFixedRate(runnableCaptor.capture(), anyLong(), anyLong(), any()))


### PR DESCRIPTION
This creates a private instance of OpenTelemetry for internal metrics. Currently this only includes connection error distributions. This is necessary to unblock upcoming changes that will track additional metrics and a new unified BigtableClient monitored resource. The new monitored resource is incompatible with CustomOpenTelemetryMetricsProvider mechanic and thus needs its own instance of OpenTelemetry.

Next steps:
- replace the generic gce_instance & k8s_container monitored resources with bigtable_client
- introduce low level metrics for DirectAccess

Change-Id: Iaff323ea30ce17262d007d70344405637b81fd27

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed
- [ ] All new data plane features have a completed end to end testing plan

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
