### PR TITLE
ci: update sdk-platform-java reference to google-cloud-java

### DIFF
--- a/.github/scripts/update_generation_config.sh
+++ b/.github/scripts/update_generation_config.sh
@@ -147,7 +147,7 @@ latest_version=$(get_latest_released_version "com.google.api" "gapic-generator-j
 update_config "gapic_generator_version" "${latest_version}" "${generation_config}"
 
 # Update composite action version to latest gapic-generator-java version
-update_action "googleapis/sdk-platform-java/.github/scripts" \
+update_action "googleapis/google-cloud-java/sdk-platform-java/.github/scripts" \
   "${latest_version}" \
   "${workflow}"
 

--- a/.github/scripts/update_generation_config.sh
+++ b/.github/scripts/update_generation_config.sh
@@ -147,7 +147,7 @@ latest_version=$(get_latest_released_version "com.google.api" "gapic-generator-j
 update_config "gapic_generator_version" "${latest_version}" "${generation_config}"
 
 # Update composite action version to latest gapic-generator-java version
-update_action "googleapis/google-cloud-java/sdk-platform-java/.github/scripts" \
+update_action "googleapis/sdk-platform-java/.github/scripts" \
   "${latest_version}" \
   "${workflow}"
 

--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -37,7 +37,7 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
-    - uses: googleapis/sdk-platform-java/.github/scripts@v2.68.0
+    - uses: googleapis/google-cloud-java/sdk-platform-java/.github/scripts@v1.85.0
       if: env.SHOULD_RUN == 'true'
       with:
         base_ref: ${{ github.base_ref }}

--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -40,6 +40,7 @@ jobs:
     - uses: googleapis/google-cloud-java/sdk-platform-java/.github/scripts@v1.85.0
       if: env.SHOULD_RUN == 'true'
       with:
+        image_tag: latest
         base_ref: ${{ github.base_ref }}
         head_ref: ${{ github.head_ref }}
         token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}

--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -14,6 +14,6 @@ jobs:
       shell: bash
       run: .kokoro/build.sh
     - name: Unmanaged dependency check
-      uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v3.58.0
+      uses: googleapis/google-cloud-java/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@v1.85.0
       with:
         bom-path: google-cloud-bigtable-bom/pom.xml

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.59.0" # {x-version-update:google-cloud-shared-dependencies:current}
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.61.0" # {x-version-update:google-cloud-shared-dependencies:current}
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-b.cfg
+++ b/.kokoro/presubmit/graalvm-native-b.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.59.0" # {x-version-update:google-cloud-shared-dependencies:current}
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.61.0" # {x-version-update:google-cloud-shared-dependencies:current}
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-c.cfg
+++ b/.kokoro/presubmit/graalvm-native-c.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_c:3.59.0" # {x-version-update:google-cloud-shared-dependencies:current}
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_c:3.61.0" # {x-version-update:google-cloud-shared-dependencies:current}
 }
 
 env_vars: {

--- a/renovate.json
+++ b/renovate.json
@@ -106,7 +106,7 @@
         "^.github/workflows/unmanaged_dependency_check.yaml$"
       ],
       "matchStrings": ["uses: googleapis/google-cloud-java/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@v(?<currentValue>.+?)\\n"],
-      "depNameTemplate": "com.google.cloud:sdk-platform-java-config",
+      "depNameTemplate": "com.google.cloud:gapic-libraries-bom",
       "datasourceTemplate": "maven"
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -105,7 +105,7 @@
       "fileMatch": [
         "^.github/workflows/unmanaged_dependency_check.yaml$"
       ],
-      "matchStrings": ["uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v(?<currentValue>.+?)\\n"],
+      "matchStrings": ["uses: googleapis/google-cloud-java/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@v(?<currentValue>.+?)\\n"],
       "depNameTemplate": "com.google.cloud:sdk-platform-java-config",
       "datasourceTemplate": "maven"
     }


### PR DESCRIPTION
We moved the definition of the workflow files from sdk-platform-java repository to the sdk-platform-java folder in the google-cloud-java repository.

This uses the "latest" Docker tag in `.github/workflows/hermetic_library_generation.yaml` to confirm the behavior of the today's hermetic build container image update.

b/503444342
