### PR TITLE
test: Add ExecuteQuery integration test with Proto/Enum types

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
@@ -2091,8 +2091,7 @@ public final class BigtableTableAdminClient implements AutoCloseable {
   }
 
   /**
-   * Deletes an schema bundle with the specified schema bundle ID in the specified table. Note that
-   * the deletion is prohibited if the schema bundle has deletion_protection field set to true.
+   * Deletes an schema bundle with the specified schema bundle ID in the specified table.
    *
    * <p>Sample code:
    *
@@ -2106,8 +2105,7 @@ public final class BigtableTableAdminClient implements AutoCloseable {
 
   /**
    * Asynchronously deletes an schema bundle with the specified schema bundle ID in the specified
-   * table. Note that the deletion is prohibited if the schema bundle has deletion_protection field
-   * set to true.
+   * table.
    *
    * <p>Sample code:
    *

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateSchemaBundleRequest.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/CreateSchemaBundleRequest.java
@@ -68,8 +68,7 @@ public final class CreateSchemaBundleRequest {
   }
 
   /** Sets the proto schema for this schema bundle. */
-  public CreateSchemaBundleRequest setProtoSchema(@Nonnull ByteString protoSchema)
-      throws IOException {
+  public CreateSchemaBundleRequest setProtoSchema(@Nonnull ByteString protoSchema) {
     Preconditions.checkNotNull(protoSchema, "protoSchema must be set");
     requestBuilder.setSchemaBundle(
         com.google.bigtable.admin.v2.SchemaBundle.newBuilder()


### PR DESCRIPTION
Change-Id: I1f0e24fb27c719d96839687418dde54d50fbc841

With minor bug fixes to SchemaBundle public admin APIs:
- Remove comment about deletion protection since SchemaBundle doesn't have deletion protection feature.
- Remove unnecessary IO exception for `setProtoSchema` function.
