### PR TITLE
textproxy: Allow testproxy to build its own proto registry

### DIFF
--- a/test-proxy/src/main/java/com/google/cloud/bigtable/testproxy/CbtTestProxy.java
+++ b/test-proxy/src/main/java/com/google/cloud/bigtable/testproxy/CbtTestProxy.java
@@ -706,7 +706,8 @@ public class CbtTestProxy extends CloudBigtableV2TestProxyImplBase implements Cl
               .dataClient()
               .executeQuery(
                   BoundStatementDeserializer.toBoundStatement(preparedStatement, request));
-      responseObserver.onNext(ResultSetSerializer.toExecuteQueryResult(resultSet));
+      responseObserver.onNext(
+          new ResultSetSerializer(request.getProtoDescriptors()).toExecuteQueryResult(resultSet));
     } catch (InterruptedException e) {
       responseObserver.onError(e);
       return;

--- a/test-proxy/src/main/proto/test_proxy.proto
+++ b/test-proxy/src/main/proto/test_proxy.proto
@@ -20,6 +20,7 @@ import "google/api/client.proto";
 import "google/bigtable/v2/bigtable.proto";
 import "google/bigtable/v2/data.proto";
 import "google/protobuf/duration.proto";
+import "google/protobuf/descriptor.proto";
 import "google/rpc/status.proto";
 
 option go_package = "./testproxypb";
@@ -256,6 +257,9 @@ message ExecuteQueryRequest {
 
   // The raw request to the Bigtable server.
   google.bigtable.v2.ExecuteQueryRequest request = 2;
+
+  // The file descriptor set for the query.
+  google.protobuf.FileDescriptorSet proto_descriptors = 3;
 }
 
 // Response from test proxy service for ExecuteQueryRequest.


### PR DESCRIPTION
Test proxy needs to build the proto type dynamically so it can properly construct the response message. 

Change-Id: Ie930064363d92d61daad498e8380dd87ab6722dd

This is needed for the test proxy to read values from proto/enum columns, as the current API `getProtoMessage(int columnIndex, AbstractMessage message)` and `getProtoEnum(int columnIndex, Function<Integer, ProtocolMessageEnum> forNumber)` mandates such a message object or static function as the second argument.

⚠️  **Reviewer Guidance: Unconventional Approach**
The solution implemented here for handling Enum is quite hacky (and implemented via Gemini), so it should be reviewed with extra attention.
~~The way we build the internal proto registry (`messageDescriptorMap`, `enumDescriptorMap`) from a `FileDescriptorSet` is also not straightforward (but tested locally).~~
