### PR TITLE
feat: add BigtableTableAdminClientV2 to support Selective GAPIC

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
@@ -71,7 +71,6 @@ import com.google.cloud.bigtable.admin.v2.models.UpdateBackupRequest;
 import com.google.cloud.bigtable.admin.v2.models.UpdateSchemaBundleRequest;
 import com.google.cloud.bigtable.admin.v2.models.UpdateTableRequest;
 import com.google.cloud.bigtable.admin.v2.stub.EnhancedBigtableTableAdminStub;
-import com.google.cloud.bigtable.data.v2.internal.TableAdminRequestContext;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClient.java
@@ -184,10 +184,8 @@ public final class BigtableTableAdminClient implements AutoCloseable {
   /** Constructs an instance of BigtableTableAdminClient with the given settings. */
   public static BigtableTableAdminClient create(@Nonnull BigtableTableAdminSettings settings)
       throws IOException {
-    TableAdminRequestContext requestContext =
-        TableAdminRequestContext.create(settings.getProjectId(), settings.getInstanceId());
     EnhancedBigtableTableAdminStub stub =
-        EnhancedBigtableTableAdminStub.createEnhanced(settings.getStubSettings(), requestContext);
+        EnhancedBigtableTableAdminStub.createEnhanced(settings.getStubSettings());
     return create(settings.getProjectId(), settings.getInstanceId(), stub);
   }
 
@@ -1697,7 +1695,9 @@ public final class BigtableTableAdminClient implements AutoCloseable {
    */
   public ApiFuture<Void> waitForConsistencyAsync(String tableId, String consistencyToken) {
     return stub.awaitConsistencyCallable()
-        .futureCall(ConsistencyRequest.forReplication(tableId, consistencyToken));
+        .futureCall(
+            ConsistencyRequest.forReplication(
+                NameUtil.formatTableName(projectId, instanceId, tableId), consistencyToken));
   }
 
   /**

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.ApiExceptions;
+import com.google.cloud.bigtable.admin.v2.models.ConsistencyRequest;
+import com.google.cloud.bigtable.admin.v2.models.OptimizeRestoredTableOperationToken;
+import com.google.cloud.bigtable.admin.v2.models.RestoredTableResult;
+import com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStub;
+import com.google.cloud.bigtable.admin.v2.stub.EnhancedBigtableTableAdminStub;
+import com.google.common.base.Strings;
+import com.google.protobuf.Empty;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Nonnull;
+
+/**
+ * Modern Cloud Bigtable Table Admin Client.
+ *
+ * <p>This client extends the auto-generated {@link BaseBigtableTableAdminClient} to provide manual
+ * overrides and additional convenience methods for Critical User Journeys (CUJs) that the GAPIC
+ * generator cannot handle natively (e.g., chained Long Running Operations, Consistency Polling).
+ */
+public class BigtableTableAdminClientV2 extends BaseBigtableTableAdminClient {
+
+  protected BigtableTableAdminClientV2(BaseBigtableTableAdminSettings settings) throws IOException {
+    super(settings);
+  }
+
+  protected BigtableTableAdminClientV2(BigtableTableAdminStub stub) {
+    super(stub);
+  }
+
+  /** Constructs an instance of BigtableTableAdminClientV2 with the given settings. */
+  public static final BigtableTableAdminClientV2 createClient(BaseBigtableTableAdminSettings settings)
+      throws IOException {
+    // Explicitly create the enhanced stub
+    EnhancedBigtableTableAdminStub stub =
+        EnhancedBigtableTableAdminStub.createEnhanced(
+            (com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStubSettings) settings.getStubSettings());
+    // Pass the enhanced stub to the existing stub-based constructor
+    return new BigtableTableAdminClientV2(stub);
+  }
+
+  /** Constructs an instance of BigtableTableAdminClientV2 with the given stub. */
+  public static final BigtableTableAdminClientV2 createClient(BigtableTableAdminStub stub) {
+    return new BigtableTableAdminClientV2(stub);
+  }
+
+  /**
+   * Awaits the completion of the "Optimize Restored Table" operation.
+   *
+   * <p>This method blocks until the restore operation is complete, extracts the optimization token,
+   * and returns an ApiFuture for the optimization phase.
+   *
+   * @param restoreFuture The future returned by restoreTableAsync().
+   * @return An ApiFuture that tracks the optimization progress.
+   */
+  public ApiFuture<Empty> awaitOptimizeRestoredTable(ApiFuture<RestoredTableResult> restoreFuture) {
+    // 1. Block and wait for the restore operation to complete
+    RestoredTableResult result;
+    try {
+      result = restoreFuture.get();
+    } catch (Exception e) {
+      throw new RuntimeException("Restore operation failed", e);
+    }
+
+    // 2. Extract the operation token from the result
+    // (RestoredTableResult already wraps the OptimizeRestoredTableOperationToken)
+    OptimizeRestoredTableOperationToken token = result.getOptimizeRestoredTableOperationToken();
+
+    if (token == null || Strings.isNullOrEmpty(token.getOperationName())) {
+      // If there is no optimization operation, return immediate success.
+      return ApiFutures.immediateFuture(Empty.getDefaultInstance());
+    }
+
+    // 3. Return the future for the optimization operation
+    return ((EnhancedBigtableTableAdminStub) getStub()).awaitOptimizeRestoredTableCallable().resumeFutureCall(token.getOperationName());
+  }
+
+  /**
+   * Awaits a restored table is fully optimized.
+   *
+   * <p>Sample code
+   *
+   * <pre>{@code
+   * RestoredTableResult result =
+   *     client.restoreTable(RestoreTableRequest.of(clusterId, backupId).setTableId(tableId));
+   * client.awaitOptimizeRestoredTable(result.getOptimizeRestoredTableOperationToken());
+   * }</pre>
+   */
+  public void awaitOptimizeRestoredTable(OptimizeRestoredTableOperationToken token)
+      throws ExecutionException, InterruptedException {
+    awaitOptimizeRestoredTableAsync(token).get();
+  }
+
+  /**
+   * Awaits a restored table is fully optimized asynchronously.
+   *
+   * <p>Sample code
+   *
+   * <pre>{@code
+   * RestoredTableResult result =
+   *     client.restoreTable(RestoreTableRequest.of(clusterId, backupId).setTableId(tableId));
+   * ApiFuture<Void> future = client.awaitOptimizeRestoredTableAsync(
+   *     result.getOptimizeRestoredTableOperationToken());
+   *
+   * ApiFutures.addCallback(
+   *   future,
+   *   new ApiFutureCallback<Void>() {
+   *     public void onSuccess(Void unused) {
+   *       System.out.println("The optimization of the restored table is done.");
+   *     }
+   *
+   *     public void onFailure(Throwable t) {
+   *       t.printStackTrace();
+   *     }
+   *   },
+   *   MoreExecutors.directExecutor()
+   * );
+   * }</pre>
+   */
+  public ApiFuture<Void> awaitOptimizeRestoredTableAsync(
+      OptimizeRestoredTableOperationToken token) {
+    ApiFuture<Empty> emptyFuture =
+        ((EnhancedBigtableTableAdminStub) getStub()).awaitOptimizeRestoredTableCallable().resumeFutureCall(token.getOperationName());
+    return ApiFutures.transform(
+        emptyFuture,
+        new com.google.api.core.ApiFunction<Empty, Void>() {
+          @Override
+          public Void apply(Empty input) {
+            return null;
+          }
+        },
+        com.google.common.util.concurrent.MoreExecutors.directExecutor());
+  }
+
+  /**
+   * Polls an existing consistency token until table replication is consistent across all clusters.
+   * Useful for checking consistency of a token generated in a separate process. Blocks until
+   * completion.
+   *
+   * @param tableName The fully qualified table name to check.
+   * @param consistencyToken The token to poll.
+   */
+  public void waitForConsistency(String tableName, String consistencyToken) {
+    ApiExceptions.callAndTranslateApiException(waitForConsistencyAsync(tableName, consistencyToken));
+  }
+
+  /**
+   * Asynchronously polls the consistency token. Returns a future that completes when table
+   * replication is consistent across all clusters.
+   *
+   * @param tableName The fully qualified table name to check.
+   * @param consistencyToken The token to poll.
+   */
+  public ApiFuture<Void> waitForConsistencyAsync(String tableName, String consistencyToken) {
+    return ((EnhancedBigtableTableAdminStub) getStub()).awaitConsistencyCallable()
+        .futureCall(ConsistencyRequest.forReplication(tableName, consistencyToken));
+  }
+}

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2.java
@@ -27,7 +27,6 @@ import com.google.common.base.Strings;
 import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
-import javax.annotation.Nonnull;
 
 /**
  * Modern Cloud Bigtable Table Admin Client.
@@ -47,12 +46,13 @@ public class BigtableTableAdminClientV2 extends BaseBigtableTableAdminClient {
   }
 
   /** Constructs an instance of BigtableTableAdminClientV2 with the given settings. */
-  public static final BigtableTableAdminClientV2 createClient(BaseBigtableTableAdminSettings settings)
-      throws IOException {
+  public static final BigtableTableAdminClientV2 createClient(
+      BaseBigtableTableAdminSettings settings) throws IOException {
     // Explicitly create the enhanced stub
     EnhancedBigtableTableAdminStub stub =
         EnhancedBigtableTableAdminStub.createEnhanced(
-            (com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStubSettings) settings.getStubSettings());
+            (com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStubSettings)
+                settings.getStubSettings());
     // Pass the enhanced stub to the existing stub-based constructor
     return new BigtableTableAdminClientV2(stub);
   }
@@ -90,7 +90,9 @@ public class BigtableTableAdminClientV2 extends BaseBigtableTableAdminClient {
     }
 
     // 3. Return the future for the optimization operation
-    return ((EnhancedBigtableTableAdminStub) getStub()).awaitOptimizeRestoredTableCallable().resumeFutureCall(token.getOperationName());
+    return ((EnhancedBigtableTableAdminStub) getStub())
+        .awaitOptimizeRestoredTableCallable()
+        .resumeFutureCall(token.getOperationName());
   }
 
   /**
@@ -138,7 +140,9 @@ public class BigtableTableAdminClientV2 extends BaseBigtableTableAdminClient {
   public ApiFuture<Void> awaitOptimizeRestoredTableAsync(
       OptimizeRestoredTableOperationToken token) {
     ApiFuture<Empty> emptyFuture =
-        ((EnhancedBigtableTableAdminStub) getStub()).awaitOptimizeRestoredTableCallable().resumeFutureCall(token.getOperationName());
+        ((EnhancedBigtableTableAdminStub) getStub())
+            .awaitOptimizeRestoredTableCallable()
+            .resumeFutureCall(token.getOperationName());
     return ApiFutures.transform(
         emptyFuture,
         new com.google.api.core.ApiFunction<Empty, Void>() {
@@ -159,7 +163,8 @@ public class BigtableTableAdminClientV2 extends BaseBigtableTableAdminClient {
    * @param consistencyToken The token to poll.
    */
   public void waitForConsistency(String tableName, String consistencyToken) {
-    ApiExceptions.callAndTranslateApiException(waitForConsistencyAsync(tableName, consistencyToken));
+    ApiExceptions.callAndTranslateApiException(
+        waitForConsistencyAsync(tableName, consistencyToken));
   }
 
   /**
@@ -170,7 +175,8 @@ public class BigtableTableAdminClientV2 extends BaseBigtableTableAdminClient {
    * @param consistencyToken The token to poll.
    */
   public ApiFuture<Void> waitForConsistencyAsync(String tableName, String consistencyToken) {
-    return ((EnhancedBigtableTableAdminStub) getStub()).awaitConsistencyCallable()
+    return ((EnhancedBigtableTableAdminStub) getStub())
+        .awaitConsistencyCallable()
         .futureCall(ConsistencyRequest.forReplication(tableName, consistencyToken));
   }
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/ConsistencyRequest.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/ConsistencyRequest.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class ConsistencyRequest {
   @Nonnull
-  protected abstract String getTableId();
+  protected abstract String getTableName();
 
   @Nonnull
   protected abstract CheckConsistencyRequest.ModeCase getMode();
@@ -43,36 +43,33 @@ public abstract class ConsistencyRequest {
   @Nullable
   public abstract String getConsistencyToken();
 
-  public static ConsistencyRequest forReplication(String tableId) {
+  public static ConsistencyRequest forReplication(String tableName) {
     return new AutoValue_ConsistencyRequest(
-        tableId, CheckConsistencyRequest.ModeCase.STANDARD_READ_REMOTE_WRITES, null);
+        tableName, CheckConsistencyRequest.ModeCase.STANDARD_READ_REMOTE_WRITES, null);
   }
 
   /**
    * Creates a request to check consistency using an existing token.
    *
-   * @param tableId The table ID.
+   * @param tableName The table name.
    * @param consistencyToken The token to check. Must not be null.
    * @throws NullPointerException if consistencyToken is null.
    */
-  public static ConsistencyRequest forReplication(String tableId, String consistencyToken) {
+  public static ConsistencyRequest forReplication(String tableName, String consistencyToken) {
     Preconditions.checkNotNull(consistencyToken, "consistencyToken must not be null");
 
     return new AutoValue_ConsistencyRequest(
-        tableId, CheckConsistencyRequest.ModeCase.STANDARD_READ_REMOTE_WRITES, consistencyToken);
+        tableName, CheckConsistencyRequest.ModeCase.STANDARD_READ_REMOTE_WRITES, consistencyToken);
   }
 
-  public static ConsistencyRequest forDataBoost(String tableId) {
+  public static ConsistencyRequest forDataBoost(String tableName) {
     return new AutoValue_ConsistencyRequest(
-        tableId, CheckConsistencyRequest.ModeCase.DATA_BOOST_READ_LOCAL_WRITES, null);
+        tableName, CheckConsistencyRequest.ModeCase.DATA_BOOST_READ_LOCAL_WRITES, null);
   }
 
   @InternalApi
-  public CheckConsistencyRequest toCheckConsistencyProto(
-      TableAdminRequestContext requestContext, String token) {
+  public CheckConsistencyRequest toCheckConsistencyProto(String token) {
     CheckConsistencyRequest.Builder builder = CheckConsistencyRequest.newBuilder();
-    TableName tableName =
-        TableName.of(requestContext.getProjectId(), requestContext.getInstanceId(), getTableId());
 
     if (getMode().equals(CheckConsistencyRequest.ModeCase.STANDARD_READ_REMOTE_WRITES)) {
       builder.setStandardReadRemoteWrites(StandardReadRemoteWrites.newBuilder().build());
@@ -80,16 +77,12 @@ public abstract class ConsistencyRequest {
       builder.setDataBoostReadLocalWrites(DataBoostReadLocalWrites.newBuilder().build());
     }
 
-    return builder.setName(tableName.toString()).setConsistencyToken(token).build();
+    return builder.setName(getTableName()).setConsistencyToken(token).build();
   }
 
   @InternalApi
-  public GenerateConsistencyTokenRequest toGenerateTokenProto(
-      TableAdminRequestContext requestContext) {
+  public GenerateConsistencyTokenRequest toGenerateTokenProto() {
     GenerateConsistencyTokenRequest.Builder builder = GenerateConsistencyTokenRequest.newBuilder();
-    TableName tableName =
-        TableName.of(requestContext.getProjectId(), requestContext.getInstanceId(), getTableId());
-
-    return builder.setName(tableName.toString()).build();
+    return builder.setName(getTableName()).build();
   }
 }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/ConsistencyRequest.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/models/ConsistencyRequest.java
@@ -21,8 +21,6 @@ import com.google.bigtable.admin.v2.CheckConsistencyRequest;
 import com.google.bigtable.admin.v2.DataBoostReadLocalWrites;
 import com.google.bigtable.admin.v2.GenerateConsistencyTokenRequest;
 import com.google.bigtable.admin.v2.StandardReadRemoteWrites;
-import com.google.bigtable.admin.v2.TableName;
-import com.google.cloud.bigtable.data.v2.internal.TableAdminRequestContext;
 import com.google.common.base.Preconditions;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/stub/AwaitConsistencyCallable.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/stub/AwaitConsistencyCallable.java
@@ -56,15 +56,12 @@ class AwaitConsistencyCallable extends UnaryCallable<ConsistencyRequest, Void> {
   private final UnaryCallable<CheckConsistencyRequest, CheckConsistencyResponse> checkCallable;
   private final RetryingExecutor<CheckConsistencyResponse> executor;
 
-  private final TableAdminRequestContext requestContext;
-
   static AwaitConsistencyCallable create(
       UnaryCallable<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
           generateCallable,
       UnaryCallable<CheckConsistencyRequest, CheckConsistencyResponse> checkCallable,
       ClientContext clientContext,
-      RetrySettings pollingSettings,
-      TableAdminRequestContext requestContext) {
+      RetrySettings pollingSettings) {
 
     RetryAlgorithm<CheckConsistencyResponse> retryAlgorithm =
         new RetryAlgorithm<>(
@@ -75,7 +72,7 @@ class AwaitConsistencyCallable extends UnaryCallable<ConsistencyRequest, Void> {
         new ScheduledRetryingExecutor<>(retryAlgorithm, clientContext.getExecutor());
 
     return new AwaitConsistencyCallable(
-        generateCallable, checkCallable, retryingExecutor, requestContext);
+        generateCallable, checkCallable, retryingExecutor);
   }
 
   @VisibleForTesting
@@ -83,12 +80,10 @@ class AwaitConsistencyCallable extends UnaryCallable<ConsistencyRequest, Void> {
       UnaryCallable<GenerateConsistencyTokenRequest, GenerateConsistencyTokenResponse>
           generateCallable,
       UnaryCallable<CheckConsistencyRequest, CheckConsistencyResponse> checkCallable,
-      RetryingExecutor<CheckConsistencyResponse> executor,
-      TableAdminRequestContext requestContext) {
+      RetryingExecutor<CheckConsistencyResponse> executor) {
     this.generateCallable = generateCallable;
     this.checkCallable = checkCallable;
     this.executor = executor;
-    this.requestContext = requestContext;
   }
 
   @Override
@@ -98,13 +93,12 @@ class AwaitConsistencyCallable extends UnaryCallable<ConsistencyRequest, Void> {
     // If the token is already provided, skip generation and poll directly.
     if (consistencyRequest.getConsistencyToken() != null) {
       CheckConsistencyRequest request =
-          consistencyRequest.toCheckConsistencyProto(
-              requestContext, consistencyRequest.getConsistencyToken());
+          consistencyRequest.toCheckConsistencyProto(consistencyRequest.getConsistencyToken());
       return pollToken(request, apiCallContext);
     }
 
     ApiFuture<GenerateConsistencyTokenResponse> tokenFuture =
-        generateToken(consistencyRequest.toGenerateTokenProto(requestContext), apiCallContext);
+        generateToken(consistencyRequest.toGenerateTokenProto(), apiCallContext);
 
     return ApiFutures.transformAsync(
         tokenFuture,
@@ -112,8 +106,7 @@ class AwaitConsistencyCallable extends UnaryCallable<ConsistencyRequest, Void> {
           @Override
           public ApiFuture<Void> apply(GenerateConsistencyTokenResponse input) {
             CheckConsistencyRequest request =
-                consistencyRequest.toCheckConsistencyProto(
-                    requestContext, input.getConsistencyToken());
+                consistencyRequest.toCheckConsistencyProto(input.getConsistencyToken());
             return pollToken(request, apiCallContext);
           }
         },

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/stub/AwaitConsistencyCallable.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/stub/AwaitConsistencyCallable.java
@@ -37,7 +37,6 @@ import com.google.bigtable.admin.v2.CheckConsistencyResponse;
 import com.google.bigtable.admin.v2.GenerateConsistencyTokenRequest;
 import com.google.bigtable.admin.v2.GenerateConsistencyTokenResponse;
 import com.google.cloud.bigtable.admin.v2.models.ConsistencyRequest;
-import com.google.cloud.bigtable.data.v2.internal.TableAdminRequestContext;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.Callable;
@@ -71,8 +70,7 @@ class AwaitConsistencyCallable extends UnaryCallable<ConsistencyRequest, Void> {
     RetryingExecutor<CheckConsistencyResponse> retryingExecutor =
         new ScheduledRetryingExecutor<>(retryAlgorithm, clientContext.getExecutor());
 
-    return new AwaitConsistencyCallable(
-        generateCallable, checkCallable, retryingExecutor);
+    return new AwaitConsistencyCallable(generateCallable, checkCallable, retryingExecutor);
   }
 
   @VisibleForTesting

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/stub/AwaitReplicationCallable.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/stub/AwaitReplicationCallable.java
@@ -42,7 +42,7 @@ class AwaitReplicationCallable extends UnaryCallable<TableName, Void> {
 
   @Override
   public ApiFuture<Void> futureCall(final TableName tableName, final ApiCallContext context) {
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(tableName.getTable());
+    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(tableName.toString());
 
     return awaitConsistencyCallable.futureCall(consistencyRequest, context);
   }

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/stub/EnhancedBigtableTableAdminStub.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/stub/EnhancedBigtableTableAdminStub.java
@@ -54,8 +54,6 @@ public class EnhancedBigtableTableAdminStub extends GrpcBigtableTableAdminStub {
   private final BigtableTableAdminStubSettings settings;
   private final ClientContext clientContext;
 
-  private final TableAdminRequestContext requestContext;
-
   @Deprecated private final AwaitReplicationCallable awaitReplicationCallable;
 
   private final AwaitConsistencyCallable awaitConsistencyCallable;
@@ -63,22 +61,20 @@ public class EnhancedBigtableTableAdminStub extends GrpcBigtableTableAdminStub {
       optimizeRestoredTableOperationBaseCallable;
 
   public static EnhancedBigtableTableAdminStub createEnhanced(
-      BigtableTableAdminStubSettings settings, TableAdminRequestContext requestContext)
+      BigtableTableAdminStubSettings settings)
       throws IOException {
     return new EnhancedBigtableTableAdminStub(
-        settings, ClientContext.create(settings), requestContext);
+        settings, ClientContext.create(settings));
   }
 
   private EnhancedBigtableTableAdminStub(
       BigtableTableAdminStubSettings settings,
-      ClientContext clientContext,
-      TableAdminRequestContext requestContext)
+      ClientContext clientContext)
       throws IOException {
     super(settings, clientContext);
 
     this.settings = settings;
     this.clientContext = clientContext;
-    this.requestContext = requestContext;
     this.awaitConsistencyCallable = createAwaitConsistencyCallable();
     this.awaitReplicationCallable = createAwaitReplicationCallable();
     this.optimizeRestoredTableOperationBaseCallable =
@@ -113,8 +109,7 @@ public class EnhancedBigtableTableAdminStub extends GrpcBigtableTableAdminStub {
         generateConsistencyTokenCallable(),
         checkConsistencyCallable(),
         clientContext,
-        pollingSettings,
-        requestContext);
+        pollingSettings);
   }
 
   // Plug into gax operation infrastructure

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/stub/EnhancedBigtableTableAdminStub.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/stub/EnhancedBigtableTableAdminStub.java
@@ -32,7 +32,6 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.bigtable.admin.v2.OptimizeRestoredTableMetadata;
 import com.google.bigtable.admin.v2.TableName;
 import com.google.cloud.bigtable.admin.v2.models.ConsistencyRequest;
-import com.google.cloud.bigtable.data.v2.internal.TableAdminRequestContext;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import io.grpc.MethodDescriptor;
@@ -61,16 +60,12 @@ public class EnhancedBigtableTableAdminStub extends GrpcBigtableTableAdminStub {
       optimizeRestoredTableOperationBaseCallable;
 
   public static EnhancedBigtableTableAdminStub createEnhanced(
-      BigtableTableAdminStubSettings settings)
-      throws IOException {
-    return new EnhancedBigtableTableAdminStub(
-        settings, ClientContext.create(settings));
+      BigtableTableAdminStubSettings settings) throws IOException {
+    return new EnhancedBigtableTableAdminStub(settings, ClientContext.create(settings));
   }
 
   private EnhancedBigtableTableAdminStub(
-      BigtableTableAdminStubSettings settings,
-      ClientContext clientContext)
-      throws IOException {
+      BigtableTableAdminStubSettings settings, ClientContext clientContext) throws IOException {
     super(settings, clientContext);
 
     this.settings = settings;

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2Test.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2Test.java
@@ -44,12 +44,12 @@ import org.mockito.stubbing.Answer;
 public class BigtableTableAdminClientV2Test {
   @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
-  private static final String TABLE_NAME = "projects/my-project/instances/my-instance/tables/my-table";
+  private static final String TABLE_NAME =
+      "projects/my-project/instances/my-instance/tables/my-table";
 
   @Mock private EnhancedBigtableTableAdminStub mockStub;
 
-  @Mock
-  private UnaryCallable<ConsistencyRequest, Void> mockAwaitConsistencyCallable;
+  @Mock private UnaryCallable<ConsistencyRequest, Void> mockAwaitConsistencyCallable;
 
   @Mock
   private OperationCallable<Void, Empty, OptimizeRestoredTableMetadata>

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2Test.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2Test.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.admin.v2.OptimizeRestoredTableMetadata;
+import com.google.cloud.bigtable.admin.v2.models.ConsistencyRequest;
+import com.google.cloud.bigtable.admin.v2.models.OptimizeRestoredTableOperationToken;
+import com.google.cloud.bigtable.admin.v2.models.RestoredTableResult;
+import com.google.cloud.bigtable.admin.v2.stub.EnhancedBigtableTableAdminStub;
+import com.google.protobuf.Empty;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.Answer;
+
+@RunWith(JUnit4.class)
+public class BigtableTableAdminClientV2Test {
+  @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private static final String TABLE_NAME = "projects/my-project/instances/my-instance/tables/my-table";
+
+  @Mock private EnhancedBigtableTableAdminStub mockStub;
+
+  @Mock
+  private UnaryCallable<ConsistencyRequest, Void> mockAwaitConsistencyCallable;
+
+  @Mock
+  private OperationCallable<Void, Empty, OptimizeRestoredTableMetadata>
+      mockOptimizeRestoredTableCallable;
+
+  private BigtableTableAdminClientV2 client;
+
+  @Before
+  public void setUp() {
+    client = BigtableTableAdminClientV2.createClient(mockStub);
+  }
+
+  @Test
+  public void testWaitForConsistencyWithToken() {
+    // Setup
+    Mockito.when(mockStub.awaitConsistencyCallable()).thenReturn(mockAwaitConsistencyCallable);
+
+    String token = "my-token";
+    ConsistencyRequest expectedRequest = ConsistencyRequest.forReplication(TABLE_NAME, token);
+
+    final AtomicBoolean wasCalled = new AtomicBoolean(false);
+
+    Mockito.when(mockAwaitConsistencyCallable.futureCall(expectedRequest))
+        .thenAnswer(
+            (Answer<ApiFuture<Void>>)
+                invocationOnMock -> {
+                  wasCalled.set(true);
+                  return ApiFutures.immediateFuture(null);
+                });
+
+    // Execute
+    client.waitForConsistency(TABLE_NAME, token);
+
+    // Verify
+    assertThat(wasCalled.get()).isTrue();
+  }
+
+  @Test
+  public void testAwaitOptimizeRestoredTable() throws Exception {
+    // Setup
+    Mockito.when(mockStub.awaitOptimizeRestoredTableCallable())
+        .thenReturn(mockOptimizeRestoredTableCallable);
+
+    String optimizeToken = "my-optimization-token";
+
+    // 1. Mock the Token
+    OptimizeRestoredTableOperationToken mockToken =
+        Mockito.mock(OptimizeRestoredTableOperationToken.class);
+    Mockito.when(mockToken.getOperationName()).thenReturn(optimizeToken);
+
+    // 2. Mock the Result (wrapping the token)
+    RestoredTableResult mockResult = Mockito.mock(RestoredTableResult.class);
+    Mockito.when(mockResult.getOptimizeRestoredTableOperationToken()).thenReturn(mockToken);
+
+    // 3. Mock the Input Future (returning the result)
+    ApiFuture<RestoredTableResult> mockRestoreFuture = Mockito.mock(ApiFuture.class);
+    Mockito.when(mockRestoreFuture.get()).thenReturn(mockResult);
+
+    // 4. Mock the Stub's behavior (resuming the Optimize Op)
+    OperationFuture<Empty, OptimizeRestoredTableMetadata> mockOptimizeOp =
+        Mockito.mock(OperationFuture.class);
+    Mockito.when(mockOptimizeRestoredTableCallable.resumeFutureCall(optimizeToken))
+        .thenReturn(mockOptimizeOp);
+
+    // Execute
+    ApiFuture<Empty> result = client.awaitOptimizeRestoredTable(mockRestoreFuture);
+
+    // Verify
+    assertThat(result).isEqualTo(mockOptimizeOp);
+    Mockito.verify(mockOptimizeRestoredTableCallable).resumeFutureCall(optimizeToken);
+  }
+
+  @Test
+  public void testAwaitOptimizeRestoredTable_NoOp() throws Exception {
+    // Setup: Result with NO optimization token (null or empty)
+    RestoredTableResult mockResult = Mockito.mock(RestoredTableResult.class);
+    Mockito.when(mockResult.getOptimizeRestoredTableOperationToken()).thenReturn(null);
+
+    // Mock the Input Future
+    ApiFuture<RestoredTableResult> mockRestoreFuture = Mockito.mock(ApiFuture.class);
+    Mockito.when(mockRestoreFuture.get()).thenReturn(mockResult);
+
+    // Execute
+    ApiFuture<Empty> result = client.awaitOptimizeRestoredTable(mockRestoreFuture);
+
+    // Verify: Returns immediate success (Empty) without calling the stub
+    assertThat(result.get()).isEqualTo(Empty.getDefaultInstance());
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/ConsistencyRequestTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/ConsistencyRequestTest.java
@@ -58,8 +58,7 @@ public class ConsistencyRequestTest {
   public void testToGenerateTokenProto() {
     ConsistencyRequest consistencyRequest = ConsistencyRequest.forDataBoost(TABLE_NAME);
 
-    GenerateConsistencyTokenRequest generateRequest =
-        consistencyRequest.toGenerateTokenProto();
+    GenerateConsistencyTokenRequest generateRequest = consistencyRequest.toGenerateTokenProto();
 
     assertThat(generateRequest.getName()).isEqualTo(TABLE_NAME);
   }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/ConsistencyRequestTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/models/ConsistencyRequestTest.java
@@ -19,31 +19,23 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.bigtable.admin.v2.CheckConsistencyRequest;
 import com.google.bigtable.admin.v2.GenerateConsistencyTokenRequest;
-import com.google.cloud.bigtable.data.v2.internal.NameUtil;
-import com.google.cloud.bigtable.data.v2.internal.TableAdminRequestContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ConsistencyRequestTest {
-  private final String PROJECT_ID = "my-project";
-  private final String INSTANCE_ID = "my-instance";
-  private final String TABLE_ID = "my-table";
+  private final String TABLE_NAME = "projects/my-project/instances/my-instance/tables/my-table";
   private final String CONSISTENCY_TOKEN = "my-token";
 
   @Test
   public void testToCheckConsistencyProtoWithStandard() {
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_ID);
-
-    TableAdminRequestContext requestContext =
-        TableAdminRequestContext.create(PROJECT_ID, INSTANCE_ID);
+    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_NAME);
 
     CheckConsistencyRequest checkConsistencyRequest =
-        consistencyRequest.toCheckConsistencyProto(requestContext, CONSISTENCY_TOKEN);
+        consistencyRequest.toCheckConsistencyProto(CONSISTENCY_TOKEN);
 
-    assertThat(checkConsistencyRequest.getName())
-        .isEqualTo(NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_ID));
+    assertThat(checkConsistencyRequest.getName()).isEqualTo(TABLE_NAME);
     assertThat(checkConsistencyRequest.getConsistencyToken()).isEqualTo(CONSISTENCY_TOKEN);
     assertThat(checkConsistencyRequest.getModeCase())
         .isEqualTo(CheckConsistencyRequest.ModeCase.STANDARD_READ_REMOTE_WRITES);
@@ -51,16 +43,12 @@ public class ConsistencyRequestTest {
 
   @Test
   public void testToCheckConsistencyProtoWithDataBoost() {
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forDataBoost(TABLE_ID);
-
-    TableAdminRequestContext requestContext =
-        TableAdminRequestContext.create(PROJECT_ID, INSTANCE_ID);
+    ConsistencyRequest consistencyRequest = ConsistencyRequest.forDataBoost(TABLE_NAME);
 
     CheckConsistencyRequest checkConsistencyRequest =
-        consistencyRequest.toCheckConsistencyProto(requestContext, CONSISTENCY_TOKEN);
+        consistencyRequest.toCheckConsistencyProto(CONSISTENCY_TOKEN);
 
-    assertThat(checkConsistencyRequest.getName())
-        .isEqualTo(NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_ID));
+    assertThat(checkConsistencyRequest.getName()).isEqualTo(TABLE_NAME);
     assertThat(checkConsistencyRequest.getConsistencyToken()).isEqualTo(CONSISTENCY_TOKEN);
     assertThat(checkConsistencyRequest.getModeCase())
         .isEqualTo(CheckConsistencyRequest.ModeCase.DATA_BOOST_READ_LOCAL_WRITES);
@@ -68,31 +56,23 @@ public class ConsistencyRequestTest {
 
   @Test
   public void testToGenerateTokenProto() {
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forDataBoost(TABLE_ID);
-
-    TableAdminRequestContext requestContext =
-        TableAdminRequestContext.create(PROJECT_ID, INSTANCE_ID);
+    ConsistencyRequest consistencyRequest = ConsistencyRequest.forDataBoost(TABLE_NAME);
 
     GenerateConsistencyTokenRequest generateRequest =
-        consistencyRequest.toGenerateTokenProto(requestContext);
+        consistencyRequest.toGenerateTokenProto();
 
-    assertThat(generateRequest.getName())
-        .isEqualTo(NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_ID));
+    assertThat(generateRequest.getName()).isEqualTo(TABLE_NAME);
   }
 
   @Test
   public void testToCheckConsistencyProtoWithToken() {
     ConsistencyRequest consistencyRequest =
-        ConsistencyRequest.forReplication(TABLE_ID, CONSISTENCY_TOKEN);
-
-    TableAdminRequestContext requestContext =
-        TableAdminRequestContext.create(PROJECT_ID, INSTANCE_ID);
+        ConsistencyRequest.forReplication(TABLE_NAME, CONSISTENCY_TOKEN);
 
     CheckConsistencyRequest checkConsistencyRequest =
-        consistencyRequest.toCheckConsistencyProto(requestContext, CONSISTENCY_TOKEN);
+        consistencyRequest.toCheckConsistencyProto(CONSISTENCY_TOKEN);
 
-    assertThat(checkConsistencyRequest.getName())
-        .isEqualTo(NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_ID));
+    assertThat(checkConsistencyRequest.getName()).isEqualTo(TABLE_NAME);
     assertThat(checkConsistencyRequest.getConsistencyToken()).isEqualTo(CONSISTENCY_TOKEN);
     assertThat(checkConsistencyRequest.getModeCase())
         .isEqualTo(CheckConsistencyRequest.ModeCase.STANDARD_READ_REMOTE_WRITES);

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/stub/AwaitConsistencyCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/stub/AwaitConsistencyCallableTest.java
@@ -111,7 +111,8 @@ public class AwaitConsistencyCallableTest {
     Mockito.when(mockGenerateConsistencyTokenCallable.futureCall(expectedRequest, CALL_CONTEXT))
         .thenReturn(ApiFutures.<GenerateConsistencyTokenResponse>immediateFailedFuture(fakeError));
 
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_NAME.toString());
+    ConsistencyRequest consistencyRequest =
+        ConsistencyRequest.forReplication(TABLE_NAME.toString());
     ApiFuture<Void> future = awaitConsistencyCallable.futureCall(consistencyRequest, CALL_CONTEXT);
 
     Throwable actualError = null;
@@ -147,7 +148,8 @@ public class AwaitConsistencyCallableTest {
     Mockito.when(mockCheckConsistencyCallable.futureCall(expectedRequest2, CALL_CONTEXT))
         .thenReturn(ApiFutures.<CheckConsistencyResponse>immediateFailedFuture(expectedError));
 
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_NAME.toString());
+    ConsistencyRequest consistencyRequest =
+        ConsistencyRequest.forReplication(TABLE_NAME.toString());
     ApiFuture<Void> future = awaitConsistencyCallable.futureCall(consistencyRequest, CALL_CONTEXT);
 
     Throwable actualError = null;
@@ -184,7 +186,8 @@ public class AwaitConsistencyCallableTest {
     Mockito.when(mockCheckConsistencyCallable.futureCall(expectedRequest2, CALL_CONTEXT))
         .thenReturn(ApiFutures.immediateFuture(expectedResponse2));
 
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_NAME.toString());
+    ConsistencyRequest consistencyRequest =
+        ConsistencyRequest.forReplication(TABLE_NAME.toString());
     ApiFuture<Void> consistentFuture =
         awaitConsistencyCallable.futureCall(consistencyRequest, CALL_CONTEXT);
 
@@ -219,7 +222,8 @@ public class AwaitConsistencyCallableTest {
         .thenReturn(ApiFutures.immediateFuture(expectedResponse2))
         .thenReturn(ApiFutures.immediateFuture(expectedResponse3));
 
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_NAME.toString());
+    ConsistencyRequest consistencyRequest =
+        ConsistencyRequest.forReplication(TABLE_NAME.toString());
     ApiFuture<Void> consistentFuture =
         awaitConsistencyCallable.futureCall(consistencyRequest, CALL_CONTEXT);
 
@@ -250,7 +254,8 @@ public class AwaitConsistencyCallableTest {
     Mockito.when(mockCheckConsistencyCallable.futureCall(expectedRequest2, CALL_CONTEXT))
         .thenReturn(ApiFutures.immediateFuture(expectedResponse2));
 
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_NAME.toString());
+    ConsistencyRequest consistencyRequest =
+        ConsistencyRequest.forReplication(TABLE_NAME.toString());
     ApiFuture<Void> consistentFuture =
         awaitConsistencyCallable.futureCall(consistencyRequest, CALL_CONTEXT);
 

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/stub/AwaitConsistencyCallableTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/stub/AwaitConsistencyCallableTest.java
@@ -98,8 +98,7 @@ public class AwaitConsistencyCallableTest {
             mockGenerateConsistencyTokenCallable,
             mockCheckConsistencyCallable,
             clientContext,
-            retrySettings,
-            REQUEST_CONTEXT);
+            retrySettings);
     awaitReplicationCallable = AwaitReplicationCallable.create(awaitConsistencyCallable);
   }
 
@@ -112,7 +111,7 @@ public class AwaitConsistencyCallableTest {
     Mockito.when(mockGenerateConsistencyTokenCallable.futureCall(expectedRequest, CALL_CONTEXT))
         .thenReturn(ApiFutures.<GenerateConsistencyTokenResponse>immediateFailedFuture(fakeError));
 
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_ID);
+    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_NAME.toString());
     ApiFuture<Void> future = awaitConsistencyCallable.futureCall(consistencyRequest, CALL_CONTEXT);
 
     Throwable actualError = null;
@@ -148,7 +147,7 @@ public class AwaitConsistencyCallableTest {
     Mockito.when(mockCheckConsistencyCallable.futureCall(expectedRequest2, CALL_CONTEXT))
         .thenReturn(ApiFutures.<CheckConsistencyResponse>immediateFailedFuture(expectedError));
 
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_ID);
+    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_NAME.toString());
     ApiFuture<Void> future = awaitConsistencyCallable.futureCall(consistencyRequest, CALL_CONTEXT);
 
     Throwable actualError = null;
@@ -185,7 +184,7 @@ public class AwaitConsistencyCallableTest {
     Mockito.when(mockCheckConsistencyCallable.futureCall(expectedRequest2, CALL_CONTEXT))
         .thenReturn(ApiFutures.immediateFuture(expectedResponse2));
 
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_ID);
+    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_NAME.toString());
     ApiFuture<Void> consistentFuture =
         awaitConsistencyCallable.futureCall(consistencyRequest, CALL_CONTEXT);
 
@@ -220,7 +219,7 @@ public class AwaitConsistencyCallableTest {
         .thenReturn(ApiFutures.immediateFuture(expectedResponse2))
         .thenReturn(ApiFutures.immediateFuture(expectedResponse3));
 
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_ID);
+    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_NAME.toString());
     ApiFuture<Void> consistentFuture =
         awaitConsistencyCallable.futureCall(consistencyRequest, CALL_CONTEXT);
 
@@ -251,7 +250,7 @@ public class AwaitConsistencyCallableTest {
     Mockito.when(mockCheckConsistencyCallable.futureCall(expectedRequest2, CALL_CONTEXT))
         .thenReturn(ApiFutures.immediateFuture(expectedResponse2));
 
-    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_ID);
+    ConsistencyRequest consistencyRequest = ConsistencyRequest.forReplication(TABLE_NAME.toString());
     ApiFuture<Void> consistentFuture =
         awaitConsistencyCallable.futureCall(consistencyRequest, CALL_CONTEXT);
 
@@ -333,7 +332,7 @@ public class AwaitConsistencyCallableTest {
     // 1. Setup: Request with a pre-existing token
     String existingToken = "existing-token";
     ConsistencyRequest consistencyRequest =
-        ConsistencyRequest.forReplication(TABLE_ID, existingToken);
+        ConsistencyRequest.forReplication(TABLE_NAME.toString(), existingToken);
 
     // 2. Setup: Mock the check operation to succeed immediately
     CheckConsistencyRequest expectedCheckRequest =


### PR DESCRIPTION
This commit introduces `BigtableTableAdminClientV2`, a new client class that extends the auto-generated `BaseBigtableTableAdminClient`. It relocates the manual wrappers for CUJs from the legacy `BigtableTableAdminClient`.

b/502616786