### PR TITLE
chore: export internal DirectAccess gRPC metrics to the new bigtable_client monitored resource

### DIFF
--- a/google-cloud-bigtable/pom.xml
+++ b/google-cloud-bigtable/pom.xml
@@ -203,6 +203,10 @@
       <artifactId>grpc-protobuf</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-opentelemetry</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
     </dependency>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
@@ -172,8 +172,10 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
 
     // Skips exporting if there's none
     if (bigtableTimeSeries.isEmpty()) {
+      System.out.println("skipping empty metrics: " + this.exporterName);
       return CompletableResultCode.ofSuccess();
     }
+    System.out.println(bigtableTimeSeries);
 
     CompletableResultCode exportCode = new CompletableResultCode();
     bigtableTimeSeries.forEach(
@@ -335,18 +337,10 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
         return ImmutableMap.of();
       }
 
-      List<MetricData> relevantData =
-          metricData.stream()
-              .filter(md -> APPLICATION_METRICS.contains(md.getName()))
-              .collect(Collectors.toList());
-      if (relevantData.isEmpty()) {
-        return ImmutableMap.of();
-      }
-
       return ImmutableMap.of(
           ProjectName.of(monitoredResource.getLabelsOrThrow(APPLICATION_RESOURCE_PROJECT_ID)),
           BigtableExporterUtils.convertToApplicationResourceTimeSeries(
-              relevantData, monitoredResource));
+              metricData, monitoredResource));
     }
   }
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
@@ -50,6 +50,8 @@ public class BuiltinMetricsConstants {
   static final AttributeKey<String> STATUS_KEY = AttributeKey.stringKey("status");
   static final AttributeKey<String> CLIENT_UID_KEY = AttributeKey.stringKey("client_uid");
 
+  public static final String METER_NAME = "bigtable.googleapis.com/internal/client/";
+
   // Metric names
   public static final String OPERATION_LATENCIES_NAME = "operation_latencies";
   public static final String ATTEMPT_LATENCIES_NAME = "attempt_latencies";
@@ -61,6 +63,38 @@ public class BuiltinMetricsConstants {
   static final String REMAINING_DEADLINE_NAME = "remaining_deadline";
   static final String CLIENT_BLOCKING_LATENCIES_NAME = "throttling_latencies";
   static final String PER_CONNECTION_ERROR_COUNT_NAME = "per_connection_error_count";
+
+  public static final Map<String, Set<String>> GRPC_METRICS =
+      ImmutableMap.<String, Set<String>>builder()
+          .put(
+              "grpc.client.attempt.duration",
+              ImmutableSet.of("grpc.lb.locality", "grpc.method", "grpc.target", "grpc.status"))
+          .put(
+              "grpc.lb.rls.default_target_picks",
+              ImmutableSet.of("grpc.lb.rls.data_plane_target", "grpc.lb.pick_result"))
+          .put(
+              "grpc.lb.rls.target_picks",
+              ImmutableSet.of(
+                  "grpc.target",
+                  "grpc.lb.rls.server_target",
+                  "grpc.lb.rls.data_plane_target",
+                  "grpc.lb.pick_result"))
+          .put(
+              "grpc.lb.rls.failed_picks",
+              ImmutableSet.of("grpc.target", "grpc.lb.rls.server_target"))
+          // TODO: "grpc.xds_client.connected"
+          .put("grpc.xds_client.server_failure", ImmutableSet.of("grpc.target", "grpc.xds.server"))
+          // TODO: "grpc.xds_client.resource_updates_valid",
+          .put(
+              "grpc.xds_client.resource_updates_invalid",
+              ImmutableSet.of("grpc.target", "grpc.xds.server", "grpc.xds.resource_type"))
+          // TODO: "grpc.xds_client.resources"
+          .build();
+
+  public static final Set<String> INTERNAL_METRICS =
+      ImmutableSet.of(PER_CONNECTION_ERROR_COUNT_NAME).stream()
+          .map(m -> METER_NAME + m)
+          .collect(ImmutableSet.toImmutableSet());
 
   // Buckets under 100,000 are identical to buckets for server side metrics handler_latencies.
   // Extending client side bucket to up to 3,200,000.
@@ -96,8 +130,6 @@ public class BuiltinMetricsConstants {
               250_000.0,
               500_000.0,
               1_000_000.0));
-
-  public static final String METER_NAME = "bigtable.googleapis.com/internal/client/";
 
   static final Set<AttributeKey> COMMON_ATTRIBUTES =
       ImmutableSet.of(


### PR DESCRIPTION
This will export a relevant subset of the metrics described in https://github.com/grpc/proposal/blob/master/A78-grpc-metrics-wrr-pf-xds.md as internal metrics to help rollout of DirectAccess

Change-Id: Ifddadb84d091f0f904f8f0f6e8da52de552e9757

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed
- [ ] All new data plane features have a completed end to end testing plan

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
