### PR TITLE
test: option to run integration tests with modified dependencies

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -50,7 +50,7 @@ fi
 # maven.main.skip skips recompiling the project with modified dependency versions. This
 # makes the build similar to users' environment where they would upgrade their dependencies
 # (without recompiling Cloud Java libraries).
-INTEGRATION_TEST_ARGS="${INTEGRATION_TEST_ARGS} -Dmaven.main.skip -Dgrpc.version=1.72.0"
+INTEGRATION_TEST_ARGS="${INTEGRATION_TEST_ARGS} -Dmaven.main.skip -Dgrpc.version=1.72.0 -Dprotobuf.version=4.31.0-RC1"
 echo "Start dependency tree of modified dependencies by: ${INTEGRATION_TEST_ARGS}"
 mvn -B -ntp dependency:tree ${INTEGRATION_TEST_ARGS}
 echo "End of dependency tree"

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -43,6 +43,19 @@ if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTI
     export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
 fi
 
+# TODO: We have to figure out how to pass this version
+if [ -z "${INTEGRATION_TEST_ARGS}" ];then
+  INTEGRATION_TEST_ARGS="-V"
+fi
+# maven.main.skip skips recompiling the project with modified dependency versions. This
+# makes the build similar to users' environment where they would upgrade their dependencies
+# (without recompiling Cloud Java libraries).
+INTEGRATION_TEST_ARGS="${INTEGRATION_TEST_ARGS} -Dmaven.main.skip -Dgrpc.version=1.72.0"
+echo "Start dependency tree of modified dependencies by: ${INTEGRATION_TEST_ARGS}"
+mvn -B -ntp dependency:tree ${INTEGRATION_TEST_ARGS}
+echo "End of dependency tree"
+echo
+
 RETURN_CODE=0
 set +e
 


### PR DESCRIPTION
This pull request explores the idea of running the integration
tests with modified dependency versions.

First, the integraiton test script (build.sh) compiles the project
with normal dependencies (the latest shared dependencies BOM).
After that, when it runs "mvn verify", it uses slightly modified
dependencies (`-Dgrpc.version=1.72.0` in this case), without
re-compiling the main source code by `-Dmaven.main.skip` argument.

This runtime is similar to what our library users would have when
they upgrade the 3rd-party dependencies in their builds, because
they do not recompile GCP client libraries.
