### PR TITLE
fix: don't use String.format in Preconditions messages

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/BulkMutation.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/BulkMutation.java
@@ -101,9 +101,9 @@ public final class BulkMutation implements Serializable, Cloneable {
     long mutationCount = mutation.getMutations().size();
     Preconditions.checkArgument(
         mutationCountSum + mutationCount <= MAX_MUTATION,
-        String.format(
-            "Too many mutations, got %s, limit is %s",
-            mutationCountSum + mutationCount, MAX_MUTATION));
+        "Too many mutations, got %s, limit is %s",
+        mutationCountSum + mutationCount,
+        MAX_MUTATION);
     this.mutationCountSum += mutationCount;
 
     builder.addEntries(

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/RowMutationEntry.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/RowMutationEntry.java
@@ -204,9 +204,9 @@ public class RowMutationEntry implements MutationApi<RowMutationEntry>, Serializ
   public MutateRowsRequest.Entry toProto() {
     Preconditions.checkArgument(
         mutation.getMutations().size() <= MAX_MUTATION,
-        String.format(
-            "Too many mutations, got %s, limit is %s",
-            mutation.getMutations().size(), MAX_MUTATION));
+        "Too many mutations, got %s, limit is %s",
+        mutation.getMutations().size(),
+        MAX_MUTATION);
     return MutateRowsRequest.Entry.newBuilder()
         .setRowKey(key)
         .addAllMutations(mutation.getMutations())


### PR DESCRIPTION
This creates unnecessary allocations/work in the common case where the precondition is met.