### PR TITLE
chore: clean up resouce created by test

### DIFF
--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableLogicalViewIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableLogicalViewIT.java
@@ -35,6 +35,7 @@ import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
 import io.grpc.StatusRuntimeException;
 import java.util.List;
 import java.util.logging.Logger;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -69,6 +70,13 @@ public class BigtableLogicalViewIT {
   public void setUp() throws InterruptedException {
     client = testEnvRule.env().getInstanceAdminClient();
     testTable = createTestTable(testEnvRule.env().getTableAdminClient());
+  }
+
+  @After
+  public void tearDown() throws InterruptedException {
+    if (testTable != null) {
+      testEnvRule.env().getTableAdminClient().deleteTable(testTable.getId());
+    }
   }
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/SampleRowsIT.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/SampleRowsIT.java
@@ -104,6 +104,8 @@ public class SampleRowsIT {
         .env()
         .getTableAdminClient()
         .deleteAuthorizedView(testAuthorizedView.getTableId(), testAuthorizedView.getId());
+
+    testEnvRule.env().getTableAdminClient().deleteTable(testAuthorizedView.getTableId());
   }
 
   private static AuthorizedView createPreSplitTableAndAuthorizedView() {

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/TestEnvRule.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/TestEnvRule.java
@@ -167,14 +167,17 @@ public class TestEnvRule implements TestRule {
   private void cleanupStaleTables(String stalePrefix) {
     for (String tableId : env().getTableAdminClient().listTables()) {
       if (!tableId.startsWith(PrefixGenerator.PREFIX)) {
+        LOGGER.info("Skip cleaning up table: " + tableId);
         continue;
       }
       if (stalePrefix.compareTo(tableId) > 0) {
+        LOGGER.info("Preparing stale table for delete: " + tableId);
         prepTableForDelete(tableId);
         try {
+          LOGGER.info("Deleting stable table: " + tableId);
           env().getTableAdminClient().deleteTable(tableId);
-        } catch (NotFoundException ignored) {
-
+        } catch (NotFoundException e) {
+          LOGGER.log(Level.WARNING, "Deleting stale table failed: " + tableId, e);
         }
       }
     }


### PR DESCRIPTION
CleanupStaleTable in TestEnvRule doesn't seem to clean up test tables properly, add some loggings to figure out the issue and clean up tables in the integration test so we don't run into problems. 