### PR TITLE
chore: remove duplicated dependency management of generated protos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,33 +148,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Production Deps have been moved to google-cloud-bigtable-deps-bom -->
-
-            <dependency>
-                <groupId>com.google.api.grpc</groupId>
-                <artifactId>proto-google-cloud-bigtable-v2</artifactId>
-                <version>2.61.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-bigtable-v2:current} -->
-            </dependency>
-            <dependency>
-                <groupId>com.google.api.grpc</groupId>
-                <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
-                <version>2.61.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-bigtable-admin-v2:current} -->
-            </dependency>
-            <dependency>
-                <groupId>com.google.api.grpc</groupId>
-                <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
-                <version>2.61.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-bigtable-v2:current} -->
-            </dependency>
-            <dependency>
-                <groupId>com.google.api.grpc</groupId>
-                <artifactId>grpc-google-cloud-bigtable-admin-v2</artifactId>
-                <version>2.61.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-bigtable-admin-v2:current} -->
-            </dependency>
-            <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-bigtable</artifactId>
-                <version>2.61.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
-            </dependency>
             <!-- Test Deps in alphabetical order -->
             <dependency>
                 <groupId>com.google.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,31 @@
         <dependencies>
             <!-- Test Deps in alphabetical order -->
             <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-bigtable-v2</artifactId>
+        <version>2.61.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-bigtable-v2:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
+        <version>2.61.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-bigtable-admin-v2:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
+        <version>2.61.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-bigtable-v2:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>grpc-google-cloud-bigtable-admin-v2</artifactId>
+        <version>2.61.1-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-bigtable-admin-v2:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable</artifactId>
+        <version>2.61.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+      </dependency>
+      <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-conformance-tests</artifactId>
                 <version>0.3.7</version>


### PR DESCRIPTION
All of these versions are already set in google-cloud-bigtable-bom which is used by all of the artifacts already

Change-Id: I0e14e4c477d3b60e3635ec741b8294c2ad39c581

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed
- [ ] All new data plane features have a completed end to end testing plan

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
