### PR TITLE
chore: migrate internal metrics to use bigtable_client monitored resource

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
@@ -94,9 +94,7 @@ public class BigtableClientContext {
     // no reason to build the internal OtelProvider
     if (transportProvider != null) {
       internalOtel =
-          settings
-              .getInternalMetricsProvider()
-              .createOtelProvider(credentials, settings.getMetricsEndpoint());
+          settings.getInternalMetricsProvider().createOtelProvider(settings, credentials);
       if (internalOtel != null) {
         // Set up per connection error count tracker if all dependencies are met:
         // a configurable transport provider + otel

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -1346,8 +1346,8 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   @FunctionalInterface
   public interface InternalMetricsProvider {
     @Nullable
-    OpenTelemetrySdk createOtelProvider(Credentials creds, @Nullable String endpoint)
-        throws IOException;
+    OpenTelemetrySdk createOtelProvider(
+        EnhancedBigtableStubSettings userSettings, Credentials creds) throws IOException;
   }
 
   private static final InternalMetricsProvider DEFAULT_INTERNAL_OTEL_PROVIDER =

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
@@ -322,16 +322,10 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
             .map(m -> METER_NAME + m)
             .collect(ImmutableList.toImmutableList());
 
-    private final String taskId;
     private final Supplier<MonitoredResource> monitoredResource;
 
     InternalTimeSeriesConverter(Supplier<MonitoredResource> monitoredResource) {
-      this(monitoredResource, BigtableExporterUtils.DEFAULT_TASK_VALUE.get());
-    }
-
-    InternalTimeSeriesConverter(Supplier<MonitoredResource> monitoredResource, String taskId) {
       this.monitoredResource = monitoredResource;
-      this.taskId = taskId;
     }
 
     @Override
@@ -352,7 +346,7 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
       return ImmutableMap.of(
           ProjectName.of(monitoredResource.getLabelsOrThrow(APPLICATION_RESOURCE_PROJECT_ID)),
           BigtableExporterUtils.convertToApplicationResourceTimeSeries(
-              relevantData, taskId, monitoredResource));
+              relevantData, monitoredResource));
     }
   }
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
@@ -158,7 +158,7 @@ class BigtableExporterUtils {
   }
 
   static List<TimeSeries> convertToApplicationResourceTimeSeries(
-      Collection<MetricData> collection, String taskId, MonitoredResource applicationResource) {
+      Collection<MetricData> collection, MonitoredResource applicationResource) {
     Preconditions.checkNotNull(
         applicationResource,
         "convert application metrics is called when the supported resource is not detected");
@@ -172,7 +172,7 @@ class BigtableExporterUtils {
           .map(
               pointData ->
                   convertPointToApplicationResourceTimeSeries(
-                      metricData, pointData, taskId, applicationResource))
+                      metricData, pointData, applicationResource))
           .forEach(allTimeSeries::add);
     }
     return allTimeSeries;
@@ -291,10 +291,7 @@ class BigtableExporterUtils {
   }
 
   private static TimeSeries convertPointToApplicationResourceTimeSeries(
-      MetricData metricData,
-      PointData pointData,
-      String taskId,
-      MonitoredResource applicationResource) {
+      MetricData metricData, PointData pointData, MonitoredResource applicationResource) {
     TimeSeries.Builder builder =
         TimeSeries.newBuilder()
             .setMetricKind(convertMetricKind(metricData))
@@ -308,7 +305,6 @@ class BigtableExporterUtils {
       metricBuilder.putLabels(key.getKey(), String.valueOf(attributes.get(key)));
     }
 
-    metricBuilder.putLabels(CLIENT_UID_KEY.getKey(), taskId);
     builder.setMetric(metricBuilder.build());
 
     TimeInterval timeInterval =

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
@@ -36,13 +36,16 @@ import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConst
 import com.google.api.Distribution;
 import com.google.api.Metric;
 import com.google.api.MonitoredResource;
+import com.google.cloud.bigtable.Version;
+import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings;
 import com.google.cloud.opentelemetry.detection.AttributeKeys;
 import com.google.cloud.opentelemetry.detection.DetectedPlatform;
 import com.google.cloud.opentelemetry.detection.GCPPlatformDetector;
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.monitoring.v3.Point;
 import com.google.monitoring.v3.ProjectName;
@@ -65,18 +68,22 @@ import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /** Utils to convert OpenTelemetry types to Google Cloud Monitoring types. */
 class BigtableExporterUtils {
+  private static final String CLIENT_NAME = "java-bigtable/" + Version.VERSION;
 
   private static final Logger logger = Logger.getLogger(BigtableExporterUtils.class.getName());
 
@@ -86,6 +93,11 @@ class BigtableExporterUtils {
   private static final Set<AttributeKey<String>> BIGTABLE_PROMOTED_RESOURCE_LABELS =
       ImmutableSet.of(
           BIGTABLE_PROJECT_ID_KEY, INSTANCE_ID_KEY, TABLE_ID_KEY, CLUSTER_ID_KEY, ZONE_ID_KEY);
+
+  private static final Map<GCPPlatformDetector.SupportedPlatform, String> SUPPORTED_PLATFORM_MAP =
+      ImmutableMap.of(
+          GCPPlatformDetector.SupportedPlatform.GOOGLE_COMPUTE_ENGINE, "gcp_compute_engine",
+          GCPPlatformDetector.SupportedPlatform.GOOGLE_KUBERNETES_ENGINE, "gcp_kubernetes_engine");
 
   private BigtableExporterUtils() {}
 
@@ -167,9 +179,11 @@ class BigtableExporterUtils {
   }
 
   @Nullable
-  static MonitoredResource detectResourceSafe() {
+  static MonitoredResource createInternalMonitoredResource(EnhancedBigtableStubSettings settings) {
     try {
-      return detectResource();
+      MonitoredResource monitoredResource = detectResource(settings);
+      logger.log(Level.FINE, "Internal metrics monitored resource: %s", monitoredResource);
+      return monitoredResource;
     } catch (Exception e) {
       logger.log(
           Level.WARNING,
@@ -180,62 +194,64 @@ class BigtableExporterUtils {
   }
 
   @Nullable
-  private static MonitoredResource detectResource() {
+  private static MonitoredResource detectResource(EnhancedBigtableStubSettings settings) {
     GCPPlatformDetector detector = GCPPlatformDetector.DEFAULT_INSTANCE;
     DetectedPlatform detectedPlatform = detector.detectPlatform();
-    MonitoredResource monitoredResource = null;
-    try {
-      switch (detectedPlatform.getSupportedPlatform()) {
-        case GOOGLE_COMPUTE_ENGINE:
-          monitoredResource =
-              createGceMonitoredResource(
-                  detectedPlatform.getProjectId(), detectedPlatform.getAttributes());
-          break;
-        case GOOGLE_KUBERNETES_ENGINE:
-          monitoredResource =
-              createGkeMonitoredResource(
-                  detectedPlatform.getProjectId(), detectedPlatform.getAttributes());
-          break;
+
+    @Nullable
+    String cloud_platform = SUPPORTED_PLATFORM_MAP.get(detectedPlatform.getSupportedPlatform());
+    if (cloud_platform == null) {
+      return null;
+    }
+
+    Map<String, String> attrs = detectedPlatform.getAttributes();
+    ImmutableList<String> locationKeys =
+        ImmutableList.of(
+            AttributeKeys.GCE_CLOUD_REGION,
+            AttributeKeys.GCE_AVAILABILITY_ZONE,
+            AttributeKeys.GKE_LOCATION_TYPE_REGION,
+            AttributeKeys.GKE_CLUSTER_LOCATION);
+
+    String region =
+        locationKeys.stream().map(attrs::get).filter(Objects::nonNull).findFirst().orElse("global");
+
+    // Deal with possibility of a zone. Zones are of the form us-east1-c, but we want a region
+    // which, which is us-east1.
+    region = Arrays.stream(region.split("-")).limit(2).collect(Collectors.joining("-"));
+
+    String hostname = attrs.get(AttributeKeys.GCE_INSTANCE_HOSTNAME);
+    //    if (hostname == null) {
+    //      hostname = attrs.get(AttributeKeys.SERVERLESS_COMPUTE_NAME);
+    //    }
+    //    if (hostname == null) {
+    //      hostname = attrs.get(AttributeKeys.GAE_MODULE_NAME);
+    //    }
+    if (hostname == null) {
+      hostname = System.getenv("HOSTNAME");
+    }
+    if (hostname == null) {
+      try {
+        hostname = InetAddress.getLocalHost().getHostName();
+      } catch (UnknownHostException ignored) {
       }
-    } catch (IllegalStateException e) {
-      logger.log(
-          Level.WARNING,
-          "Failed to create monitored resource for " + detectedPlatform.getSupportedPlatform(),
-          e);
     }
-    return monitoredResource;
-  }
-
-  private static MonitoredResource createGceMonitoredResource(
-      String projectId, Map<String, String> attributes) {
-    return MonitoredResource.newBuilder()
-        .setType("gce_instance")
-        .putLabels("project_id", projectId)
-        .putLabels("instance_id", getAttribute(attributes, AttributeKeys.GCE_INSTANCE_ID))
-        .putLabels("zone", getAttribute(attributes, AttributeKeys.GCE_AVAILABILITY_ZONE))
-        .build();
-  }
-
-  private static MonitoredResource createGkeMonitoredResource(
-      String projectId, Map<String, String> attributes) {
-    return MonitoredResource.newBuilder()
-        .setType("k8s_container")
-        .putLabels("project_id", projectId)
-        .putLabels("location", getAttribute(attributes, AttributeKeys.GKE_CLUSTER_LOCATION))
-        .putLabels("cluster_name", getAttribute(attributes, AttributeKeys.GKE_CLUSTER_NAME))
-        .putLabels("namespace_name", MoreObjects.firstNonNull(System.getenv("NAMESPACE"), ""))
-        .putLabels("pod_name", MoreObjects.firstNonNull(System.getenv("HOSTNAME"), ""))
-        .putLabels("container_name", MoreObjects.firstNonNull(System.getenv("CONTAINER_NAME"), ""))
-        .build();
-  }
-
-  private static String getAttribute(Map<String, String> attributes, String key) {
-    String value = attributes.get(key);
-    if (value == null) {
-      throw new IllegalStateException(
-          "Required attribute " + key + " does not exist in the attributes map " + attributes);
+    if (hostname == null) {
+      hostname = "";
     }
-    return value;
+
+    return MonitoredResource.newBuilder()
+        .setType("bigtable_client")
+        .putLabels("project_id", settings.getProjectId())
+        .putLabels("instance", settings.getInstanceId())
+        .putLabels("app_profile", settings.getAppProfileId())
+        .putLabels("client_project", detectedPlatform.getProjectId())
+        .putLabels("region", region)
+        .putLabels("cloud_platform", cloud_platform)
+        .putLabels("host_id", attrs.get(AttributeKeys.GKE_HOST_ID))
+        .putLabels("host_name", hostname)
+        .putLabels("client_name", CLIENT_NAME)
+        .putLabels("uuid", DEFAULT_TASK_VALUE.get())
+        .build();
   }
 
   private static TimeSeries convertPointToBigtableTimeSeries(

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/Util.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/Util.java
@@ -34,6 +34,7 @@ import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ResponseParams;
 import com.google.bigtable.v2.SampleRowKeysRequest;
 import com.google.bigtable.v2.TableName;
+import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -248,7 +249,7 @@ public class Util {
   }
 
   public static OpenTelemetrySdk newInternalOpentelemetry(
-      Credentials credentials, @Nullable String metricsEndpoint) throws IOException {
+      EnhancedBigtableStubSettings settings, Credentials credentials) throws IOException {
     SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder();
 
     for (Map.Entry<InstrumentSelector, View> e :
@@ -261,9 +262,10 @@ public class Util {
             BigtableCloudMonitoringExporter.create(
                 "application metrics",
                 credentials,
-                metricsEndpoint,
+                settings.getMetricsEndpoint(),
                 new BigtableCloudMonitoringExporter.InternalTimeSeriesConverter(
-                    Suppliers.memoize(BigtableExporterUtils::detectResourceSafe)))));
+                    Suppliers.memoize(
+                        () -> BigtableExporterUtils.createInternalMonitoredResource(settings))))));
     return OpenTelemetrySdk.builder().setMeterProvider(meterProviderBuilder.build()).build();
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporterTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporterTest.java
@@ -315,11 +315,18 @@ public class BigtableCloudMonitoringExporterTest {
             new BigtableCloudMonitoringExporter.InternalTimeSeriesConverter(
                 Suppliers.ofInstance(
                     MonitoredResource.newBuilder()
-                        .setType("gce-instance")
-                        .putLabels("some-gce-key", "some-gce-value")
+                        .setType("bigtable_client")
                         .putLabels("project_id", gceProjectId)
-                        .build()),
-                taskId));
+                        .putLabels("instance", "resource-instance")
+                        .putLabels("app_profile", "resource-app-profile")
+                        .putLabels("client_project", "client-project")
+                        .putLabels("region", "cleint-region")
+                        .putLabels("cloud_platform", "gce_instance")
+                        .putLabels("host_id", "1234567890")
+                        .putLabels("host_name", "harold")
+                        .putLabels("client_name", "java/1234")
+                        .putLabels("uuid", "something")
+                        .build())));
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
 
@@ -371,21 +378,28 @@ public class BigtableCloudMonitoringExporterTest {
     com.google.monitoring.v3.TimeSeries timeSeries = request.getTimeSeriesList().get(0);
 
     assertThat(timeSeries.getResource().getLabelsMap())
-        .containsExactly("some-gce-key", "some-gce-value", "project_id", gceProjectId);
+        .isEqualTo(
+            ImmutableMap.<String, String>builder()
+                .put("project_id", gceProjectId)
+                .put("instance", "resource-instance")
+                .put("app_profile", "resource-app-profile")
+                .put("client_project", "client-project")
+                .put("region", "cleint-region")
+                .put("cloud_platform", "gce_instance")
+                .put("host_id", "1234567890")
+                .put("host_name", "harold")
+                .put("client_name", "java/1234")
+                .put("uuid", "something")
+                .build());
 
-    assertThat(timeSeries.getMetric().getLabelsMap()).hasSize(5);
     assertThat(timeSeries.getMetric().getLabelsMap())
-        .containsAtLeast(
-            BIGTABLE_PROJECT_ID_KEY.getKey(),
-            projectId,
-            INSTANCE_ID_KEY.getKey(),
-            instanceId,
-            APP_PROFILE_KEY.getKey(),
-            appProfileId,
-            CLIENT_NAME_KEY.getKey(),
-            clientName,
-            CLIENT_UID_KEY.getKey(),
-            taskId);
+        .isEqualTo(
+            ImmutableMap.builder()
+                .put(BIGTABLE_PROJECT_ID_KEY.getKey(), projectId)
+                .put(INSTANCE_ID_KEY.getKey(), instanceId)
+                .put(APP_PROFILE_KEY.getKey(), appProfileId)
+                .put(CLIENT_NAME_KEY.getKey(), clientName)
+                .build());
   }
 
   @Test


### PR DESCRIPTION
This unifies the k8s_container & gce_instance monitored resources. In addition it adds some client specific attributes on the new monitored resource to make it easier to debug customer issues

Change-Id: Ic0a3b2efeb486a82dab53028ee524fe473a619ad

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed
- [ ] All new data plane features have a completed end to end testing plan

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
