### PR TITLE
tests: Migrate usage of GeneratedMessageV3 to Message

### DIFF
--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/SkipTrailersTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/SkipTrailersTest.java
@@ -252,15 +252,13 @@ public class SkipTrailersTest {
                   BigtableGrpc.getReadRowsMethod(),
                   ServerCalls.asyncServerStreamingCall(
                       (req, observer) -> rpcs.add(ServerRpc.create(req, observer))));
-      ImmutableList<MethodDescriptor<? extends Message, ? extends Message>>
-          unaryDescriptors =
-              ImmutableList.of(
-                  BigtableGrpc.getMutateRowMethod(),
-                  BigtableGrpc.getCheckAndMutateRowMethod(),
-                  BigtableGrpc.getReadModifyWriteRowMethod());
+      ImmutableList<MethodDescriptor<? extends Message, ? extends Message>> unaryDescriptors =
+          ImmutableList.of(
+              BigtableGrpc.getMutateRowMethod(),
+              BigtableGrpc.getCheckAndMutateRowMethod(),
+              BigtableGrpc.getReadModifyWriteRowMethod());
 
-      for (MethodDescriptor<? extends Message, ? extends Message> desc :
-          unaryDescriptors) {
+      for (MethodDescriptor<? extends Message, ? extends Message> desc : unaryDescriptors) {
         builder.addMethod(
             desc.toBuilder().setType(MethodDescriptor.MethodType.SERVER_STREAMING).build(),
             ServerCalls.asyncServerStreamingCall(


### PR DESCRIPTION
GeneratedMessageV3 is no longer the parent class of gen code starting 4.x. Migrate usage of GeneratedMessageV3 to Message in tests so it does not block 4.x gen code upgrade.