### PR TITLE
Support Proto/Enum types in test proxy

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/common/Type.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/common/Type.java
@@ -505,15 +505,18 @@ public interface Type {
   abstract class SchemalessProto implements SqlType.Proto {
 
     public static SchemalessProto fromProto(com.google.bigtable.v2.Type.Proto proto) {
-      return create(proto.getMessageName());
+      return create(proto.getMessageName(), proto.getSchemaBundleId());
     }
 
-    public static SchemalessProto create(java.lang.String messageName) {
-      return new AutoValue_Type_SchemalessProto(messageName);
+    public static SchemalessProto create(
+        java.lang.String messageName, java.lang.String schemaBundleId) {
+      return new AutoValue_Type_SchemalessProto(messageName, schemaBundleId);
     }
 
     @Override
     public abstract java.lang.String getMessageName();
+
+    public abstract java.lang.String schemaBundleId();
 
     @Override
     public Parser<AbstractMessage> getParserForType() {
@@ -529,7 +532,12 @@ public interface Type {
 
     @Override
     public java.lang.String toString() {
-      return getCode().name() + "{messageName=" + getMessageName() + "}";
+      return getCode().name()
+          + "{messageName="
+          + getMessageName()
+          + ", schemaBundleId="
+          + schemaBundleId()
+          + "}";
     }
   }
 
@@ -544,14 +552,17 @@ public interface Type {
   abstract class SchemalessEnum implements SqlType.Enum {
 
     public static SchemalessEnum fromProto(com.google.bigtable.v2.Type.Enum proto) {
-      return create(proto.getEnumName());
+      return create(proto.getEnumName(), proto.getSchemaBundleId());
     }
 
-    public static SchemalessEnum create(java.lang.String enumName) {
-      return new AutoValue_Type_SchemalessEnum(enumName);
+    public static SchemalessEnum create(
+        java.lang.String enumName, java.lang.String schemaBundleId) {
+      return new AutoValue_Type_SchemalessEnum(enumName, schemaBundleId);
     }
 
     public abstract java.lang.String getEnumName();
+
+    public abstract java.lang.String schemaBundleId();
 
     @Override
     public Function<Integer, ProtocolMessageEnum> getForNumber() {
@@ -567,7 +578,12 @@ public interface Type {
 
     @Override
     public java.lang.String toString() {
-      return getCode().name() + "{enumName=" + getEnumName() + "}";
+      return getCode().name()
+          + "{enumName="
+          + getEnumName()
+          + ", schemaBundleId="
+          + schemaBundleId()
+          + "}";
     }
   }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/common/TypeTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/common/TypeTest.java
@@ -57,9 +57,10 @@ public class TypeTest {
     assertThat(Type.Timestamp.create().toString()).isEqualTo("TIMESTAMP");
     assertThat(Type.Date.create().toString()).isEqualTo("DATE");
     assertThat(Type.SchemalessStruct.create().toString()).isEqualTo("STRUCT");
-    assertThat(Type.SchemalessProto.create("MyMessage").toString())
-        .isEqualTo("PROTO{messageName=MyMessage}");
-    assertThat(Type.SchemalessEnum.create("MyEnum").toString()).isEqualTo("ENUM{enumName=MyEnum}");
+    assertThat(Type.SchemalessProto.create("MyMessage", "my_bundle").toString())
+        .isEqualTo("PROTO{messageName=MyMessage, schemaBundleId=my_bundle}");
+    assertThat(Type.SchemalessEnum.create("MyEnum", "other_bundle").toString())
+        .isEqualTo("ENUM{enumName=MyEnum, schemaBundleId=other_bundle}");
   }
 
   @Test
@@ -123,37 +124,48 @@ public class TypeTest {
 
   @Test
   public void proto_equals() {
-    assertThat(Type.SchemalessProto.create("MyMessage"))
-        .isEqualTo(Type.SchemalessProto.create("MyMessage"));
+    assertThat(Type.SchemalessProto.create("MyMessage", "my_bundle"))
+        .isEqualTo(Type.SchemalessProto.create("MyMessage", "my_bundle"));
     assertThat(Type.Proto.create(Singer.getDefaultInstance()))
         .isEqualTo(Type.Proto.create(Singer.getDefaultInstance()));
 
-    assertThat(Type.SchemalessProto.create("MyMessage"))
-        .isNotEqualTo(Type.SchemalessProto.create("AnotherMessage"));
+    assertThat(Type.SchemalessProto.create("MyMessage", "my_bundle"))
+        .isNotEqualTo(Type.SchemalessProto.create("AnotherMessage", "my_bundle"));
+    assertThat(Type.SchemalessProto.create("MyMessage", "my_bundle"))
+        .isNotEqualTo(Type.SchemalessProto.create("MyMessage", "another_bundle"));
     assertThat(Type.Proto.create(Singer.getDefaultInstance()))
         .isNotEqualTo(Type.Proto.create(Album.getDefaultInstance()));
 
-    assertThat(Type.SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Singer"))
+    assertThat(
+            Type.SchemalessProto.create(
+                "com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle"))
         .isNotEqualTo(Type.Proto.create(Singer.getDefaultInstance()));
     assertThat(Type.Proto.create(Singer.getDefaultInstance()))
-        .isNotEqualTo(Type.SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Singer"));
+        .isNotEqualTo(
+            Type.SchemalessProto.create(
+                "com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle"));
   }
 
   @Test
   public void enum_equals() {
-    assertThat(Type.SchemalessEnum.create("MyEnum"))
-        .isEqualTo(Type.SchemalessEnum.create("MyEnum"));
+    assertThat(Type.SchemalessEnum.create("MyEnum", "my_bundle"))
+        .isEqualTo(Type.SchemalessEnum.create("MyEnum", "my_bundle"));
     assertThat(Type.Enum.create(Genre::forNumber)).isEqualTo(Type.Enum.create(Genre::forNumber));
 
-    assertThat(Type.SchemalessEnum.create("MyEnum"))
-        .isNotEqualTo(Type.SchemalessEnum.create("AnotherEnum"));
+    assertThat(Type.SchemalessEnum.create("MyEnum", "my_bundle"))
+        .isNotEqualTo(Type.SchemalessEnum.create("AnotherEnum", "my_bundle"));
+    assertThat(Type.SchemalessEnum.create("MyEnum", "my_bundle"))
+        .isNotEqualTo(Type.SchemalessEnum.create("MyEnum", "another_bundle"));
     assertThat(Type.Enum.create(Genre::forNumber))
         .isNotEqualTo(Type.Enum.create(Format::forNumber));
 
-    assertThat(Type.SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre"))
+    assertThat(
+            Type.SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle"))
         .isNotEqualTo(Type.Enum.create(Genre::forNumber));
     assertThat(Type.Enum.create(Genre::forNumber))
-        .isNotEqualTo(Type.SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre"));
+        .isNotEqualTo(
+            Type.SchemalessEnum.create(
+                "com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle"));
   }
 
   @Test
@@ -230,13 +242,13 @@ public class TypeTest {
 
   @Test
   public void schemalessProto_throwsExceptionOnGetParser() {
-    SchemalessProto proto = Type.SchemalessProto.create("MyMessage");
+    SchemalessProto proto = Type.SchemalessProto.create("MyMessage", "my_bundle");
     assertThrows(UnsupportedOperationException.class, proto::getParserForType);
   }
 
   @Test
   public void schemalessEnum_throwsExceptionOnGetForNumber() {
-    SchemalessEnum myEnum = Type.SchemalessEnum.create("MyEnum");
+    SchemalessEnum myEnum = Type.SchemalessEnum.create("MyEnum", "my_bundle");
     assertThrows(UnsupportedOperationException.class, myEnum::getForNumber);
   }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/AbstractProtoStructReaderTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/AbstractProtoStructReaderTest.java
@@ -257,7 +257,8 @@ public class AbstractProtoStructReaderTest {
                           "testField",
                           mapType(
                               bytesType(),
-                              protoType("com.google.cloud.bigtable.data.v2.test.Singer"))))),
+                              protoType(
+                                  "com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle"))))),
               Collections.singletonList(
                   mapValue(mapElement(bytesValue("key"), bytesValue(singer.toByteArray())))));
       HashMap<ByteString, Singer> expectedMap = new HashMap<>();
@@ -280,7 +281,8 @@ public class AbstractProtoStructReaderTest {
                   "testField",
                   SqlType.mapOf(
                       SqlType.bytes(),
-                      SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Singer"))));
+                      SchemalessProto.create(
+                          "com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle"))));
       assertThrows(
           UnsupportedOperationException.class,
           () ->
@@ -288,7 +290,8 @@ public class AbstractProtoStructReaderTest {
                   0,
                   SqlType.mapOf(
                       SqlType.bytes(),
-                      SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Singer"))));
+                      SchemalessProto.create(
+                          "com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle"))));
       assertThrows(
           IllegalStateException.class,
           () ->
@@ -319,7 +322,8 @@ public class AbstractProtoStructReaderTest {
                           "testField",
                           mapType(
                               bytesType(),
-                              enumType("com.google.cloud.bigtable.data.v2.test.Genre"))))),
+                              enumType(
+                                  "com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle"))))),
               Collections.singletonList(mapValue(mapElement(bytesValue("key"), int64Value(0)))));
       HashMap<ByteString, Genre> expectedMap = new HashMap<>();
       expectedMap.put(ByteString.copyFromUtf8("key"), Genre.POP);
@@ -340,7 +344,8 @@ public class AbstractProtoStructReaderTest {
                   "testField",
                   SqlType.mapOf(
                       SqlType.bytes(),
-                      SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre"))));
+                      SchemalessEnum.create(
+                          "com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle"))));
       assertThrows(
           UnsupportedOperationException.class,
           () ->
@@ -348,7 +353,8 @@ public class AbstractProtoStructReaderTest {
                   0,
                   SqlType.mapOf(
                       SqlType.bytes(),
-                      SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre"))));
+                      SchemalessEnum.create(
+                          "com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle"))));
       assertThrows(
           UnsupportedOperationException.class,
           () ->
@@ -356,7 +362,8 @@ public class AbstractProtoStructReaderTest {
                   "testField",
                   SqlType.mapOf(
                       SqlType.bytes(),
-                      SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre"))));
+                      SchemalessEnum.create(
+                          "com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle"))));
       assertThrows(
           UnsupportedOperationException.class,
           () ->
@@ -364,7 +371,8 @@ public class AbstractProtoStructReaderTest {
                   0,
                   SqlType.mapOf(
                       SqlType.bytes(),
-                      SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre"))));
+                      SchemalessEnum.create(
+                          "com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle"))));
       assertThrows(
           IllegalStateException.class,
           () -> structWithMap.getMap("testField", SqlType.mapOf(SqlType.bytes(), SqlType.bytes())));
@@ -481,8 +489,8 @@ public class AbstractProtoStructReaderTest {
                           structField("stringField", stringType()),
                           structField("intField", int64Type()),
                           structField("listField", arrayType(stringType())),
-                          structField("protoField", protoType("MyMessage")),
-                          structField("enumField", enumType("MyEnum"))))),
+                          structField("protoField", protoType("MyMessage", "my_bundle")),
+                          structField("enumField", enumType("MyEnum", "other_bundle"))))),
               Collections.singletonList(
                   arrayValue(
                       stringValue("test"),
@@ -501,8 +509,8 @@ public class AbstractProtoStructReaderTest {
                               structField("stringField", stringType()),
                               structField("intField", int64Type()),
                               structField("listField", arrayType(stringType())),
-                              structField("protoField", protoType("MyMessage")),
-                              structField("enumField", enumType("MyEnum")))),
+                              structField("protoField", protoType("MyMessage", "my_bundle")),
+                              structField("enumField", enumType("MyEnum", "other_bundle")))),
                   arrayValue(
                           stringValue("test"),
                           int64Value(100),
@@ -686,7 +694,8 @@ public class AbstractProtoStructReaderTest {
             {
               Collections.singletonList(
                   columnMetadata(
-                      "testField", protoType("com.google.cloud.bigtable.data.v2.test.Singer"))),
+                      "testField",
+                      protoType("com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle"))),
               Collections.singletonList(
                   bytesValue(
                       Singer.newBuilder()
@@ -707,7 +716,9 @@ public class AbstractProtoStructReaderTest {
               Collections.singletonList(
                   columnMetadata(
                       "testField",
-                      arrayType(protoType("com.google.cloud.bigtable.data.v2.test.Singer")))),
+                      arrayType(
+                          protoType(
+                              "com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle")))),
               Collections.singletonList(
                   arrayValue(
                       bytesValue(
@@ -743,7 +754,8 @@ public class AbstractProtoStructReaderTest {
                       "testField",
                       mapType(
                           bytesType(),
-                          protoType("com.google.cloud.bigtable.data.v2.test.Singer")))),
+                          protoType(
+                              "com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle")))),
               Collections.singletonList(
                   mapValue(
                       mapElement(
@@ -791,7 +803,8 @@ public class AbstractProtoStructReaderTest {
             {
               Collections.singletonList(
                   columnMetadata(
-                      "testField", enumType("com.google.cloud.bigtable.data.v2.test.Genre"))),
+                      "testField",
+                      enumType("com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle"))),
               Collections.singletonList(int64Value(1)),
               0,
               "testField",
@@ -806,7 +819,8 @@ public class AbstractProtoStructReaderTest {
               Collections.singletonList(
                   columnMetadata(
                       "testField",
-                      arrayType(enumType("com.google.cloud.bigtable.data.v2.test.Genre")))),
+                      arrayType(
+                          enumType("com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle")))),
               Collections.singletonList(arrayValue(nullValue(), int64Value(2), int64Value(100))),
               0,
               "testField",
@@ -824,7 +838,8 @@ public class AbstractProtoStructReaderTest {
                   columnMetadata(
                       "testField",
                       mapType(
-                          bytesType(), enumType("com.google.cloud.bigtable.data.v2.test.Genre")))),
+                          bytesType(),
+                          enumType("com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle")))),
               Collections.singletonList(
                   mapValue(
                       mapElement(bytesValue("foo"), int64Value(1)),

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/ProtoStructTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/ProtoStructTest.java
@@ -85,9 +85,12 @@ public class ProtoStructTest {
                       structField("listField", arrayType(stringType())),
                       structField("mapField", mapType(stringType(), stringType())),
                       structField(
-                          "protoField", protoType("com.google.cloud.bigtable.data.v2.test.Singer")),
+                          "protoField",
+                          protoType("com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle")),
                       structField(
-                          "enumField", enumType("com.google.cloud.bigtable.data.v2.test.Genre")))),
+                          "enumField",
+                          enumType(
+                              "com.google.cloud.bigtable.data.v2.test.Genre", "other_bundle")))),
           arrayValue(
                   bytesValue("testBytes"),
                   stringValue("testString"),
@@ -184,9 +187,11 @@ public class ProtoStructTest {
     assertThat(struct.getColumnType("mapField"))
         .isEqualTo(SqlType.mapOf(SqlType.string(), SqlType.string()));
     assertThat(struct.getColumnType("protoField"))
-        .isEqualTo(SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Singer"));
+        .isEqualTo(
+            SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle"));
     assertThat(struct.getColumnType("enumField"))
-        .isEqualTo(SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre"));
+        .isEqualTo(
+            SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre", "other_bundle"));
   }
 
   @Test
@@ -205,9 +210,11 @@ public class ProtoStructTest {
     assertThat(struct.getColumnType(10))
         .isEqualTo(SqlType.mapOf(SqlType.string(), SqlType.string()));
     assertThat(struct.getColumnType(11))
-        .isEqualTo(SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Singer"));
+        .isEqualTo(
+            SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle"));
     assertThat(struct.getColumnType(12))
-        .isEqualTo(SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre"));
+        .isEqualTo(
+            SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre", "other_bundle"));
   }
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/ResultSetImplTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/ResultSetImplTest.java
@@ -103,8 +103,10 @@ public class ResultSetImplTest {
             columnMetadata("struct", structType(structField("string", stringType()))),
             columnMetadata("list", arrayType(stringType())),
             columnMetadata("map", mapType(stringType(), stringType())),
-            columnMetadata("proto", protoType("com.google.cloud.bigtable.data.v2.test.Singer")),
-            columnMetadata("enum", enumType("com.google.cloud.bigtable.data.v2.test.Genre")));
+            columnMetadata(
+                "proto", protoType("com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle")),
+            columnMetadata(
+                "enum", enumType("com.google.cloud.bigtable.data.v2.test.Genre", "other_bundle")));
     ResultSetMetadata metadata = ProtoResultSetMetadata.fromProto(protoMetadata);
     ResultSet resultSet =
         resultSetWithFakeStream(

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/sql/SqlTypeTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/sql/SqlTypeTest.java
@@ -76,8 +76,9 @@ public class SqlTypeTest {
     protoToJavaMapping.put(arrayType(stringType()), SqlType.arrayOf(SqlType.string()));
     protoToJavaMapping.put(
         mapType(bytesType(), stringType()), SqlType.mapOf(SqlType.bytes(), SqlType.string()));
-    protoToJavaMapping.put(protoType("foo"), SchemalessProto.create("foo"));
-    protoToJavaMapping.put(enumType("foo"), SchemalessEnum.create("foo"));
+    protoToJavaMapping.put(
+        protoType("foo", "my_bundle"), SchemalessProto.create("foo", "my_bundle"));
+    protoToJavaMapping.put(enumType("foo", "my_bundle"), SchemalessEnum.create("foo", "my_bundle"));
   }
 
   @Test
@@ -173,16 +174,17 @@ public class SqlTypeTest {
     SqlType.Proto<Singer> singerProto = SqlType.protoOf(Singer.getDefaultInstance());
     SqlType.Proto<Album> albumProto = SqlType.protoOf(Album.getDefaultInstance());
     SqlType.Proto schemalessSinger =
-        SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Singer");
+        SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle");
     SqlType.Proto schemalessAlbum =
-        SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Album");
+        SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Album", "my_bundle");
 
     // Both Schemaless types
     assertThat(SqlType.typesMatch(schemalessSinger, schemalessAlbum)).isFalse();
     assertThat(
             SqlType.typesMatch(
                 schemalessSinger,
-                SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Singer")))
+                SchemalessProto.create(
+                    "com.google.cloud.bigtable.data.v2.test.Singer", "my_bundle")))
         .isTrue();
 
     // Both concrete types
@@ -193,17 +195,28 @@ public class SqlTypeTest {
     // Schemaless versus concrete types (unqualified proto message names must match)
     assertThat(SqlType.typesMatch(schemalessSinger, singerProto)).isTrue();
     assertThat(SqlType.typesMatch(singerProto, schemalessSinger)).isTrue();
-    assertThat(SqlType.typesMatch(singerProto, SchemalessProto.create("Singer"))).isTrue();
-    assertThat(SqlType.typesMatch(singerProto, SchemalessProto.create("foo.bar.Singer"))).isTrue();
+    assertThat(SqlType.typesMatch(singerProto, SchemalessProto.create("Singer", "my_bundle")))
+        .isTrue();
+    assertThat(
+            SqlType.typesMatch(singerProto, SchemalessProto.create("foo.bar.Singer", "my_bundle")))
+        .isTrue();
+    assertThat(SqlType.typesMatch(singerProto, SchemalessProto.create("Singer", "other_bundle")))
+        .isTrue();
+    assertThat(
+            SqlType.typesMatch(
+                singerProto, SchemalessProto.create("foo.bar.Singer", "other_bundle")))
+        .isTrue();
     assertThat(SqlType.typesMatch(schemalessSinger, albumProto)).isFalse();
     assertThat(SqlType.typesMatch(albumProto, schemalessSinger)).isFalse();
-    assertThat(SqlType.typesMatch(singerProto, SchemalessProto.create("Album"))).isFalse();
+    assertThat(SqlType.typesMatch(singerProto, SchemalessProto.create("Album", "my_bundle")))
+        .isFalse();
     assertThat(
             SqlType.typesMatch(
                 singerProto,
-                SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Album")))
+                SchemalessProto.create(
+                    "com.google.cloud.bigtable.data.v2.test.Album", "my_bundle")))
         .isFalse();
-    assertThat(SqlType.typesMatch(singerProto, SchemalessProto.create(""))).isFalse();
+    assertThat(SqlType.typesMatch(singerProto, SchemalessProto.create("", "my_bundle"))).isFalse();
   }
 
   @Test
@@ -211,16 +224,16 @@ public class SqlTypeTest {
     SqlType.Enum<Genre> genreEnum = SqlType.enumOf(Genre::forNumber);
     SqlType.Enum<Format> formatEnum = SqlType.enumOf(Format::forNumber);
     SqlType.Enum schemalessGenre =
-        SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre");
+        SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle");
     SqlType.Enum schemalessFormat =
-        SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Format");
+        SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Format", "my_bundle");
 
     // Both Schemaless types
     assertThat(SqlType.typesMatch(schemalessGenre, schemalessFormat)).isFalse();
     assertThat(
             SqlType.typesMatch(
                 schemalessGenre,
-                SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre")))
+                SchemalessEnum.create("com.google.cloud.bigtable.data.v2.test.Genre", "my_bundle")))
         .isTrue();
 
     // Both concrete types
@@ -230,16 +243,25 @@ public class SqlTypeTest {
     // Schemaless versus concrete types (unqualified enum message names must match)
     assertThat(SqlType.typesMatch(schemalessGenre, genreEnum)).isTrue();
     assertThat(SqlType.typesMatch(genreEnum, schemalessGenre)).isTrue();
-    assertThat(SqlType.typesMatch(genreEnum, SchemalessEnum.create("Genre"))).isTrue();
-    assertThat(SqlType.typesMatch(genreEnum, SchemalessEnum.create("foo.bar.Genre"))).isTrue();
+    assertThat(SqlType.typesMatch(genreEnum, SchemalessEnum.create("Genre", "my_bundle"))).isTrue();
+    assertThat(SqlType.typesMatch(genreEnum, SchemalessEnum.create("foo.bar.Genre", "my_bundle")))
+        .isTrue();
+    assertThat(SqlType.typesMatch(genreEnum, SchemalessEnum.create("Genre", "other_bundle")))
+        .isTrue();
+    assertThat(
+            SqlType.typesMatch(genreEnum, SchemalessEnum.create("foo.bar.Genre", "other_bundle")))
+        .isTrue();
     assertThat(SqlType.typesMatch(schemalessGenre, formatEnum)).isFalse();
     assertThat(SqlType.typesMatch(formatEnum, schemalessGenre)).isFalse();
-    assertThat(SqlType.typesMatch(genreEnum, SchemalessEnum.create("Format"))).isFalse();
+    assertThat(SqlType.typesMatch(genreEnum, SchemalessEnum.create("Format", "my_bundle")))
+        .isFalse();
     assertThat(
             SqlType.typesMatch(
-                genreEnum, SchemalessProto.create("com.google.cloud.bigtable.data.v2.test.Format")))
+                genreEnum,
+                SchemalessProto.create(
+                    "com.google.cloud.bigtable.data.v2.test.Format", "my_bundle")))
         .isFalse();
-    assertThat(SqlType.typesMatch(genreEnum, SchemalessEnum.create(""))).isFalse();
+    assertThat(SqlType.typesMatch(genreEnum, SchemalessEnum.create("", "my_bundle"))).isFalse();
   }
 
   @Test

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/sql/ProtoRowsMergingStateMachineTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/sql/ProtoRowsMergingStateMachineTest.java
@@ -660,14 +660,14 @@ public final class ProtoRowsMergingStateMachineTest {
               IllegalStateException.class,
               () ->
                   ProtoRowsMergingStateMachine.validateValueAndType(
-                      Type.SchemalessProto.create("test"), stringValue("test")));
+                      Type.SchemalessProto.create("test", "my_bundle"), stringValue("test")));
           break;
         case ENUM:
           assertThrows(
               IllegalStateException.class,
               () ->
                   ProtoRowsMergingStateMachine.validateValueAndType(
-                      Type.SchemalessEnum.create("test"), bytesValue("val")));
+                      Type.SchemalessEnum.create("test", "my_bundle"), bytesValue("val")));
           break;
         default:
           assertWithMessage(

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/sql/SqlProtoFactory.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/sql/SqlProtoFactory.java
@@ -224,14 +224,17 @@ public class SqlProtoFactory {
         .build();
   }
 
-  public static Type protoType(String messageName) {
+  public static Type protoType(String messageName, String schemaBundleId) {
     return Type.newBuilder()
-        .setProtoType(Type.Proto.newBuilder().setMessageName(messageName))
+        .setProtoType(
+            Type.Proto.newBuilder().setMessageName(messageName).setSchemaBundleId(schemaBundleId))
         .build();
   }
 
-  public static Type enumType(String enumName) {
-    return Type.newBuilder().setEnumType(Type.Enum.newBuilder().setEnumName(enumName)).build();
+  public static Type enumType(String enumName, String schemaBundleId) {
+    return Type.newBuilder()
+        .setEnumType(Type.Enum.newBuilder().setEnumName(enumName).setSchemaBundleId(schemaBundleId))
+        .build();
   }
 
   public static Value nullValue() {


### PR DESCRIPTION
This PR introduces the following changes:

1. Support Proto/Enum types in the test proxy.
2. Save `schemaBundleId` in SchemalessProto/Enum types.
3. Updates all affected tests accordingly.

`2.` is basically a no-op, as the `schema_bundle_id` is currently not populated by the server in ExecuteQuery response [b/430920742](https://b.corp.google.com/issues/430920742), and SchemalessProto/Enum types are not exposed to the external users. However, this change ensures that once [b/430920742](https://b.corp.google.com/issues/430920742) is resolved, the Java client will correctly handle and store the `schema_bundle_id`, and the test proxy will be able to save it correctly in its own protos.

Change-Id: I8878817ea7f194ce9d51939c1aae314304281b52

