### PR TITLE
fix: publish batch flow control metrics

### DIFF
--- a/google-cloud-bigtable/clirr-ignored-differences.xml
+++ b/google-cloud-bigtable/clirr-ignored-differences.xml
@@ -498,4 +498,10 @@
         <className>com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants</className>
         <field>*</field>
     </difference>
+    <difference>
+        <!-- InternalApi was udpated -->
+        <differenceType>7002</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants</className>
+        <method>*</method>
+    </difference>
 </differences>

--- a/google-cloud-bigtable/clirr-ignored-differences.xml
+++ b/google-cloud-bigtable/clirr-ignored-differences.xml
@@ -492,4 +492,10 @@
         <className>com/google/cloud/bigtable/gaxx/grpc/BigtableChannelPoolSettings$Builder</className>
         <method>com.google.cloud.bigtable.gaxx.grpc.BigtableChannelPoolSettings$Builder setLoadBalancingStrategy(com.google.cloud.bigtable.gaxx.grpc.BigtableChannelPoolSettings$LoadBalancingStrategy)</method>
     </difference>
+    <difference>
+        <!-- InternalApi was udpated -->
+        <differenceType>6001</differenceType>
+        <className>com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants</className>
+        <field>*</field>
+    </difference>
 </differences>

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataClientFactory.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataClientFactory.java
@@ -111,7 +111,9 @@ public final class BigtableDataClientFactory implements AutoCloseable {
           sharedClientContext.getClientContext().toBuilder()
               .setTracerFactory(
                   EnhancedBigtableStub.createBigtableTracerFactory(
-                      defaultSettings.getStubSettings(), sharedClientContext.getOpenTelemetry()))
+                      defaultSettings.getStubSettings(),
+                      sharedClientContext.getOpenTelemetry(),
+                      sharedClientContext.getInternalOpenTelemtry()))
               .build();
 
       return BigtableDataClient.createWithClientContext(defaultSettings, clientContext);
@@ -139,7 +141,9 @@ public final class BigtableDataClientFactory implements AutoCloseable {
         sharedClientContext.getClientContext().toBuilder()
             .setTracerFactory(
                 EnhancedBigtableStub.createBigtableTracerFactory(
-                    settings.getStubSettings(), sharedClientContext.getOpenTelemetry()))
+                    settings.getStubSettings(),
+                    sharedClientContext.getOpenTelemetry(),
+                    sharedClientContext.getInternalOpenTelemtry()))
             .build();
     return BigtableDataClient.createWithClientContext(settings, clientContext);
   }
@@ -166,7 +170,9 @@ public final class BigtableDataClientFactory implements AutoCloseable {
         sharedClientContext.getClientContext().toBuilder()
             .setTracerFactory(
                 EnhancedBigtableStub.createBigtableTracerFactory(
-                    settings.getStubSettings(), sharedClientContext.getOpenTelemetry()))
+                    settings.getStubSettings(),
+                    sharedClientContext.getOpenTelemetry(),
+                    sharedClientContext.getInternalOpenTelemtry()))
             .build();
 
     return BigtableDataClient.createWithClientContext(settings, clientContext);
@@ -194,7 +200,9 @@ public final class BigtableDataClientFactory implements AutoCloseable {
         sharedClientContext.getClientContext().toBuilder()
             .setTracerFactory(
                 EnhancedBigtableStub.createBigtableTracerFactory(
-                    settings.getStubSettings(), sharedClientContext.getOpenTelemetry()))
+                    settings.getStubSettings(),
+                    sharedClientContext.getOpenTelemetry(),
+                    sharedClientContext.getInternalOpenTelemtry()))
             .build();
     return BigtableDataClient.createWithClientContext(settings, clientContext);
   }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/BigtableClientContext.java
@@ -193,6 +193,10 @@ public class BigtableClientContext {
     return this.openTelemetry;
   }
 
+  public OpenTelemetry getInternalOpenTelemtry() {
+    return this.internalOpenTelemetry;
+  }
+
   public ClientContext getClientContext() {
     return this.clientContext;
   }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableCloudMonitoringExporter.java
@@ -23,7 +23,6 @@ import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConst
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.FIRST_RESPONSE_LATENCIES_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.METER_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.OPERATION_LATENCIES_NAME;
-import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.PER_CONNECTION_ERROR_COUNT_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.REMAINING_DEADLINE_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.RETRY_COUNT_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.SERVER_LATENCIES_NAME;
@@ -331,11 +330,6 @@ public final class BigtableCloudMonitoringExporter implements MetricExporter {
   }
 
   static class InternalTimeSeriesConverter implements TimeSeriesConverter {
-    private static final ImmutableList<String> APPLICATION_METRICS =
-        ImmutableSet.of(PER_CONNECTION_ERROR_COUNT_NAME).stream()
-            .map(m -> METER_NAME + m)
-            .collect(ImmutableList.toImmutableList());
-
     private final Supplier<MonitoredResource> monitoredResource;
 
     InternalTimeSeriesConverter(Supplier<MonitoredResource> monitoredResource) {

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
@@ -25,12 +25,12 @@ import static com.google.api.MetricDescriptor.ValueType;
 import static com.google.api.MetricDescriptor.ValueType.DISTRIBUTION;
 import static com.google.api.MetricDescriptor.ValueType.DOUBLE;
 import static com.google.api.MetricDescriptor.ValueType.INT64;
+import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.BIGTABLE_CLIENT_METRICS;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.BIGTABLE_PROJECT_ID_KEY;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.CLIENT_UID_KEY;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.CLUSTER_ID_KEY;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.GRPC_METRICS;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.INSTANCE_ID_KEY;
-import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.INTERNAL_METRICS;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.METER_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.TABLE_ID_KEY;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.ZONE_ID_KEY;
@@ -171,6 +171,7 @@ class BigtableExporterUtils {
         "convert application metrics is called when the supported resource is not detected");
     List<TimeSeries> allTimeSeries = new ArrayList<>();
     for (MetricData metricData : collection) {
+      System.out.println("====== metric data: " + metricData.getName() + " data: " + metricData);
       metricData.getData().getPoints().stream()
           .map(
               pointData ->
@@ -186,6 +187,7 @@ class BigtableExporterUtils {
     try {
       MonitoredResource monitoredResource = detectResource(settings);
       logger.log(Level.FINE, "Internal metrics monitored resource: %s", monitoredResource);
+      System.out.println("detected resource: " + monitoredResource);
       return monitoredResource;
     } catch (Exception e) {
       logger.log(
@@ -317,7 +319,7 @@ class BigtableExporterUtils {
     // To unify these:
     // - the useless views should be removed
     // - internal metrics should use relative metric names w/o the prefix
-    if (INTERNAL_METRICS.contains(metricData.getName())) {
+    if (BIGTABLE_CLIENT_METRICS.contains(metricData.getName())) {
       metricBuilder = newApplicationMetricBuilder(metricData.getName(), pointData.getAttributes());
     } else if (GRPC_METRICS.containsKey(metricData.getName())) {
       metricBuilder = newGrpcMetricBuilder(metricData.getName(), pointData.getAttributes());

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
@@ -171,7 +171,6 @@ class BigtableExporterUtils {
         "convert application metrics is called when the supported resource is not detected");
     List<TimeSeries> allTimeSeries = new ArrayList<>();
     for (MetricData metricData : collection) {
-      System.out.println("====== metric data: " + metricData.getName() + " data: " + metricData);
       metricData.getData().getPoints().stream()
           .map(
               pointData ->
@@ -187,7 +186,6 @@ class BigtableExporterUtils {
     try {
       MonitoredResource monitoredResource = detectResource(settings);
       logger.log(Level.FINE, "Internal metrics monitored resource: %s", monitoredResource);
-      System.out.println("detected resource: " + monitoredResource);
       return monitoredResource;
     } catch (Exception e) {
       logger.log(

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
@@ -100,11 +100,11 @@ class BigtableExporterUtils {
       ImmutableSet.of(
           BIGTABLE_PROJECT_ID_KEY, INSTANCE_ID_KEY, TABLE_ID_KEY, CLUSTER_ID_KEY, ZONE_ID_KEY);
 
-  // These labels are defined on the Bigtable client resource. It's hard coded when we create the
-  // internal exporter for connection level metrics. For request level metrics, these attributes
-  // are updated with the actual value from the request and we use them to update the monitored
-  // schema. This is needed for BigtableDataClientFactory, when the otel instance is created with
-  // one instance / app profile but the actual call is on a different instance / app profile.
+  // These labels are defined on the bigtable_client monitored resource. For connection level
+  // metrics, they are hard coded from the settings when we create the internal otel. For per
+  // request metrics, we update the values of these fields with the values from metrics label.
+  // This is needed for BigtableDataClientFactory when the otel instance is created with the
+  // shared settings and the clients are created with different instances / app profile ids.
   private static final Set<AttributeKey<String>> BIGTABLE_CLIENT_RESOURCE_LABEL =
       ImmutableSet.of(BIGTABLE_PROJECT_ID_KEY, INSTANCE_ID_KEY, APP_PROFILE_KEY);
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableExporterUtils.java
@@ -362,9 +362,9 @@ class BigtableExporterUtils {
       AttributeKey<?> key = e.getKey();
       if (BIGTABLE_CLIENT_RESOURCE_LABEL.contains(key)) {
         updatedResource.putLabels(key.getKey(), String.valueOf(e.getValue()));
-      } else {
-        metricBuilder.putLabels(e.getKey().getKey(), String.valueOf(e.getValue()));
       }
+
+      metricBuilder.putLabels(e.getKey().getKey(), String.valueOf(e.getValue()));
     }
     return metricBuilder;
   }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
@@ -57,6 +57,7 @@ public class BuiltinMetricsConstants {
   static final AttributeKey<String> TRANSPORT_REGION = AttributeKey.stringKey("transport_region");
   static final AttributeKey<String> TRANSPORT_ZONE = AttributeKey.stringKey("transport_zone");
   static final AttributeKey<String> TRANSPORT_SUBZONE = AttributeKey.stringKey("transport_subzone");
+  static final AttributeKey<String> LB_POLICY_KEY = AttributeKey.stringKey("lb_policy");
 
   // gRPC attribute keys
   // Note that these attributes keys from transformed from
@@ -280,7 +281,13 @@ public class BuiltinMetricsConstants {
         InstrumentType.HISTOGRAM,
         "1",
         ImmutableSet.<AttributeKey>builder()
-            .add(BIGTABLE_PROJECT_ID_KEY, INSTANCE_ID_KEY, APP_PROFILE_KEY, CLIENT_NAME_KEY)
+            .add(
+                BIGTABLE_PROJECT_ID_KEY,
+                INSTANCE_ID_KEY,
+                APP_PROFILE_KEY,
+                TRANSPORT_TYPE,
+                STREAMING_KEY,
+                LB_POLICY_KEY)
             .build());
     defineView(
         views,
@@ -288,14 +295,24 @@ public class BuiltinMetricsConstants {
         null,
         InstrumentType.GAUGE,
         "1",
-        ImmutableSet.<AttributeKey>builder().add(METHOD_KEY).build());
+        ImmutableSet.<AttributeKey>builder()
+            .add(BIGTABLE_PROJECT_ID_KEY, INSTANCE_ID_KEY, APP_PROFILE_KEY, METHOD_KEY)
+            .build());
     defineView(
         views,
         BATCH_WRITE_FLOW_CONTROL_FACTOR_NAME,
         AGGREGATION_BATCH_WRITE_FLOW_CONTROL_FACTOR_HISTOGRAM,
         InstrumentType.HISTOGRAM,
         "1",
-        ImmutableSet.<AttributeKey>builder().add(STATUS_KEY, APPLIED_KEY, METHOD_KEY).build());
+        ImmutableSet.<AttributeKey>builder()
+            .add(
+                BIGTABLE_PROJECT_ID_KEY,
+                INSTANCE_ID_KEY,
+                APP_PROFILE_KEY,
+                STATUS_KEY,
+                APPLIED_KEY,
+                METHOD_KEY)
+            .build());
     return views.build();
   }
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
@@ -167,8 +167,13 @@ public class BuiltinMetricsConstants {
                   GRPC_TARGET_KEY.getKey()))
           .build();
 
-  public static final Set<String> INTERNAL_METRICS =
-      ImmutableSet.of(PER_CONNECTION_ERROR_COUNT_NAME, OUTSTANDING_RPCS_PER_CHANNEL_NAME).stream()
+  public static final Set<String> BIGTABLE_CLIENT_METRICS =
+      ImmutableSet.of(
+              PER_CONNECTION_ERROR_COUNT_NAME,
+              OUTSTANDING_RPCS_PER_CHANNEL_NAME,
+              BATCH_WRITE_FLOW_CONTROL_FACTOR_NAME,
+              BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME)
+          .stream()
           .map(m -> METER_NAME + m)
           .collect(ImmutableSet.toImmutableSet());
   // End allow list of metrics that will be exported
@@ -246,8 +251,6 @@ public class BuiltinMetricsConstants {
             .build();
     Set<String> attributesFilter =
         ImmutableSet.<String>builder()
-            .addAll(
-                COMMON_ATTRIBUTES.stream().map(AttributeKey::getKey).collect(Collectors.toSet()))
             .addAll(attributes.stream().map(AttributeKey::getKey).collect(Collectors.toSet()))
             .build();
     ViewBuilder viewBuilder =
@@ -285,20 +288,18 @@ public class BuiltinMetricsConstants {
         null,
         InstrumentType.GAUGE,
         "1",
-        ImmutableSet.<AttributeKey>builder().addAll(COMMON_ATTRIBUTES).build());
+        ImmutableSet.<AttributeKey>builder().add(METHOD_KEY).build());
     defineView(
         views,
         BATCH_WRITE_FLOW_CONTROL_FACTOR_NAME,
         AGGREGATION_BATCH_WRITE_FLOW_CONTROL_FACTOR_HISTOGRAM,
         InstrumentType.HISTOGRAM,
         "1",
-        ImmutableSet.<AttributeKey>builder()
-            .addAll(COMMON_ATTRIBUTES)
-            .add(STATUS_KEY, APPLIED_KEY)
-            .build());
+        ImmutableSet.<AttributeKey>builder().add(STATUS_KEY, APPLIED_KEY, METHOD_KEY).build());
     return views.build();
   }
 
+  // uses cloud.BigtableTable schema
   public static Map<InstrumentSelector, View> getAllViews() {
     ImmutableMap.Builder<InstrumentSelector, View> views = ImmutableMap.builder();
 

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
@@ -279,6 +279,23 @@ public class BuiltinMetricsConstants {
         ImmutableSet.<AttributeKey>builder()
             .add(BIGTABLE_PROJECT_ID_KEY, INSTANCE_ID_KEY, APP_PROFILE_KEY, CLIENT_NAME_KEY)
             .build());
+    defineView(
+        views,
+        BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME,
+        null,
+        InstrumentType.GAUGE,
+        "1",
+        ImmutableSet.<AttributeKey>builder().addAll(COMMON_ATTRIBUTES).build());
+    defineView(
+        views,
+        BATCH_WRITE_FLOW_CONTROL_FACTOR_NAME,
+        AGGREGATION_BATCH_WRITE_FLOW_CONTROL_FACTOR_HISTOGRAM,
+        InstrumentType.HISTOGRAM,
+        "1",
+        ImmutableSet.<AttributeKey>builder()
+            .addAll(COMMON_ATTRIBUTES)
+            .add(STATUS_KEY, APPLIED_KEY)
+            .build());
     return views.build();
   }
 
@@ -372,23 +389,6 @@ public class BuiltinMetricsConstants {
         ImmutableSet.<AttributeKey>builder()
             .addAll(COMMON_ATTRIBUTES)
             .add(STREAMING_KEY, STATUS_KEY)
-            .build());
-    defineView(
-        views,
-        BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME,
-        null,
-        InstrumentType.GAUGE,
-        "1",
-        ImmutableSet.<AttributeKey>builder().addAll(COMMON_ATTRIBUTES).build());
-    defineView(
-        views,
-        BATCH_WRITE_FLOW_CONTROL_FACTOR_NAME,
-        AGGREGATION_BATCH_WRITE_FLOW_CONTROL_FACTOR_HISTOGRAM,
-        InstrumentType.HISTOGRAM,
-        "1",
-        ImmutableSet.<AttributeKey>builder()
-            .addAll(COMMON_ATTRIBUTES)
-            .add(STATUS_KEY, APPLIED_KEY)
             .build());
     return views.build();
   }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsConstants.java
@@ -262,7 +262,7 @@ public class BuiltinMetricsConstants {
   }
 
   // uses cloud.BigtableClient schema
-  public static Map<InstrumentSelector, View> getInternalViews() {
+  public static Map<InstrumentSelector, View> getBigtableClientViews() {
     ImmutableMap.Builder<InstrumentSelector, View> views = ImmutableMap.builder();
     defineView(
         views,
@@ -300,7 +300,7 @@ public class BuiltinMetricsConstants {
   }
 
   // uses cloud.BigtableTable schema
-  public static Map<InstrumentSelector, View> getAllViews() {
+  public static Map<InstrumentSelector, View> getBigtableTableViews() {
     ImmutableMap.Builder<InstrumentSelector, View> views = ImmutableMap.builder();
 
     defineView(

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsView.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsView.java
@@ -118,7 +118,7 @@ public class BuiltinMetricsView {
             new BigtableCloudMonitoringExporter.PublicTimeSeriesConverter());
 
     for (Map.Entry<InstrumentSelector, View> entry :
-        BuiltinMetricsConstants.getAllViews().entrySet()) {
+        BuiltinMetricsConstants.getBigtableTableViews().entrySet()) {
       builder.registerView(entry.getKey(), entry.getValue());
     }
     builder.registerMetricReader(PeriodicMetricReader.create(publicExporter));

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/Util.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/Util.java
@@ -259,11 +259,6 @@ public class Util {
       EnhancedBigtableStubSettings settings, Credentials credentials) throws IOException {
     SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder();
 
-    for (Map.Entry<InstrumentSelector, View> e :
-        BuiltinMetricsConstants.getInternalViews().entrySet()) {
-      meterProviderBuilder.registerView(e.getKey(), e.getValue());
-    }
-
     meterProviderBuilder.registerMetricReader(
         PeriodicMetricReader.create(
             BigtableCloudMonitoringExporter.create(
@@ -274,6 +269,13 @@ public class Util {
                 new BigtableCloudMonitoringExporter.InternalTimeSeriesConverter(
                     Suppliers.memoize(
                         () -> BigtableExporterUtils.createInternalMonitoredResource(settings))))));
+
+    for (Map.Entry<InstrumentSelector, View> e :
+        BuiltinMetricsConstants.getInternalViews().entrySet()) {
+      System.out.println("register internal view " + e.getKey().getInstrumentName());
+      meterProviderBuilder.registerView(e.getKey(), e.getValue());
+    }
+
     return OpenTelemetrySdk.builder().setMeterProvider(meterProviderBuilder.build()).build();
   }
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/Util.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/Util.java
@@ -259,6 +259,11 @@ public class Util {
       EnhancedBigtableStubSettings settings, Credentials credentials) throws IOException {
     SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder();
 
+    for (Map.Entry<InstrumentSelector, View> e :
+        BuiltinMetricsConstants.getInternalViews().entrySet()) {
+      meterProviderBuilder.registerView(e.getKey(), e.getValue());
+    }
+
     meterProviderBuilder.registerMetricReader(
         PeriodicMetricReader.create(
             BigtableCloudMonitoringExporter.create(
@@ -269,12 +274,6 @@ public class Util {
                 new BigtableCloudMonitoringExporter.InternalTimeSeriesConverter(
                     Suppliers.memoize(
                         () -> BigtableExporterUtils.createInternalMonitoredResource(settings))))));
-
-    for (Map.Entry<InstrumentSelector, View> e :
-        BuiltinMetricsConstants.getInternalViews().entrySet()) {
-      System.out.println("register internal view " + e.getKey().getInstrumentName());
-      meterProviderBuilder.registerView(e.getKey(), e.getValue());
-    }
 
     return OpenTelemetrySdk.builder().setMeterProvider(meterProviderBuilder.build()).build();
   }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/Util.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/metrics/Util.java
@@ -260,7 +260,7 @@ public class Util {
     SdkMeterProviderBuilder meterProviderBuilder = SdkMeterProvider.builder();
 
     for (Map.Entry<InstrumentSelector, View> e :
-        BuiltinMetricsConstants.getInternalViews().entrySet()) {
+        BuiltinMetricsConstants.getBigtableClientViews().entrySet()) {
       meterProviderBuilder.registerView(e.getKey(), e.getValue());
     }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracerCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BigtableTracerCallableTest.java
@@ -136,6 +136,7 @@ public class BigtableTracerCallableTest {
                     settings.getStubSettings(),
                     Tags.getTagger(),
                     localStats.getStatsRecorder(),
+                    null,
                     null))
             .build();
     attempts = settings.getStubSettings().readRowsSettings().getRetrySettings().getMaxAttempts();
@@ -161,6 +162,7 @@ public class BigtableTracerCallableTest {
                     noHeaderSettings.getStubSettings(),
                     Tags.getTagger(),
                     localStats.getStatsRecorder(),
+                    null,
                     null))
             .build();
     noHeaderStub =

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
@@ -17,14 +17,17 @@ package com.google.cloud.bigtable.data.v2.stub.metrics;
 
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.APPLICATION_BLOCKING_LATENCIES_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.APPLIED_KEY;
+import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.APP_PROFILE_KEY;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.ATTEMPT_LATENCIES_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.BATCH_WRITE_FLOW_CONTROL_FACTOR_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME;
+import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.BIGTABLE_PROJECT_ID_KEY;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.CLIENT_BLOCKING_LATENCIES_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.CLIENT_NAME_KEY;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.CLUSTER_ID_KEY;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.CONNECTIVITY_ERROR_COUNT_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.FIRST_RESPONSE_LATENCIES_NAME;
+import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.INSTANCE_ID_KEY;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.METHOD_KEY;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.OPERATION_LATENCIES_NAME;
 import static com.google.cloud.bigtable.data.v2.stub.metrics.BuiltinMetricsConstants.REMAINING_DEADLINE_NAME;
@@ -832,7 +835,13 @@ public class BuiltinMetricsTracerTest {
 
       MetricData targetQpsMetric =
           getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME);
-      Attributes targetQpsAttributes = Attributes.of(METHOD_KEY, "Bigtable.MutateRows");
+      Attributes targetQpsAttributes =
+          Attributes.builder()
+              .put(METHOD_KEY, "Bigtable.MutateRows")
+              .put(BIGTABLE_PROJECT_ID_KEY, PROJECT_ID)
+              .put(INSTANCE_ID_KEY, INSTANCE_ID)
+              .put(APP_PROFILE_KEY, APP_PROFILE_ID)
+              .build();
       double actual_qps = getAggregatedDoubleValue(targetQpsMetric, targetQpsAttributes);
       double expected_qps = 12;
       assertThat(expected_qps).isEqualTo(actual_qps);
@@ -843,6 +852,9 @@ public class BuiltinMetricsTracerTest {
               .put(METHOD_KEY, "Bigtable.MutateRows")
               .put(APPLIED_KEY, true)
               .put(STATUS_KEY, "OK")
+              .put(BIGTABLE_PROJECT_ID_KEY, PROJECT_ID)
+              .put(INSTANCE_ID_KEY, INSTANCE_ID)
+              .put(APP_PROFILE_KEY, APP_PROFILE_ID)
               .build();
       double actual_factor_mean = getAggregatedDoubleValue(factorMetric, factorAttributes);
       double expected_factor_mean = 1.2;
@@ -862,7 +874,12 @@ public class BuiltinMetricsTracerTest {
       MetricData targetQpsMetric =
           getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME);
       Attributes targetQpsAttributes =
-          Attributes.builder().put(METHOD_KEY, "Bigtable.MutateRows").build();
+          Attributes.builder()
+              .put(METHOD_KEY, "Bigtable.MutateRows")
+              .put(BIGTABLE_PROJECT_ID_KEY, PROJECT_ID)
+              .put(INSTANCE_ID_KEY, INSTANCE_ID)
+              .put(APP_PROFILE_KEY, APP_PROFILE_ID)
+              .build();
       double actual_qps = getAggregatedDoubleValue(targetQpsMetric, targetQpsAttributes);
       double expected_qps = 8.0;
       assertThat(expected_qps).isEqualTo(actual_qps);
@@ -873,6 +890,9 @@ public class BuiltinMetricsTracerTest {
               .put(METHOD_KEY, "Bigtable.MutateRows")
               .put(APPLIED_KEY, true)
               .put(STATUS_KEY, "OK")
+              .put(BIGTABLE_PROJECT_ID_KEY, PROJECT_ID)
+              .put(INSTANCE_ID_KEY, INSTANCE_ID)
+              .put(APP_PROFILE_KEY, APP_PROFILE_ID)
               .build();
       double actual_factor_mean = getAggregatedDoubleValue(factorMetric, factorAttributes);
       double expected_factor_mean = 0.8;
@@ -892,7 +912,12 @@ public class BuiltinMetricsTracerTest {
       MetricData targetQpsMetric =
           getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME);
       Attributes targetQpsAttributes =
-          Attributes.builder().put(METHOD_KEY, "Bigtable.MutateRows").build();
+          Attributes.builder()
+              .put(METHOD_KEY, "Bigtable.MutateRows")
+              .put(BIGTABLE_PROJECT_ID_KEY, PROJECT_ID)
+              .put(INSTANCE_ID_KEY, INSTANCE_ID)
+              .put(APP_PROFILE_KEY, APP_PROFILE_ID)
+              .build();
       double actual_qps = getAggregatedDoubleValue(targetQpsMetric, targetQpsAttributes);
       // Factor is 1.8 but capped at 1.3 so updated QPS is 13.
       double expected_qps = 13;
@@ -904,6 +929,9 @@ public class BuiltinMetricsTracerTest {
               .put(METHOD_KEY, "Bigtable.MutateRows")
               .put(APPLIED_KEY, true)
               .put(STATUS_KEY, "OK")
+              .put(BIGTABLE_PROJECT_ID_KEY, PROJECT_ID)
+              .put(INSTANCE_ID_KEY, INSTANCE_ID)
+              .put(APP_PROFILE_KEY, APP_PROFILE_ID)
               .build();
       double actual_factor_mean = getAggregatedDoubleValue(factorMetric, factorAttributes);
       // Factor is 1.8 but capped at 1.3
@@ -924,7 +952,12 @@ public class BuiltinMetricsTracerTest {
       MetricData targetQpsMetric =
           getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME);
       Attributes targetQpsAttributes =
-          Attributes.builder().put(METHOD_KEY, "Bigtable.MutateRows").build();
+          Attributes.builder()
+              .put(METHOD_KEY, "Bigtable.MutateRows")
+              .put(BIGTABLE_PROJECT_ID_KEY, PROJECT_ID)
+              .put(INSTANCE_ID_KEY, INSTANCE_ID)
+              .put(APP_PROFILE_KEY, APP_PROFILE_ID)
+              .build();
       double actual_qps = getAggregatedDoubleValue(targetQpsMetric, targetQpsAttributes);
       // Factor is 0.5 but capped at 0.7 so updated QPS is 7.
       double expected_qps = 7;
@@ -936,6 +969,9 @@ public class BuiltinMetricsTracerTest {
               .put(METHOD_KEY, "Bigtable.MutateRows")
               .put(APPLIED_KEY, true)
               .put(STATUS_KEY, "OK")
+              .put(BIGTABLE_PROJECT_ID_KEY, PROJECT_ID)
+              .put(INSTANCE_ID_KEY, INSTANCE_ID)
+              .put(APP_PROFILE_KEY, APP_PROFILE_ID)
               .build();
       double actual_factor_mean = getAggregatedDoubleValue(factorMetric, factorAttributes);
       // Factor is 0.5 but capped at 0.7
@@ -957,7 +993,12 @@ public class BuiltinMetricsTracerTest {
       MetricData targetQpsMetric =
           getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME);
       Attributes targetQpsAttributes =
-          Attributes.builder().put(METHOD_KEY, "Bigtable.MutateRows").build();
+          Attributes.builder()
+              .put(METHOD_KEY, "Bigtable.MutateRows")
+              .put(BIGTABLE_PROJECT_ID_KEY, PROJECT_ID)
+              .put(INSTANCE_ID_KEY, INSTANCE_ID)
+              .put(APP_PROFILE_KEY, APP_PROFILE_ID)
+              .build();
       double actual_qps = getAggregatedDoubleValue(targetQpsMetric, targetQpsAttributes);
       // On error, min factor is applied.
       double expected_qps = 7;
@@ -969,6 +1010,9 @@ public class BuiltinMetricsTracerTest {
               .put(METHOD_KEY, "Bigtable.MutateRows")
               .put(APPLIED_KEY, true)
               .put(STATUS_KEY, "UNAVAILABLE")
+              .put(BIGTABLE_PROJECT_ID_KEY, PROJECT_ID)
+              .put(INSTANCE_ID_KEY, INSTANCE_ID)
+              .put(APP_PROFILE_KEY, APP_PROFILE_ID)
               .build();
       double actual_factor_mean = getAggregatedDoubleValue(factorMetric, factorAttributes);
       // On error, min factor is applied.

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
@@ -179,6 +179,11 @@ public class BuiltinMetricsTracerTest {
       meterProvider.registerView(entry.getKey(), entry.getValue());
     }
 
+    for (Map.Entry<InstrumentSelector, View> entry :
+        BuiltinMetricsConstants.getInternalViews().entrySet()) {
+      meterProvider.registerView(entry.getKey(), entry.getValue());
+    }
+
     OpenTelemetrySdk otel =
         OpenTelemetrySdk.builder().setMeterProvider(meterProvider.build()).build();
     BuiltinMetricsTracerFactory facotry = BuiltinMetricsTracerFactory.create(otel, baseAttributes);

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
@@ -832,15 +832,14 @@ public class BuiltinMetricsTracerTest {
 
       MetricData targetQpsMetric =
           getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME);
-      Attributes targetQpsAttributes =
-          baseAttributes.toBuilder().put(METHOD_KEY, "Bigtable.MutateRows").build();
+      Attributes targetQpsAttributes = Attributes.of(METHOD_KEY, "Bigtable.MutateRows");
       double actual_qps = getAggregatedDoubleValue(targetQpsMetric, targetQpsAttributes);
       double expected_qps = 12;
       assertThat(expected_qps).isEqualTo(actual_qps);
 
       MetricData factorMetric = getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_FACTOR_NAME);
       Attributes factorAttributes =
-          baseAttributes.toBuilder()
+          Attributes.builder()
               .put(METHOD_KEY, "Bigtable.MutateRows")
               .put(APPLIED_KEY, true)
               .put(STATUS_KEY, "OK")
@@ -863,14 +862,14 @@ public class BuiltinMetricsTracerTest {
       MetricData targetQpsMetric =
           getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME);
       Attributes targetQpsAttributes =
-          baseAttributes.toBuilder().put(METHOD_KEY, "Bigtable.MutateRows").build();
+          Attributes.builder().put(METHOD_KEY, "Bigtable.MutateRows").build();
       double actual_qps = getAggregatedDoubleValue(targetQpsMetric, targetQpsAttributes);
       double expected_qps = 8.0;
       assertThat(expected_qps).isEqualTo(actual_qps);
 
       MetricData factorMetric = getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_FACTOR_NAME);
       Attributes factorAttributes =
-          baseAttributes.toBuilder()
+          Attributes.builder()
               .put(METHOD_KEY, "Bigtable.MutateRows")
               .put(APPLIED_KEY, true)
               .put(STATUS_KEY, "OK")
@@ -893,7 +892,7 @@ public class BuiltinMetricsTracerTest {
       MetricData targetQpsMetric =
           getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME);
       Attributes targetQpsAttributes =
-          baseAttributes.toBuilder().put(METHOD_KEY, "Bigtable.MutateRows").build();
+          Attributes.builder().put(METHOD_KEY, "Bigtable.MutateRows").build();
       double actual_qps = getAggregatedDoubleValue(targetQpsMetric, targetQpsAttributes);
       // Factor is 1.8 but capped at 1.3 so updated QPS is 13.
       double expected_qps = 13;
@@ -901,7 +900,7 @@ public class BuiltinMetricsTracerTest {
 
       MetricData factorMetric = getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_FACTOR_NAME);
       Attributes factorAttributes =
-          baseAttributes.toBuilder()
+          Attributes.builder()
               .put(METHOD_KEY, "Bigtable.MutateRows")
               .put(APPLIED_KEY, true)
               .put(STATUS_KEY, "OK")
@@ -925,7 +924,7 @@ public class BuiltinMetricsTracerTest {
       MetricData targetQpsMetric =
           getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME);
       Attributes targetQpsAttributes =
-          baseAttributes.toBuilder().put(METHOD_KEY, "Bigtable.MutateRows").build();
+          Attributes.builder().put(METHOD_KEY, "Bigtable.MutateRows").build();
       double actual_qps = getAggregatedDoubleValue(targetQpsMetric, targetQpsAttributes);
       // Factor is 0.5 but capped at 0.7 so updated QPS is 7.
       double expected_qps = 7;
@@ -933,7 +932,7 @@ public class BuiltinMetricsTracerTest {
 
       MetricData factorMetric = getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_FACTOR_NAME);
       Attributes factorAttributes =
-          baseAttributes.toBuilder()
+          Attributes.builder()
               .put(METHOD_KEY, "Bigtable.MutateRows")
               .put(APPLIED_KEY, true)
               .put(STATUS_KEY, "OK")
@@ -958,7 +957,7 @@ public class BuiltinMetricsTracerTest {
       MetricData targetQpsMetric =
           getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_TARGET_QPS_NAME);
       Attributes targetQpsAttributes =
-          baseAttributes.toBuilder().put(METHOD_KEY, "Bigtable.MutateRows").build();
+          Attributes.builder().put(METHOD_KEY, "Bigtable.MutateRows").build();
       double actual_qps = getAggregatedDoubleValue(targetQpsMetric, targetQpsAttributes);
       // On error, min factor is applied.
       double expected_qps = 7;
@@ -966,7 +965,7 @@ public class BuiltinMetricsTracerTest {
 
       MetricData factorMetric = getMetricData(metricReader, BATCH_WRITE_FLOW_CONTROL_FACTOR_NAME);
       Attributes factorAttributes =
-          baseAttributes.toBuilder()
+          Attributes.builder()
               .put(METHOD_KEY, "Bigtable.MutateRows")
               .put(APPLIED_KEY, true)
               .put(STATUS_KEY, "UNAVAILABLE")

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/BuiltinMetricsTracerTest.java
@@ -175,12 +175,12 @@ public class BuiltinMetricsTracerTest {
         SdkMeterProvider.builder().registerMetricReader(metricReader);
 
     for (Map.Entry<InstrumentSelector, View> entry :
-        BuiltinMetricsConstants.getAllViews().entrySet()) {
+        BuiltinMetricsConstants.getBigtableTableViews().entrySet()) {
       meterProvider.registerView(entry.getKey(), entry.getValue());
     }
 
     for (Map.Entry<InstrumentSelector, View> entry :
-        BuiltinMetricsConstants.getInternalViews().entrySet()) {
+        BuiltinMetricsConstants.getBigtableClientViews().entrySet()) {
       meterProvider.registerView(entry.getKey(), entry.getValue());
     }
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/metrics/MetricsTracerTest.java
@@ -131,6 +131,7 @@ public class MetricsTracerTest {
                     settings.getStubSettings(),
                     Tags.getTagger(),
                     localStats.getStatsRecorder(),
+                    null,
                     null))
             .build();
     stub = new EnhancedBigtableStub(settings.getStubSettings(), clientContext);


### PR DESCRIPTION
Currently we have 2 otel instances that publishes built in metrics:

- external OTEL: set on the tracer and collects metrics per request. Currently all the metrics on the external OTEL are published to BigtableTable schema.

- internal OTEL: set on the channel provider and collects metrics periodically. Currently all the metrics on the internal OTEL are published to BigtableClient schema. (This was added because channel level metrics don't have information about bigtable resource ids, so the bigtable resource ids need to be hard coded when creating the OTEL, and CustomMetricsProvider doesn't have a way to create the OTEL instance with bigtable resource ids.)

The new batch flow control metrics are collected per request. The metrics also publish to BigtableClient schema. This means the current plumbing doesn't work anymore.  This PR fixes the plumbing:

1. Sets the internal OTEL on the tracer. 
2. Dynamically update the BigtableClient monitored resource labels with the value from the metric labels when publishing  metrics to cloud monitoring. This is needed because of BigtableDataClientFactory.

Also fix the metric labels in the outstanding_rpc metric.