### PR TITLE
feat: add BigtableInstanceAdminClientV2 to support Selective GAPIC

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClientV2.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClientV2.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2;
+
+import com.google.cloud.bigtable.admin.v2.stub.BigtableInstanceAdminStub;
+import java.io.IOException;
+
+/**
+ * Modern Cloud Bigtable Instance Admin Client.
+ *
+ * <p>This client extends the auto-generated {@link BaseBigtableInstanceAdminClient} to provide
+ * manual overrides and additional convenience methods for Critical User Journeys (CUJs) that the
+ * GAPIC generator cannot handle natively.
+ */
+public class BigtableInstanceAdminClientV2 extends BaseBigtableInstanceAdminClient {
+
+  protected BigtableInstanceAdminClientV2(BaseBigtableInstanceAdminSettings settings)
+      throws IOException {
+    super(settings);
+  }
+
+  protected BigtableInstanceAdminClientV2(BigtableInstanceAdminStub stub) {
+    super(stub);
+  }
+
+  /** Constructs an instance of BigtableInstanceAdminClientV2 with the given settings. */
+  public static final BigtableInstanceAdminClientV2 createClient(
+      BaseBigtableInstanceAdminSettings settings) throws IOException {
+    return new BigtableInstanceAdminClientV2(settings);
+  }
+
+  /** Constructs an instance of BigtableInstanceAdminClientV2 with the given stub. */
+  public static final BigtableInstanceAdminClientV2 createClient(BigtableInstanceAdminStub stub) {
+    return new BigtableInstanceAdminClientV2(stub);
+  }
+}

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.ApiExceptions;
+import com.google.cloud.bigtable.admin.v2.models.ConsistencyRequest;
+import com.google.cloud.bigtable.admin.v2.models.OptimizeRestoredTableOperationToken;
+import com.google.cloud.bigtable.admin.v2.models.RestoredTableResult;
+import com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStub;
+import com.google.cloud.bigtable.admin.v2.stub.EnhancedBigtableTableAdminStub;
+import com.google.common.base.Strings;
+import com.google.protobuf.Empty;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Nonnull;
+
+/**
+ * Modern Cloud Bigtable Table Admin Client.
+ *
+ * <p>This client extends the auto-generated {@link BaseBigtableTableAdminClient} to provide manual
+ * overrides and additional convenience methods for Critical User Journeys (CUJs) that the GAPIC
+ * generator cannot handle natively (e.g., chained Long Running Operations, Consistency Polling).
+ */
+public class BigtableTableAdminClientV2 extends BaseBigtableTableAdminClient {
+
+  protected BigtableTableAdminClientV2(BaseBigtableTableAdminSettings settings) throws IOException {
+    super(settings);
+  }
+
+  protected BigtableTableAdminClientV2(BigtableTableAdminStub stub) {
+    super(stub);
+  }
+
+  /** Constructs an instance of BigtableTableAdminClientV2 with the given settings. */
+  public static final BigtableTableAdminClientV2 createClient(BaseBigtableTableAdminSettings settings)
+      throws IOException {
+    return new BigtableTableAdminClientV2(settings);
+  }
+
+  /** Constructs an instance of BigtableTableAdminClientV2 with the given stub. */
+  public static final BigtableTableAdminClientV2 createClient(BigtableTableAdminStub stub) {
+    return new BigtableTableAdminClientV2(stub);
+  }
+
+  /**
+   * Awaits the completion of the "Optimize Restored Table" operation.
+   *
+   * <p>This method blocks until the restore operation is complete, extracts the optimization token,
+   * and returns an ApiFuture for the optimization phase.
+   *
+   * @param restoreFuture The future returned by restoreTableAsync().
+   * @return An ApiFuture that tracks the optimization progress.
+   */
+  public ApiFuture<Empty> awaitOptimizeRestoredTable(ApiFuture<RestoredTableResult> restoreFuture) {
+    // 1. Block and wait for the restore operation to complete
+    RestoredTableResult result;
+    try {
+      result = restoreFuture.get();
+    } catch (Exception e) {
+      throw new RuntimeException("Restore operation failed", e);
+    }
+
+    // 2. Extract the operation token from the result
+    // (RestoredTableResult already wraps the OptimizeRestoredTableOperationToken)
+    OptimizeRestoredTableOperationToken token = result.getOptimizeRestoredTableOperationToken();
+
+    if (token == null || Strings.isNullOrEmpty(token.getOperationName())) {
+      // If there is no optimization operation, return immediate success.
+      return ApiFutures.immediateFuture(Empty.getDefaultInstance());
+    }
+
+    // 3. Return the future for the optimization operation
+    return ((EnhancedBigtableTableAdminStub) getStub()).awaitOptimizeRestoredTableCallable().resumeFutureCall(token.getOperationName());
+  }
+
+  /**
+   * Awaits a restored table is fully optimized.
+   *
+   * <p>Sample code
+   *
+   * <pre>{@code
+   * RestoredTableResult result =
+   *     client.restoreTable(RestoreTableRequest.of(clusterId, backupId).setTableId(tableId));
+   * client.awaitOptimizeRestoredTable(result.getOptimizeRestoredTableOperationToken());
+   * }</pre>
+   */
+  public void awaitOptimizeRestoredTable(OptimizeRestoredTableOperationToken token)
+      throws ExecutionException, InterruptedException {
+    awaitOptimizeRestoredTableAsync(token).get();
+  }
+
+  /**
+   * Awaits a restored table is fully optimized asynchronously.
+   *
+   * <p>Sample code
+   *
+   * <pre>{@code
+   * RestoredTableResult result =
+   *     client.restoreTable(RestoreTableRequest.of(clusterId, backupId).setTableId(tableId));
+   * ApiFuture<Void> future = client.awaitOptimizeRestoredTableAsync(
+   *     result.getOptimizeRestoredTableOperationToken());
+   *
+   * ApiFutures.addCallback(
+   *   future,
+   *   new ApiFutureCallback<Void>() {
+   *     public void onSuccess(Void unused) {
+   *       System.out.println("The optimization of the restored table is done.");
+   *     }
+   *
+   *     public void onFailure(Throwable t) {
+   *       t.printStackTrace();
+   *     }
+   *   },
+   *   MoreExecutors.directExecutor()
+   * );
+   * }</pre>
+   */
+  public ApiFuture<Void> awaitOptimizeRestoredTableAsync(
+      OptimizeRestoredTableOperationToken token) {
+    ApiFuture<Empty> emptyFuture =
+        ((EnhancedBigtableTableAdminStub) getStub()).awaitOptimizeRestoredTableCallable().resumeFutureCall(token.getOperationName());
+    return ApiFutures.transform(
+        emptyFuture,
+        new com.google.api.core.ApiFunction<Empty, Void>() {
+          @Override
+          public Void apply(Empty input) {
+            return null;
+          }
+        },
+        com.google.common.util.concurrent.MoreExecutors.directExecutor());
+  }
+
+  /**
+   * Polls an existing consistency token until table replication is consistent across all clusters.
+   * Useful for checking consistency of a token generated in a separate process. Blocks until
+   * completion.
+   *
+   * @param tableId The table to check.
+   * @param consistencyToken The token to poll.
+   */
+  public void waitForConsistency(String tableId, String consistencyToken) {
+    ApiExceptions.callAndTranslateApiException(waitForConsistencyAsync(tableId, consistencyToken));
+  }
+
+  /**
+   * Asynchronously polls the consistency token. Returns a future that completes when table
+   * replication is consistent across all clusters.
+   *
+   * @param tableId The table to check.
+   * @param consistencyToken The token to poll.
+   */
+  public ApiFuture<Void> waitForConsistencyAsync(String tableId, String consistencyToken) {
+    return ((EnhancedBigtableTableAdminStub) getStub()).awaitConsistencyCallable()
+        .futureCall(ConsistencyRequest.forReplication(tableId, consistencyToken));
+  }
+}

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2.java
@@ -27,7 +27,6 @@ import com.google.common.base.Strings;
 import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
-import javax.annotation.Nonnull;
 
 /**
  * Modern Cloud Bigtable Table Admin Client.
@@ -47,8 +46,8 @@ public class BigtableTableAdminClientV2 extends BaseBigtableTableAdminClient {
   }
 
   /** Constructs an instance of BigtableTableAdminClientV2 with the given settings. */
-  public static final BigtableTableAdminClientV2 createClient(BaseBigtableTableAdminSettings settings)
-      throws IOException {
+  public static final BigtableTableAdminClientV2 createClient(
+      BaseBigtableTableAdminSettings settings) throws IOException {
     return new BigtableTableAdminClientV2(settings);
   }
 
@@ -85,7 +84,9 @@ public class BigtableTableAdminClientV2 extends BaseBigtableTableAdminClient {
     }
 
     // 3. Return the future for the optimization operation
-    return ((EnhancedBigtableTableAdminStub) getStub()).awaitOptimizeRestoredTableCallable().resumeFutureCall(token.getOperationName());
+    return ((EnhancedBigtableTableAdminStub) getStub())
+        .awaitOptimizeRestoredTableCallable()
+        .resumeFutureCall(token.getOperationName());
   }
 
   /**
@@ -133,7 +134,9 @@ public class BigtableTableAdminClientV2 extends BaseBigtableTableAdminClient {
   public ApiFuture<Void> awaitOptimizeRestoredTableAsync(
       OptimizeRestoredTableOperationToken token) {
     ApiFuture<Empty> emptyFuture =
-        ((EnhancedBigtableTableAdminStub) getStub()).awaitOptimizeRestoredTableCallable().resumeFutureCall(token.getOperationName());
+        ((EnhancedBigtableTableAdminStub) getStub())
+            .awaitOptimizeRestoredTableCallable()
+            .resumeFutureCall(token.getOperationName());
     return ApiFutures.transform(
         emptyFuture,
         new com.google.api.core.ApiFunction<Empty, Void>() {
@@ -165,7 +168,8 @@ public class BigtableTableAdminClientV2 extends BaseBigtableTableAdminClient {
    * @param consistencyToken The token to poll.
    */
   public ApiFuture<Void> waitForConsistencyAsync(String tableId, String consistencyToken) {
-    return ((EnhancedBigtableTableAdminStub) getStub()).awaitConsistencyCallable()
+    return ((EnhancedBigtableTableAdminStub) getStub())
+        .awaitConsistencyCallable()
         .futureCall(ConsistencyRequest.forReplication(tableId, consistencyToken));
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClientV2Test.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClientV2Test.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.bigtable.admin.v2.stub.BigtableInstanceAdminStub;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class BigtableInstanceAdminClientV2Test {
+
+  @Test
+  public void testCreateWithStub() {
+    BigtableInstanceAdminStub mockStub = Mockito.mock(BigtableInstanceAdminStub.class);
+    BigtableInstanceAdminClientV2 client = BigtableInstanceAdminClientV2.createClient(mockStub);
+    
+    assertThat(client).isNotNull();
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClientV2Test.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClientV2Test.java
@@ -30,7 +30,7 @@ public class BigtableInstanceAdminClientV2Test {
   public void testCreateWithStub() {
     BigtableInstanceAdminStub mockStub = Mockito.mock(BigtableInstanceAdminStub.class);
     BigtableInstanceAdminClientV2 client = BigtableInstanceAdminClientV2.createClient(mockStub);
-    
+
     assertThat(client).isNotNull();
   }
 }

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2Test.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2Test.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.bigtable.admin.v2.OptimizeRestoredTableMetadata;
+import com.google.cloud.bigtable.admin.v2.models.ConsistencyRequest;
+import com.google.cloud.bigtable.admin.v2.models.OptimizeRestoredTableOperationToken;
+import com.google.cloud.bigtable.admin.v2.models.RestoredTableResult;
+import com.google.cloud.bigtable.admin.v2.stub.EnhancedBigtableTableAdminStub;
+import com.google.protobuf.Empty;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.Answer;
+
+@RunWith(JUnit4.class)
+public class BigtableTableAdminClientV2Test {
+  @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private static final String TABLE_ID = "my-table";
+
+  @Mock private EnhancedBigtableTableAdminStub mockStub;
+
+  @Mock
+  private UnaryCallable<ConsistencyRequest, Void> mockAwaitConsistencyCallable;
+
+  @Mock
+  private OperationCallable<Void, Empty, OptimizeRestoredTableMetadata>
+      mockOptimizeRestoredTableCallable;
+
+  private BigtableTableAdminClientV2 client;
+
+  @Before
+  public void setUp() {
+    client = BigtableTableAdminClientV2.createClient(mockStub);
+  }
+
+  @Test
+  public void testWaitForConsistencyWithToken() {
+    // Setup
+    Mockito.when(mockStub.awaitConsistencyCallable()).thenReturn(mockAwaitConsistencyCallable);
+
+    String token = "my-token";
+    ConsistencyRequest expectedRequest = ConsistencyRequest.forReplication(TABLE_ID, token);
+
+    final AtomicBoolean wasCalled = new AtomicBoolean(false);
+
+    Mockito.when(mockAwaitConsistencyCallable.futureCall(expectedRequest))
+        .thenAnswer(
+            (Answer<ApiFuture<Void>>)
+                invocationOnMock -> {
+                  wasCalled.set(true);
+                  return ApiFutures.immediateFuture(null);
+                });
+
+    // Execute
+    client.waitForConsistency(TABLE_ID, token);
+
+    // Verify
+    assertThat(wasCalled.get()).isTrue();
+  }
+
+  @Test
+  public void testAwaitOptimizeRestoredTable() throws Exception {
+    // Setup
+    Mockito.when(mockStub.awaitOptimizeRestoredTableCallable())
+        .thenReturn(mockOptimizeRestoredTableCallable);
+
+    String optimizeToken = "my-optimization-token";
+
+    // 1. Mock the Token
+    OptimizeRestoredTableOperationToken mockToken =
+        Mockito.mock(OptimizeRestoredTableOperationToken.class);
+    Mockito.when(mockToken.getOperationName()).thenReturn(optimizeToken);
+
+    // 2. Mock the Result (wrapping the token)
+    RestoredTableResult mockResult = Mockito.mock(RestoredTableResult.class);
+    Mockito.when(mockResult.getOptimizeRestoredTableOperationToken()).thenReturn(mockToken);
+
+    // 3. Mock the Input Future (returning the result)
+    ApiFuture<RestoredTableResult> mockRestoreFuture = Mockito.mock(ApiFuture.class);
+    Mockito.when(mockRestoreFuture.get()).thenReturn(mockResult);
+
+    // 4. Mock the Stub's behavior (resuming the Optimize Op)
+    OperationFuture<Empty, OptimizeRestoredTableMetadata> mockOptimizeOp =
+        Mockito.mock(OperationFuture.class);
+    Mockito.when(mockOptimizeRestoredTableCallable.resumeFutureCall(optimizeToken))
+        .thenReturn(mockOptimizeOp);
+
+    // Execute
+    ApiFuture<Empty> result = client.awaitOptimizeRestoredTable(mockRestoreFuture);
+
+    // Verify
+    assertThat(result).isEqualTo(mockOptimizeOp);
+    Mockito.verify(mockOptimizeRestoredTableCallable).resumeFutureCall(optimizeToken);
+  }
+
+  @Test
+  public void testAwaitOptimizeRestoredTable_NoOp() throws Exception {
+    // Setup: Result with NO optimization token (null or empty)
+    RestoredTableResult mockResult = Mockito.mock(RestoredTableResult.class);
+    Mockito.when(mockResult.getOptimizeRestoredTableOperationToken()).thenReturn(null);
+
+    // Mock the Input Future
+    ApiFuture<RestoredTableResult> mockRestoreFuture = Mockito.mock(ApiFuture.class);
+    Mockito.when(mockRestoreFuture.get()).thenReturn(mockResult);
+
+    // Execute
+    ApiFuture<Empty> result = client.awaitOptimizeRestoredTable(mockRestoreFuture);
+
+    // Verify: Returns immediate success (Empty) without calling the stub
+    assertThat(result.get()).isEqualTo(Empty.getDefaultInstance());
+  }
+}

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2Test.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2Test.java
@@ -48,8 +48,7 @@ public class BigtableTableAdminClientV2Test {
 
   @Mock private EnhancedBigtableTableAdminStub mockStub;
 
-  @Mock
-  private UnaryCallable<ConsistencyRequest, Void> mockAwaitConsistencyCallable;
+  @Mock private UnaryCallable<ConsistencyRequest, Void> mockAwaitConsistencyCallable;
 
   @Mock
   private OperationCallable<Void, Empty, OptimizeRestoredTableMetadata>


### PR DESCRIPTION
This commit introduces `BigtableInstanceAdminClientV2`, a new client class that extends the auto-generated `BaseBigtableInstanceAdminClient`. Because the legacy `BigtableInstanceAdminClient` does not contain any manual overrides for complex Critical User Journeys (CUJs) that GAPIC cannot generate natively, this new class acts as a clean, standardized entry point for the new GAPIC hierarchy.

b/502616786