### PR TITLE
chore: use 2 different exporter instances for internal and external metrics

### DIFF
--- a/google-cloud-bigtable/clirr-ignored-differences.xml
+++ b/google-cloud-bigtable/clirr-ignored-differences.xml
@@ -314,4 +314,10 @@
         <className>com/google/cloud/bigtable/data/v2/models/TargetId</className>
         <method>*scopedForMaterializedView()</method>
     </difference>
+
+    <difference>
+        <differenceType>7009</differenceType>
+        <className>com.google.cloud.bigtable.data.v2.stub.metrics.BigtableCloudMonitoringExporter</className>
+        <method>*</method>
+    </difference>
 </differences>

--- a/google-cloud-bigtable/clirr-ignored-differences.xml
+++ b/google-cloud-bigtable/clirr-ignored-differences.xml
@@ -314,8 +314,8 @@
         <className>com/google/cloud/bigtable/data/v2/models/TargetId</className>
         <method>*scopedForMaterializedView()</method>
     </difference>
-
     <difference>
+        <!-- BigtableCloudMonitoringExporter is InternalApi -->
         <differenceType>7009</differenceType>
         <className>com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter</className>
         <method>*</method>

--- a/google-cloud-bigtable/clirr-ignored-differences.xml
+++ b/google-cloud-bigtable/clirr-ignored-differences.xml
@@ -317,7 +317,7 @@
 
     <difference>
         <differenceType>7009</differenceType>
-        <className>com.google.cloud.bigtable.data.v2.stub.metrics.BigtableCloudMonitoringExporter</className>
+        <className>com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter</className>
         <method>*</method>
     </difference>
 </differences>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
@@ -156,7 +156,18 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
 
   /** Export metrics associated with a BigtableTable resource. */
   private CompletableResultCode doExport(Collection<MetricData> metricData) {
-    Map<ProjectName, List<TimeSeries>> bigtableTimeSeries = timeSeriesConverter.convert(metricData);
+    Map<ProjectName, List<TimeSeries>> bigtableTimeSeries;
+
+    try {
+      bigtableTimeSeries = timeSeriesConverter.convert(metricData);
+    } catch (Throwable t) {
+      logger.log(
+          Level.WARNING,
+          String.format(
+              "Failed to convert %s metric data to cloud monitoring timeseries.", exporterName),
+          t);
+      return CompletableResultCode.ofFailure();
+    }
 
     // Skips exporting if there's none
     if (bigtableTimeSeries.isEmpty()) {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
@@ -96,7 +96,7 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
   // https://cloud.google.com/monitoring/quotas#custom_metrics_quotas.
   private static final int EXPORT_BATCH_SIZE_LIMIT = 200;
 
-  private static String exporterName;
+  private final String exporterName;
 
   private final MetricServiceClient client;
 
@@ -114,7 +114,6 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
       @Nullable String endpoint,
       TimeSeriesConverter converter)
       throws IOException {
-    BigtableCloudMonitoringExporter.exporterName = exporterName;
 
     MetricServiceSettings.Builder settingsBuilder = MetricServiceSettings.newBuilder();
     CredentialsProvider credentialsProvider =
@@ -137,11 +136,13 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
     settingsBuilder.createServiceTimeSeriesSettings().setSimpleTimeoutNoRetriesDuration(timeout);
 
     return new BigtableCloudMonitoringExporter(
-        MetricServiceClient.create(settingsBuilder.build()), converter);
+        exporterName, MetricServiceClient.create(settingsBuilder.build()), converter);
   }
 
   @VisibleForTesting
-  BigtableCloudMonitoringExporter(MetricServiceClient client, TimeSeriesConverter converter) {
+  BigtableCloudMonitoringExporter(
+      String exporterName, MetricServiceClient client, TimeSeriesConverter converter) {
+    this.exporterName = exporterName;
     this.client = client;
     this.timeSeriesConverter = converter;
   }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
@@ -314,6 +314,11 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
 
     @Override
     public Map<ProjectName, List<TimeSeries>> convert(Collection<MetricData> metricData) {
+      MonitoredResource monitoredResource = this.monitoredResource.get();
+      if (monitoredResource == null) {
+        return ImmutableMap.of();
+      }
+
       List<MetricData> relevantData =
           metricData.stream()
               .filter(md -> APPLICATION_METRICS.contains(md.getName()))
@@ -323,9 +328,9 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
       }
 
       return ImmutableMap.of(
-          ProjectName.of(monitoredResource.get().getLabelsOrThrow(APPLICATION_RESOURCE_PROJECT_ID)),
+          ProjectName.of(monitoredResource.getLabelsOrThrow(APPLICATION_RESOURCE_PROJECT_ID)),
           BigtableExporterUtils.convertToApplicationResourceTimeSeries(
-              metricData, taskId, monitoredResource.get()));
+              metricData, taskId, monitoredResource));
     }
   }
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
@@ -175,8 +175,7 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
                   if (exportFailureLogged.compareAndSet(false, true)) {
                     String msg =
                         String.format(
-                            "createServiceTimeSeries request failed for %s.",
-                            exporterName);
+                            "createServiceTimeSeries request failed for %s.", exporterName);
                     if (throwable instanceof PermissionDeniedException) {
                       msg +=
                           String.format(

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
@@ -175,7 +175,7 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
                   if (exportFailureLogged.compareAndSet(false, true)) {
                     String msg =
                         String.format(
-                            "createServiceTimeSeries request failed for bigtable metrics %s.",
+                            "createServiceTimeSeries request failed for %s.",
                             exporterName);
                     if (throwable instanceof PermissionDeniedException) {
                       msg +=
@@ -285,7 +285,7 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
     private final String taskId;
 
     PublicTimeSeriesConverter() {
-      this(BigtableExporterUtils.getDefaultTaskValue());
+      this(BigtableExporterUtils.DEFAULT_TABLE_VALUE.get());
     }
 
     PublicTimeSeriesConverter(String taskId) {
@@ -315,7 +315,7 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
     private final Supplier<MonitoredResource> monitoredResource;
 
     InternalTimeSeriesConverter(Supplier<MonitoredResource> monitoredResource) {
-      this(monitoredResource, BigtableExporterUtils.getDefaultTaskValue());
+      this(monitoredResource, BigtableExporterUtils.DEFAULT_TABLE_VALUE.get());
     }
 
     InternalTimeSeriesConverter(Supplier<MonitoredResource> monitoredResource, String taskId) {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
@@ -122,7 +122,7 @@ class BigtableExporterUtils {
     return ProjectName.of(pointData.getAttributes().get(BIGTABLE_PROJECT_ID_KEY));
   }
 
-  // Returns a list of timeseries by project id
+  // Returns a list of timeseries by project name
   static Map<ProjectName, List<TimeSeries>> convertToBigtableTimeSeries(
       Collection<MetricData> collection, String taskId) {
     Map<ProjectName, List<TimeSeries>> allTimeSeries = new HashMap<>();
@@ -134,11 +134,11 @@ class BigtableExporterUtils {
       }
 
       for (PointData pd : metricData.getData().getPoints()) {
-        ProjectName projectId = getProjectName(pd);
+        ProjectName projectName = getProjectName(pd);
         List<TimeSeries> current =
-            allTimeSeries.computeIfAbsent(projectId, ignored -> new ArrayList<>());
+            allTimeSeries.computeIfAbsent(projectName, ignored -> new ArrayList<>());
         current.add(convertPointToBigtableTimeSeries(metricData, pd, taskId));
-        allTimeSeries.put(projectId, current);
+        allTimeSeries.put(projectName, current);
       }
     }
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
@@ -41,6 +41,8 @@ import com.google.cloud.opentelemetry.detection.DetectedPlatform;
 import com.google.cloud.opentelemetry.detection.GCPPlatformDetector;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
 import com.google.monitoring.v3.Point;
 import com.google.monitoring.v3.ProjectName;
@@ -91,7 +93,14 @@ class BigtableExporterUtils {
    * In most cases this should look like java-${UUID}@${hostname}. The hostname will be retrieved
    * from the jvm name and fallback to the local hostname.
    */
-  static String getDefaultTaskValue() {
+  private static String defaultTaskValue = null;
+
+  static final Supplier<String> DEFAULT_TABLE_VALUE = Suppliers.memoize(BigtableExporterUtils::computeDefaultTaskValue);
+
+  private static String computeDefaultTaskValue() {
+    if (defaultTaskValue != null) {
+      return defaultTaskValue;
+    }
     // Something like '<pid>@<hostname>'
     final String jvmName = ManagementFactory.getRuntimeMXBean().getName();
     // If jvm doesn't have the expected format, fallback to the local hostname

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
@@ -95,7 +95,8 @@ class BigtableExporterUtils {
    */
   private static String defaultTaskValue = null;
 
-  static final Supplier<String> DEFAULT_TABLE_VALUE = Suppliers.memoize(BigtableExporterUtils::computeDefaultTaskValue);
+  static final Supplier<String> DEFAULT_TABLE_VALUE =
+      Suppliers.memoize(BigtableExporterUtils::computeDefaultTaskValue);
 
   private static String computeDefaultTaskValue() {
     if (defaultTaskValue != null) {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
@@ -43,6 +43,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.monitoring.v3.Point;
+import com.google.monitoring.v3.ProjectName;
 import com.google.monitoring.v3.TimeInterval;
 import com.google.monitoring.v3.TimeSeries;
 import com.google.monitoring.v3.TypedValue;
@@ -107,14 +108,14 @@ class BigtableExporterUtils {
     return "java-" + UUID.randomUUID() + jvmName;
   }
 
-  static String getProjectId(PointData pointData) {
-    return pointData.getAttributes().get(BIGTABLE_PROJECT_ID_KEY);
+  static ProjectName getProjectName(PointData pointData) {
+    return ProjectName.of(pointData.getAttributes().get(BIGTABLE_PROJECT_ID_KEY));
   }
 
   // Returns a list of timeseries by project id
-  static Map<String, List<TimeSeries>> convertToBigtableTimeSeries(
-      List<MetricData> collection, String taskId) {
-    Map<String, List<TimeSeries>> allTimeSeries = new HashMap<>();
+  static Map<ProjectName, List<TimeSeries>> convertToBigtableTimeSeries(
+      Collection<MetricData> collection, String taskId) {
+    Map<ProjectName, List<TimeSeries>> allTimeSeries = new HashMap<>();
 
     for (MetricData metricData : collection) {
       if (!metricData.getInstrumentationScopeInfo().getName().equals(METER_NAME)) {
@@ -123,7 +124,7 @@ class BigtableExporterUtils {
       }
 
       for (PointData pd : metricData.getData().getPoints()) {
-        String projectId = getProjectId(pd);
+        ProjectName projectId = getProjectName(pd);
         List<TimeSeries> current =
             allTimeSeries.computeIfAbsent(projectId, ignored -> new ArrayList<>());
         current.add(convertPointToBigtableTimeSeries(metricData, pd, taskId));

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsView.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsView.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.data.v2.stub.metrics;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.base.Suppliers;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.View;
@@ -99,11 +100,22 @@ public class BuiltinMetricsView {
   public static void registerBuiltinMetrics(
       @Nullable Credentials credentials, SdkMeterProviderBuilder builder, @Nullable String endpoint)
       throws IOException {
-    MetricExporter metricExporter = BigtableCloudMonitoringExporter.create(credentials, endpoint);
+    MetricExporter publicExporter =
+        BigtableCloudMonitoringExporter.create(
+            credentials, endpoint, new BigtableCloudMonitoringExporter.PublicTimeSeriesConverter());
+    MetricExporter internalExporter =
+        BigtableCloudMonitoringExporter.create(
+            credentials,
+            endpoint,
+            new BigtableCloudMonitoringExporter.InternalTimeSeriesConverter(
+                Suppliers.memoize(BigtableExporterUtils::detectResourceSafe)));
+
     for (Map.Entry<InstrumentSelector, View> entry :
         BuiltinMetricsConstants.getAllViews().entrySet()) {
       builder.registerView(entry.getKey(), entry.getValue());
     }
-    builder.registerMetricReader(PeriodicMetricReader.create(metricExporter));
+    builder
+        .registerMetricReader(PeriodicMetricReader.create(publicExporter))
+        .registerMetricReader(PeriodicMetricReader.create(internalExporter));
   }
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsView.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsView.java
@@ -102,9 +102,13 @@ public class BuiltinMetricsView {
       throws IOException {
     MetricExporter publicExporter =
         BigtableCloudMonitoringExporter.create(
-            credentials, endpoint, new BigtableCloudMonitoringExporter.PublicTimeSeriesConverter());
+            "bigtable metrics",
+            credentials,
+            endpoint,
+            new BigtableCloudMonitoringExporter.PublicTimeSeriesConverter());
     MetricExporter internalExporter =
         BigtableCloudMonitoringExporter.create(
+            "application metrics",
             credentials,
             endpoint,
             new BigtableCloudMonitoringExporter.InternalTimeSeriesConverter(

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/DynamicFlowControlCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/DynamicFlowControlCallableTest.java
@@ -100,10 +100,11 @@ public class DynamicFlowControlCallableTest {
 
   @Test
   public void testLatenciesAreRecorded() throws Exception {
-    DynamicFlowControlStats stats = new DynamicFlowControlStats();
     DynamicFlowControlCallable callableToTest =
         new DynamicFlowControlCallable(
-            innerCallable, flowController, stats, TARGET_LATENCY_MS, ADJUSTING_INTERVAL_MS);
+            // significantly increase targetLatency to ensure that slow CI runners dont accidentally
+            // trigger a resize
+            innerCallable, flowController, stats, TARGET_LATENCY_MS * 10, ADJUSTING_INTERVAL_MS);
     Map<String, List<String>> extraHeaders = new HashMap<>();
     extraHeaders.put(LATENCY_HEADER, Arrays.asList("5"));
     ApiCallContext newContext = context.withExtraHeaders(extraHeaders);

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubTest.java
@@ -99,6 +99,7 @@ import com.google.rpc.Status;
 import io.grpc.CallOptions;
 import io.grpc.Context;
 import io.grpc.Deadline;
+import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
@@ -238,6 +239,9 @@ public class EnhancedBigtableStubTest {
             .setPrivateKeyId("fake-private-key")
             .build();
 
+    ManagedChannel channel =
+        ManagedChannelBuilder.forAddress("localhost", server.getPort()).usePlaintext().build();
+
     EnhancedBigtableStubSettings settings =
         EnhancedBigtableStubSettings.newBuilder()
             .setProjectId("fake-project")
@@ -247,11 +251,7 @@ public class EnhancedBigtableStubTest {
             .setMetricsProvider(NoopMetricsProvider.INSTANCE)
             // Use a fixed channel that will ignore the default endpoint and connect to the emulator
             .setTransportChannelProvider(
-                FixedTransportChannelProvider.create(
-                    GrpcTransportChannel.create(
-                        ManagedChannelBuilder.forAddress("localhost", server.getPort())
-                            .usePlaintext()
-                            .build())))
+                FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel)))
             // Channel refreshing doesn't work with FixedTransportChannelProvider. Disable it for
             // the test
             .setRefreshingChannel(false)
@@ -263,6 +263,7 @@ public class EnhancedBigtableStubTest {
       stub.readRowCallable().futureCall(Query.create("fake-table")).get();
       metadata = metadataInterceptor.headers.take();
     }
+    channel.shutdown();
 
     String authValue = metadata.get(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER));
     String expectedPrefix = "Bearer ";

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporterTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporterTest.java
@@ -96,6 +96,7 @@ public class BigtableCloudMonitoringExporterTest {
 
     exporter =
         new BigtableCloudMonitoringExporter(
+            "bigtable metrics",
             fakeMetricServiceClient,
             new BigtableCloudMonitoringExporter.PublicTimeSeriesConverter(taskId));
 
@@ -309,6 +310,7 @@ public class BigtableCloudMonitoringExporterTest {
     String gceProjectId = "fake-gce-project";
     BigtableCloudMonitoringExporter exporter =
         new BigtableCloudMonitoringExporter(
+            "application metrics",
             fakeMetricServiceClient,
             new BigtableCloudMonitoringExporter.InternalTimeSeriesConverter(
                 Suppliers.ofInstance(

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporterTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporterTest.java
@@ -96,7 +96,8 @@ public class BigtableCloudMonitoringExporterTest {
 
     exporter =
         new BigtableCloudMonitoringExporter(
-            fakeMetricServiceClient, /* applicationResource= */ Suppliers.ofInstance(null), taskId);
+            fakeMetricServiceClient,
+            new BigtableCloudMonitoringExporter.PublicTimeSeriesConverter(taskId));
 
     attributes =
         Attributes.builder()
@@ -309,13 +310,14 @@ public class BigtableCloudMonitoringExporterTest {
     BigtableCloudMonitoringExporter exporter =
         new BigtableCloudMonitoringExporter(
             fakeMetricServiceClient,
-            Suppliers.ofInstance(
-                MonitoredResource.newBuilder()
-                    .setType("gce-instance")
-                    .putLabels("some-gce-key", "some-gce-value")
-                    .putLabels("project_id", gceProjectId)
-                    .build()),
-            taskId);
+            new BigtableCloudMonitoringExporter.InternalTimeSeriesConverter(
+                Suppliers.ofInstance(
+                    MonitoredResource.newBuilder()
+                        .setType("gce-instance")
+                        .putLabels("some-gce-key", "some-gce-value")
+                        .putLabels("project_id", gceProjectId)
+                        .build()),
+                taskId));
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
@@ -70,6 +70,7 @@ import com.google.cloud.bigtable.data.v2.models.TableId;
 import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStub;
 import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings;
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.Comparators;
 import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
@@ -719,8 +720,11 @@ public class BuiltinMetricsTracerTest {
             .put(CLIENT_NAME_KEY, CLIENT_NAME)
             .build();
 
-    Duration value = Duration.ofMillis(getAggregatedValue(clientLatency, attributes));
-    assertThat(value).isAtLeast(CHANNEL_BLOCKING_LATENCY.minus(proxyDelayPriorTest));
+    assertThat(Duration.ofMillis(getAggregatedValue(clientLatency, attributes)))
+        .isAtLeast(
+            // Offset the expected latency to deal with asynchrony and jitter
+            CHANNEL_BLOCKING_LATENCY.minus(
+                Comparators.max(proxyDelayPriorTest, Duration.ofMillis(1))));
   }
 
   @Test
@@ -743,8 +747,11 @@ public class BuiltinMetricsTracerTest {
             .put(CLIENT_NAME_KEY, CLIENT_NAME)
             .build();
 
-    Duration actual = Duration.ofMillis(getAggregatedValue(clientLatency, attributes));
-    assertThat(actual).isAtLeast(CHANNEL_BLOCKING_LATENCY.minus(proxyDelayPriorTest));
+    assertThat(Duration.ofMillis(getAggregatedValue(clientLatency, attributes)))
+        .isAtLeast(
+            // Offset the expected latency to deal with asynchrony and jitter
+            CHANNEL_BLOCKING_LATENCY.minus(
+                Comparators.max(proxyDelayPriorTest, Duration.ofMillis(1))));
   }
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/mutaterows/MutateRowsRetryTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/mutaterows/MutateRowsRetryTest.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import com.google.cloud.bigtable.data.v2.models.BulkMutation;
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.cloud.bigtable.data.v2.stub.metrics.NoopMetricsProvider;
 import com.google.common.collect.Queues;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -62,7 +63,8 @@ public class MutateRowsRetryTest {
         BigtableDataSettings.newBuilder()
             .setProjectId("fake-project")
             .setInstanceId("fake-instance")
-            .setCredentialsProvider(NoCredentialsProvider.create());
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .setMetricsProvider(NoopMetricsProvider.INSTANCE);
 
     settings
         .stubSettings()

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/readrows/ReadRowsRetryTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/readrows/ReadRowsRetryTest.java
@@ -36,6 +36,7 @@ import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
 import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.data.v2.stub.metrics.NoopMetricsProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
@@ -86,7 +87,8 @@ public class ReadRowsRetryTest {
         BigtableDataSettings.newBuilder()
             .setProjectId(PROJECT_ID)
             .setInstanceId(INSTANCE_ID)
-            .setCredentialsProvider(NoCredentialsProvider.create());
+            .setCredentialsProvider(NoCredentialsProvider.create())
+            .setMetricsProvider(NoopMetricsProvider.INSTANCE);
 
     settings
         .stubSettings()


### PR DESCRIPTION
This is necessary to unblock upcoming changes that will track additional metrics and a new unified BigtableClient monitored resource.

The primary change was to extract metric data creation from BigtableCloudMonitoringExporter into TimeSeriesConverter. This removes the code duplication in exportBigtableResourceMetrics & exportApplicationResourceMetrics. But more importantly it allows us to have to 2 separate instances of BigtableCloudMonitoringExporter - one for internal metrics and another for public metrics. This will be needed in follow up PRs that will change the monitored resource that internal metrics use - the new monitored resource is incompatible CustomOpenTelemetryMetricsProvider that is needed for public metrics

Change-Id: I3a051f1faccaba1fc17e4151d1ed85ff8e5952f6

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed
- [ ] All new data plane features have a completed end to end testing plan

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
