### PR TITLE
fix: update local vRPC status to match the last session failure when a Session couldn't be established

### DIFF
--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/session/SessionPoolImpl.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/session/SessionPoolImpl.java
@@ -507,7 +507,7 @@ public class SessionPoolImpl<OpenReqT extends Message> implements SessionPool<Op
       // vRPCs failing with consecutive failures should fail
       VRpcResult result =
           VRpcResult.createRejectedError(
-              Status.UNAVAILABLE.withDescription(
+              Status.fromCode(status.getCode()).withDescription(
                   String.format(
                       "Session failed with consecutive failures. Most recent server status: %s,"
                           + " metadata: %s.",

--- a/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/session/SessionPoolImpl.java
+++ b/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/session/SessionPoolImpl.java
@@ -507,11 +507,12 @@ public class SessionPoolImpl<OpenReqT extends Message> implements SessionPool<Op
       // vRPCs failing with consecutive failures should fail
       VRpcResult result =
           VRpcResult.createRejectedError(
-              Status.fromCode(status.getCode()).withDescription(
-                  String.format(
-                      "Session failed with consecutive failures. Most recent server status: %s,"
-                          + " metadata: %s.",
-                      status, trailers)));
+              Status.fromCode(status.getCode())
+                  .withDescription(
+                      String.format(
+                          "Session failed with consecutive failures. Most recent server status: %s,"
+                              + " metadata: %s.",
+                          status, trailers)));
       for (PendingVRpc<?, ?> vrpc : toBeClosed) {
         try {
           vrpc.getListener().onClose(result);

--- a/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/session/SessionPoolImplTest.java
+++ b/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/session/SessionPoolImplTest.java
@@ -206,7 +206,7 @@ public class SessionPoolImplTest {
     assertThat(exception)
         .hasMessageThat()
         .contains(
-            "UNAVAILABLE: Session failed with consecutive failures. Most recent server status:"
+            "INTERNAL: Session failed with consecutive failures. Most recent server status:"
                 + " Status{code=INTERNAL, description=fake internal error. PeerInfo:"
                 + " transport_type: TRANSPORT_TYPE_SESSION_UNKNOWN, cause=null}");
   }


### PR DESCRIPTION

This should bubble up PERMISSION_DENIED as the vRPC status instead of hardcoding UNAVAILABLE and forcing end users to read the message to see why the session failed

Change-Id: Ic7336b26713199085406d267b5918f8fd9186b8e

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed
- [ ] All new data plane features have a completed end to end testing plan

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
