### PR TITLE
ci: use CLOUD_JAVA_BOT_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -36,11 +36,11 @@ jobs:
       if: env.SHOULD_RUN == 'true'
       with:
         fetch-depth: 0
-        token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
+        token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
     - uses: googleapis/google-cloud-java/sdk-platform-java/.github/scripts@google-cloud-shared-dependencies/v3.61.0
       if: env.SHOULD_RUN == 'true'
       with:
         image_tag: latest
         base_ref: ${{ github.base_ref }}
         head_ref: ${{ github.head_ref }}
-        token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
+        token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -40,7 +40,6 @@ jobs:
     - uses: googleapis/google-cloud-java/sdk-platform-java/.github/scripts@google-cloud-shared-dependencies/v3.61.0
       if: env.SHOULD_RUN == 'true'
       with:
-        image_tag: latest
         base_ref: ${{ github.base_ref }}
         head_ref: ${{ github.head_ref }}
         token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
The old secret `CLOUD_JAVA_BOT_TOKEN` has been deleted and is still referenced in this repository. Let's use the new one.

This change stops using the latest workflow from google-cloud-java. The latest was an experiment to confirm the hermetic build generation workflow in the previous release cycle.

b/509523021

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-bigtable/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Rollback plan is reviewed and LGTMed
- [ ] All new data plane features have a completed end to end testing plan

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
