### PR TITLE
chore: create a separate otel instance for internal metrics

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
@@ -128,6 +128,7 @@ public final class BigtableDataSettings {
         // disable channel refreshing when creating an emulator
         .setRefreshingChannel(false)
         .setMetricsProvider(NoopMetricsProvider.INSTANCE) // disable exporting metrics for emulator
+        .disableInternalMetrics()
         .setTransportChannelProvider(
             InstantiatingGrpcChannelProvider.newBuilder()
                 .setMaxInboundMessageSize(256 * 1024 * 1024)
@@ -295,6 +296,11 @@ public final class BigtableDataSettings {
   /** Gets the {@link MetricsProvider}. * */
   public MetricsProvider getMetricsProvider() {
     return stubSettings.getMetricsProvider();
+  }
+
+  /** Checks if internal metrics are enabled */
+  public boolean areInternalMetricsEnabled() {
+    return stubSettings.areInternalMetricsEnabled();
   }
 
   /** Returns the underlying RPC settings. */
@@ -568,6 +574,15 @@ public final class BigtableDataSettings {
     /** Gets the {@link MetricsProvider}. */
     public MetricsProvider getMetricsProvider() {
       return stubSettings.getMetricsProvider();
+    }
+
+    public Builder disableInternalMetrics() {
+      stubSettings.disableInternalMetrics();
+      return this;
+    }
+
+    public boolean areInternalMetricsEnabled() {
+      return stubSettings.areInternalMetricsEnabled();
     }
 
     /**

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
@@ -98,7 +98,8 @@ public class BigtableClientContext {
               .getInternalMetricsProvider()
               .createOtelProvider(credentials, settings.getMetricsEndpoint());
       if (internalOtel != null) {
-        // Set up per connection error count tracker if OpenTelemetry is not null
+        // Set up per connection error count tracker if all dependencies are met:
+        // a configurable transport provider + otel
         errorCountPerConnectionMetricTracker =
             setupPerConnectionErrorTracer(builder, transportProvider, internalOtel);
       }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
@@ -33,6 +33,7 @@ import com.google.cloud.bigtable.data.v2.stub.metrics.MetricsProvider;
 import com.google.cloud.bigtable.data.v2.stub.metrics.NoopMetricsProvider;
 import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -50,6 +51,7 @@ public class BigtableClientContext {
   private static final Logger logger = Logger.getLogger(BigtableClientContext.class.getName());
 
   @Nullable private final OpenTelemetry openTelemetry;
+  @Nullable private final OpenTelemetrySdk internalOpenTelemetry;
   private final ClientContext clientContext;
 
   public static BigtableClientContext create(EnhancedBigtableStubSettings settings)
@@ -84,18 +86,30 @@ public class BigtableClientContext {
             ? ((InstantiatingGrpcChannelProvider) builder.getTransportChannelProvider()).toBuilder()
             : null;
 
-    ErrorCountPerConnectionMetricTracker errorCountPerConnectionMetricTracker = null;
+    @Nullable OpenTelemetrySdk internalOtel = null;
+    @Nullable ErrorCountPerConnectionMetricTracker errorCountPerConnectionMetricTracker = null;
+
+    // Internal metrics are scoped to the connections, so we need a mutable transportProvider,
+    // otherwise there is
+    // no reason to build the internal OtelProvider
+    if (transportProvider != null) {
+      internalOtel =
+          settings
+              .getInternalMetricsProvider()
+              .createOtelProvider(credentials, settings.getMetricsEndpoint());
+      if (internalOtel != null) {
+        // Set up per connection error count tracker if OpenTelemetry is not null
+        errorCountPerConnectionMetricTracker =
+            setupPerConnectionErrorTracer(builder, transportProvider, internalOtel);
+      }
+    }
 
     if (transportProvider != null) {
       // Set up cookie holder if routing cookie is enabled
       if (builder.getEnableRoutingCookie()) {
         setupCookieHolder(transportProvider);
       }
-      // Set up per connection error count tracker if OpenTelemetry is not null
-      if (openTelemetry != null) {
-        errorCountPerConnectionMetricTracker =
-            setupPerConnectionErrorTracer(builder, transportProvider, openTelemetry);
-      }
+
       // Inject channel priming if enabled
       if (builder.isRefreshingChannel()) {
         transportProvider.setChannelPrimer(
@@ -117,12 +131,16 @@ public class BigtableClientContext {
           clientContext.getExecutor());
     }
 
-    return new BigtableClientContext(clientContext, openTelemetry);
+    return new BigtableClientContext(clientContext, openTelemetry, internalOtel);
   }
 
-  private BigtableClientContext(ClientContext clientContext, OpenTelemetry openTelemetry) {
+  private BigtableClientContext(
+      ClientContext clientContext,
+      OpenTelemetry openTelemetry,
+      @Nullable OpenTelemetrySdk internalOtel) {
     this.clientContext = clientContext;
     this.openTelemetry = openTelemetry;
+    this.internalOpenTelemetry = internalOtel;
   }
 
   public OpenTelemetry getOpenTelemetry() {
@@ -136,6 +154,9 @@ public class BigtableClientContext {
   public void close() throws Exception {
     for (BackgroundResource resource : clientContext.getBackgroundResources()) {
       resource.close();
+    }
+    if (internalOpenTelemetry != null) {
+      internalOpenTelemetry.close();
     }
   }
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
@@ -296,7 +296,7 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
     private final String taskId;
 
     PublicTimeSeriesConverter() {
-      this(BigtableExporterUtils.DEFAULT_TABLE_VALUE.get());
+      this(BigtableExporterUtils.DEFAULT_TASK_VALUE.get());
     }
 
     PublicTimeSeriesConverter(String taskId) {
@@ -326,7 +326,7 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
     private final Supplier<MonitoredResource> monitoredResource;
 
     InternalTimeSeriesConverter(Supplier<MonitoredResource> monitoredResource) {
-      this(monitoredResource, BigtableExporterUtils.DEFAULT_TABLE_VALUE.get());
+      this(monitoredResource, BigtableExporterUtils.DEFAULT_TASK_VALUE.get());
     }
 
     InternalTimeSeriesConverter(Supplier<MonitoredResource> monitoredResource, String taskId) {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
@@ -95,7 +95,7 @@ class BigtableExporterUtils {
    */
   private static String defaultTaskValue = null;
 
-  static final Supplier<String> DEFAULT_TABLE_VALUE =
+  static final Supplier<String> DEFAULT_TASK_VALUE =
       Suppliers.memoize(BigtableExporterUtils::computeDefaultTaskValue);
 
   private static String computeDefaultTaskValue() {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
@@ -140,6 +140,20 @@ public class BuiltinMetricsConstants {
     viewMap.put(selector, view);
   }
 
+  public static Map<InstrumentSelector, View> getInternalViews() {
+    ImmutableMap.Builder<InstrumentSelector, View> views = ImmutableMap.builder();
+    defineView(
+        views,
+        PER_CONNECTION_ERROR_COUNT_NAME,
+        AGGREGATION_PER_CONNECTION_ERROR_COUNT_HISTOGRAM,
+        InstrumentType.HISTOGRAM,
+        "1",
+        ImmutableSet.<AttributeKey>builder()
+            .add(BIGTABLE_PROJECT_ID_KEY, INSTANCE_ID_KEY, APP_PROFILE_KEY, CLIENT_NAME_KEY)
+            .build());
+    return views.build();
+  }
+
   public static Map<InstrumentSelector, View> getAllViews() {
     ImmutableMap.Builder<InstrumentSelector, View> views = ImmutableMap.builder();
 
@@ -205,16 +219,6 @@ public class BuiltinMetricsConstants {
         InstrumentType.COUNTER,
         "1",
         ImmutableSet.<AttributeKey>builder().addAll(COMMON_ATTRIBUTES).add(STATUS_KEY).build());
-
-    defineView(
-        views,
-        PER_CONNECTION_ERROR_COUNT_NAME,
-        AGGREGATION_PER_CONNECTION_ERROR_COUNT_HISTOGRAM,
-        InstrumentType.HISTOGRAM,
-        "1",
-        ImmutableSet.<AttributeKey>builder()
-            .add(BIGTABLE_PROJECT_ID_KEY, INSTANCE_ID_KEY, APP_PROFILE_KEY, CLIENT_NAME_KEY)
-            .build());
     defineView(
         views,
         REMAINING_DEADLINE_NAME,

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsView.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsView.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.data.v2.stub.metrics;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.common.base.Suppliers;
 import io.opentelemetry.sdk.metrics.InstrumentSelector;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.View;
@@ -106,20 +105,11 @@ public class BuiltinMetricsView {
             credentials,
             endpoint,
             new BigtableCloudMonitoringExporter.PublicTimeSeriesConverter());
-    MetricExporter internalExporter =
-        BigtableCloudMonitoringExporter.create(
-            "application metrics",
-            credentials,
-            endpoint,
-            new BigtableCloudMonitoringExporter.InternalTimeSeriesConverter(
-                Suppliers.memoize(BigtableExporterUtils::detectResourceSafe)));
 
     for (Map.Entry<InstrumentSelector, View> entry :
         BuiltinMetricsConstants.getAllViews().entrySet()) {
       builder.registerView(entry.getKey(), entry.getValue());
     }
-    builder
-        .registerMetricReader(PeriodicMetricReader.create(publicExporter))
-        .registerMetricReader(PeriodicMetricReader.create(internalExporter));
+    builder.registerMetricReader(PeriodicMetricReader.create(publicExporter));
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettingsTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettingsTest.java
@@ -976,6 +976,7 @@ public class EnhancedBigtableStubSettingsTest {
     "executeQuerySettings",
     "metricsProvider",
     "metricsEndpoint",
+    "areInternalMetricsEnabled",
   };
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
@@ -102,6 +102,7 @@ import java.net.SocketAddress;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -968,11 +969,12 @@ public class BuiltinMetricsTracerTest {
 
     Duration getCurrentDelayUsed() {
       Instant local = lastProxyDelay;
-      // If the delay was never injected
+      // If the delay was never injected - add 1 ms for channel establishment
       if (local == null) {
-        return Duration.ZERO;
+        return Duration.ofMillis(1);
       }
-      Duration duration = Duration.between(local, Instant.now());
+      Duration duration =
+          Duration.between(local, Instant.now()).plus(Duration.of(10, ChronoUnit.MICROS));
 
       assertWithMessage("test burned through all channel blocking latency during setup")
           .that(duration)

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/ErrorCountPerConnectionTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/ErrorCountPerConnectionTest.java
@@ -89,9 +89,9 @@ public class ErrorCountPerConnectionTest {
     SdkMeterProviderBuilder meterProvider =
         SdkMeterProvider.builder().registerMetricReader(metricReader);
 
-    for (Map.Entry<InstrumentSelector, View> entry :
-        BuiltinMetricsConstants.getAllViews().entrySet()) {
-      meterProvider.registerView(entry.getKey(), entry.getValue());
+    for (Map.Entry<InstrumentSelector, View> e :
+        BuiltinMetricsConstants.getInternalViews().entrySet()) {
+      meterProvider.registerView(e.getKey(), e.getValue());
     }
 
     OpenTelemetrySdk otel =
@@ -103,7 +103,8 @@ public class ErrorCountPerConnectionTest {
             .setBackgroundExecutorProvider(FixedExecutorProvider.create(executors))
             .setProjectId("fake-project")
             .setInstanceId("fake-instance")
-            .setMetricsProvider(CustomOpenTelemetryMetricsProvider.create(otel));
+            .setMetricsProvider(NoopMetricsProvider.INSTANCE)
+            .setInternalMetricsProvider((ignored1, ignored2) -> otel);
 
     runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
     when(executors.scheduleAtFixedRate(runnableCaptor.capture(), anyLong(), anyLong(), any()))


### PR DESCRIPTION
Building on #2515, this creates a private instance of otel for internal metrics. This is necessary for a follow up pr that will introduce a new internal monitored resource

Changes:
- create a separate setting for disabling internal metrics (since internal metrics will not support customer provided exporters)
- create internal metrics as part of BigtableClientContext creation
- split off internal views

Change-Id: Iaafc327f3f008bcc29510594210e0914342f84fe

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed
- [ ] All new data plane features have a completed end to end testing plan

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
